### PR TITLE
fix: group name order issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.html
+*.json
+bin/

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ task
 # Generate templates
 task generate
 
-# Build the binary
+# Build the binary (run from ./bin/vizb)
 task build
 
 # Run tests

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,7 +20,7 @@ tasks:
   build:
     desc: Build the binary with version information
     cmds:
-      - ./build.sh
+      - go build -o ./bin/vizb
 
   test:
     desc: Run all tests

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,9 +23,9 @@ tasks:
       - go build -o ./bin/vizb
 
   test:
-    desc: Run all tests
+    desc: Run all tests (no cache)
     cmds:
-      - go test -v ./...
+      - go test -count=1 -v ./...
 
   lint:
     desc: Run linter

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -40,16 +40,21 @@ func truncateFloat(f float64) string {
 }
 
 // Group results by task name
-func groupResultsByName(results []shared.BenchmarkResult) map[string][]shared.BenchmarkResult {
+func groupResultsByName(results []shared.BenchmarkResult) (map[string][]shared.BenchmarkResult, []string) {
 	benchGroups := make(map[string][]shared.BenchmarkResult)
+	groupNames := make([]string, 0)
 
 	for _, result := range results {
 		name := result.Name
 
+		if _, has := benchGroups[name]; !has {
+			groupNames = append(groupNames, name)
+		}
+
 		benchGroups[name] = append(benchGroups[name], result)
 	}
 
-	return benchGroups
+	return benchGroups, groupNames
 }
 
 func createChart(title string, results []shared.BenchmarkResult, statIndex int) *charts.Bar {
@@ -162,10 +167,12 @@ func createChart(title string, results []shared.BenchmarkResult, statIndex int) 
 
 func GenerateHTMLCharts(results []shared.BenchmarkResult) []shared.BenchCharts {
 	// Group results by task name
-	benchGroups := groupResultsByName(results)
+	benchGroups, groupNames := groupResultsByName(results)
 	benchCharts := make([]shared.BenchCharts, 0, len(benchGroups))
 
-	for name, benchResults := range benchGroups {
+	for _, name := range groupNames {
+		benchResults := benchGroups[name]
+
 		if len(benchResults) == 0 {
 			continue
 		}


### PR DESCRIPTION
Group names were being accessed directly from a map, which means their order was not guaranteed and didn’t match the benchmark order.

To fix this, an additional slice is introduced to maintain the correct order of groups.

Also refactored parts of the parser logic and improved the build task command.