### PR TITLE
Add support for other metrics/units

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -258,9 +258,12 @@ func GenerateHTMLCharts(results []shared.BenchmarkResult) []shared.BenchCharts {
 		for idx, stat := range firstResult.Stats {
 			// Determine chart title based on stat type and unit
 			var chartTitle string
-			if stat.Unit != "" {
+			switch {
+			case stat.Unit != "" && stat.NotPerOp:
+				chartTitle = fmt.Sprintf("%s (%s)", stat.Type, stat.Unit)
+			case stat.Unit != "":
 				chartTitle = fmt.Sprintf("%s (%s/op)", stat.Type, stat.Unit)
-			} else {
+			default:
 				chartTitle = fmt.Sprintf("%s/op", stat.Type)
 			}
 

--- a/pkg/parser/bench_result.go
+++ b/pkg/parser/bench_result.go
@@ -88,6 +88,18 @@ func ParseBenchmarkResults(filePath string) (results []shared.BenchmarkResult) {
 					Value: utils.FormatAllocs(value.Value, shared.FlagState.AllocUnit),
 					Unit:  shared.FlagState.AllocUnit,
 				}
+			case "B/s":
+				benchStat = shared.Stat{
+					Type:     "Throughput",
+					Value:    float64(value.Value) / 1e6,
+					Unit:     "MB/s",
+					NotPerOp: true,
+				}
+			default:
+				benchStat = shared.Stat{
+					Value: value.Value,
+					Unit:  value.Unit,
+				}
 			}
 
 			benchStats = append(benchStats, benchStat)

--- a/shared/bench_result.go
+++ b/shared/bench_result.go
@@ -1,9 +1,10 @@
 package shared
 
 type Stat struct {
-	Type  string  `json:"type"`
-	Value float64 `json:"value"`
-	Unit  string  `json:"unit"`
+	Type     string  `json:"type"`
+	Value    float64 `json:"value"`
+	Unit     string  `json:"unit"`
+	NotPerOp bool    `json:"notPerOp"`
 }
 
 type BenchmarkResult struct {


### PR DESCRIPTION
Initial work to support metrics other than the common ones. In particular, this adds support for the standard throughput metrics (MB/s) added by the `SetBytes()` call.

This is only a basic implementation, I can add the missing stuff later (tests, parametrization) if you think this is in the right direction and something desirable.