### PR TITLE
feat: add square bracket pattern support for PascalCase splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,18 +107,26 @@ The pattern defines the order and separators for extracting:
 
 **Separators**: Use `/` (slash) or `_` (underscore) to define how parts are split.
 
+**Square Brackets**: Use `[...]` for PascalCase splitting when benchmark names don't have separators
+- `[s,w,n]` - Split PascalCase and assign consecutive words
+- `[,w]` - Skip first word, assign second word to `w`
+- `[,,s]` - Skip first 2 words, assign third word to `s`
+
 **Required**: Every pattern must include `subject` (the operation being measured)
 
 ### Examples
 
-| Pattern | Benchmark Name                        | Name        | Workload    | Subject        | Description                            |
-| ------- | ------------------------------------- | ----------- | ----------- | -------------- | -------------------------------------- |
-| `s`     | `BenchmarkStringConcat`               | _(empty)_   | _(empty)_   | `StringConcat` | Default: treats entire name as subject |
-| `n/s`   | `BenchmarkStringOps/Concat`           | `StringOps` | _(empty)_   | `Concat`       | Name and subject with slash            |
-| `n/w/s` | `BenchmarkStringOps/LargeData/Concat` | `StringOps` | `LargeData` | `Concat`       | All three components                   |
-| `s/w/n` | `BenchmarkConcat/LargeData/StringOps` | `StringOps` | `LargeData` | `Concat`       | Custom order                           |
-| `n_s_w` | `BenchmarkStringOps_Concat_LargeData` | `StringOps` | `LargeData` | `Concat`       | Underscore separator                   |
-| `/n/s`  | `BenchmarkIgnored/StringOps/Concat`   | `StringOps` | _(empty)_   | `Concat`       | Skip first part                        |
+| Pattern    | Benchmark Name                        | Name        | Workload    | Subject        | Description                            |
+| ---------- | ------------------------------------- | ----------- | ----------- | -------------- | -------------------------------------- |
+| `s`        | `BenchmarkStringConcat`               | _(empty)_   | _(empty)_   | `StringConcat` | Default: treats entire name as subject |
+| `n/s`      | `BenchmarkStringOps/Concat`           | `StringOps` | _(empty)_   | `Concat`       | Name and subject with slash            |
+| `n/w/s`    | `BenchmarkStringOps/LargeData/Concat` | `StringOps` | `LargeData` | `Concat`       | All three components                   |
+| `s/w/n`    | `BenchmarkConcat/LargeData/StringOps` | `StringOps` | `LargeData` | `Concat`       | Custom order                           |
+| `n_s_w`    | `BenchmarkStringOps_Concat_LargeData` | `StringOps` | `LargeData` | `Concat`       | Underscore separator                   |
+| `/n/s`     | `BenchmarkIgnored/StringOps/Concat`   | `StringOps` | _(empty)_   | `Concat`       | Skip first part                        |
+| `[s,w,n]`  | `SubjectWorkloadName`                 | `Name`      | `Workload`  | `Subject`      | PascalCase splitting with square brackets |
+| `s/[w]/[n]`| `Concat/LargeData/StringOps`          | `String`    | `Large`     | `Concat`       | Mixed separators and PascalCase        |
+| `[,,s]`    | `FirstSecondThirdFourth`              | _(empty)_   | _(empty)_   | `Third`        | Skip first 2 words, take 3rd          |
 
 > [!Note]
 > The `workload` dimension only appears in charts when there are multiple workloads to compare. If all benchmarks have the same workload (or no workload), charts will be simplified to show just subjects.


### PR DESCRIPTION
This adds a new pattern syntax using square brackets  that enables parsing benchmark names written in PascalCase without explicit separators.

Features:
- PascalCase word splitting (e.g., "HTTPServerRequest" → ["HTTP", "Server", "Request"])
- Square bracket notation for index mapping (e.g., `[s,w,n]`)
- Skipping support with empty indices (e.g., `[,w]` skips first word)
- Mixed patterns combining separators and square brackets (e.g., `s/[w]/[n]`)
- Proper handling of consecutive uppercase letters (HTTP, JSON, etc.)

Examples:
- `[s,w,n]` with "SubjectWorkloadName" → subject=Subject, workload=Workload, name=Name
- `s/[w]/[n]` with "Concat/LargeData/StringOps" → subject=Concat, workload=Large, name=String
- `[,,s]` with "FirstSecondThirdFourth" → subject=Third (skips first 2 words)