### PR TITLE
feat(merge): added tag-based merging for historical comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - **Swap Axis**: Swap the `n`, `x` and `y` axes for diverse comparison through UI settings.
 - **Logarithmic Scale**: Use `--scale log` for bar and line charts to better visualize benchmarks with high variance in values.
 - **Multi-Dimensional Grouping**: Merge multiple benchmark data for deep comparative analysis.
+- **Tag-Based Merging**: Tag benchmarks with commit hashes or version labels to compare performance across releases with automatic data merging.
 - **Flexible Input**: Automatically processes raw `go test -bench` output and the standard JSON output of `go test -bench -json`.
 - **Comprehensive Metrics**: Compare time, memory, and numbers with customizable units.
 - **Smart Grouping**: Extract grouping logic from benchmark names using regex and group patterns.
@@ -107,6 +108,39 @@ Open the generated HTML file in your browser to view the interactive charts.
 
 > [!Note]
 > The `merge` command requires JSON files as input, which must be generated using `vizb bench.txt -o output.json`.
+
+### Tag-Based Merging
+
+Vizb supports tagging benchmarks to compare performance across multiple commits, releases, or environment variants. The `--tag` flag on the main command assigns a label (e.g., commit hash, version number) to a benchmark run. When merging, vizb groups benchmarks by `name` and deep-merges those sharing the same name but different tags into a single object, preserving all runtimes and data.
+
+#### Tagging a benchmark run
+
+```bash
+vizb bench.txt -o v1.json --tag v1 -n "Foo"
+
+vizb bench.txt -o v2.json --tag v2 -n "Foo"
+```
+
+#### How tag-based merging works
+
+When you merge two tagged benchmarks with the same name:
+
+```bash
+vizb merge v1.json v2.json -o comparison.html
+```
+
+Vizb detects the shared benchmark name, merges the datasets into a single object, and annotates each inner data point with its originating tag. The merged result keeps the latest tag (by runtime timestamp), combines all runtime entries, and appends data from both runs.
+
+#### Controlling where the tag is injected
+
+By default, the tag is injected into the `name` dimension of each inner data object. Use `--inject-dimension` (shorthand `-i`) to target `xAxis` or `yAxis` instead:
+
+```bash
+# Inject tag into xAxis so the X-axis labels show version differences
+vizb merge v1.json v2.json -i x -o comparison.html
+```
+
+Accepted values: `n` (name), `x` (xAxis), `y` (yAxis). Default is `n`.
 
 ## Advance Usage
 

--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ Vizb detects the shared benchmark name, merges the datasets into a single object
 
 #### Controlling where the tag is injected
 
-By default, the tag is injected into the `name` dimension of each inner data object. Use `--inject-dimension` (shorthand `-i`) to target `xAxis` or `yAxis` instead:
+By default, the tag is injected into the `name` dimension of each inner data object. Use `--tag-axis` (shorthand `-A`) to target `xAxis` or `yAxis` instead:
 
 ```bash
 # Inject tag into xAxis so the X-axis labels show version differences
-vizb merge v1.json v2.json -i x -o comparison.html
+vizb merge v1.json v2.json -A x -o comparison.html
 ```
 
 Accepted values: `n` (name), `x` (xAxis), `y` (yAxis). Default is `n`.

--- a/cmd/flag_validation_rules.go
+++ b/cmd/flag_validation_rules.go
@@ -64,7 +64,7 @@ var flagValidationRules = []utils.ValidationRule{
 	},
 	{
 		Label:      "inject dimension",
-		Value:      &shared.FlagState.InjectDimension,
+		Value:      &shared.FlagState.TagAxis,
 		ValidSet:   []string{"n", "x", "y"},
 		Normalizer: strings.ToLower,
 		Default:    "n",

--- a/cmd/flag_validation_rules.go
+++ b/cmd/flag_validation_rules.go
@@ -62,4 +62,11 @@ var flagValidationRules = []utils.ValidationRule{
 		Normalizer:   strings.ToLower,
 		SliceDefault: []string{"bar", "line", "pie"},
 	},
+	{
+		Label:      "inject dimension",
+		Value:      &shared.FlagState.InjectDimension,
+		ValidSet:   []string{"n", "x", "y"},
+		Normalizer: strings.ToLower,
+		Default:    "n",
+	},
 }

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -23,8 +23,8 @@ You can provide individual JSON files or directories containing JSON files.`,
 
 func init() {
 	rootCmd.AddCommand(mergeCmd)
-	mergeCmd.Flags().StringVarP(&shared.FlagState.InjectDimension, "inject-dimension", "i", "n",
-		"Dimension to inject Tag into: n (name), x (xAxis), y (yAxis)")
+	mergeCmd.Flags().StringVarP(&shared.FlagState.TagAxis, "tag-axis", "A", "n",
+		"Where to inject tag: n (name), x (xAxis), y (yAxis)")
 }
 
 func runMerge(cmd *cobra.Command, args []string) {
@@ -78,7 +78,7 @@ func runMerge(cmd *cobra.Command, args []string) {
 		validFilesCount++
 	}
 
-	mergedBench = shared.MergeBenchmarks(mergedBench, shared.FlagState.InjectDimension)
+	mergedBench = shared.MergeBenchmarks(mergedBench, shared.FlagState.TagAxis)
 
 	if len(mergedBench) == 0 {
 		shared.ExitWithError("No valid benchmark files processed", nil)

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -23,6 +23,8 @@ You can provide individual JSON files or directories containing JSON files.`,
 
 func init() {
 	rootCmd.AddCommand(mergeCmd)
+	mergeCmd.Flags().StringVarP(&shared.FlagState.InjectDimension, "inject-dimension", "i", "n",
+		"Dimension to inject Tag into: n (name), x (xAxis), y (yAxis)")
 }
 
 func runMerge(cmd *cobra.Command, args []string) {
@@ -76,7 +78,9 @@ func runMerge(cmd *cobra.Command, args []string) {
 		validFilesCount++
 	}
 
-	if validFilesCount == 0 {
+	mergedBench = shared.MergeBenchmarks(mergedBench, shared.FlagState.InjectDimension)
+
+	if len(mergedBench) == 0 {
 		shared.ExitWithError("No valid benchmark files processed", nil)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/goptics/vizb/pkg/parser"
 	"github.com/goptics/vizb/pkg/style"
@@ -55,6 +56,7 @@ func init() {
 	rootCmd.Flags().BoolVarP(&shared.FlagState.ShowLabels, "show-labels", "l", false, "Show labels on charts")
 	rootCmd.Flags().StringVarP(&shared.FlagState.FilterRegex, "filter", "f", "", "Regex pattern to include only matching benchmark names")
 	rootCmd.Flags().StringVarP(&shared.FlagState.Scale, "scale", "S", "linear", "Y-axis scale type (linear, log)")
+	rootCmd.Flags().StringVarP(&shared.FlagState.Tag, "tag", "T", "", "Tag/identifier for the benchmark")
 
 	// Add a hook to validate flags after parsing
 	cobra.OnInitialize(func() {
@@ -256,6 +258,13 @@ func prepareBenchmarkFromParsedResults(results []shared.BenchmarkData) *shared.B
 
 	benchmark.Settings.ShowLabels = shared.FlagState.ShowLabels
 	benchmark.Settings.Scale = shared.FlagState.Scale
+
+	if shared.FlagState.Tag != "" {
+		benchmark.Tag = shared.FlagState.Tag
+		benchmark.Runtimes = map[string]string{
+			benchmark.Tag: time.Now().UTC().Format(time.RFC3339),
+		}
+	}
 
 	return benchmark
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,9 +46,9 @@ func init() {
 	rootCmd.Flags().StringVarP(&shared.FlagState.Name, "name", "n", "Benchmarks", "Name of the benchmark")
 	rootCmd.Flags().StringVarP(&shared.FlagState.Description, "description", "d", "", "Description of the benchmark")
 	rootCmd.PersistentFlags().StringVarP(&shared.FlagState.OutputFile, "output", "o", "", "Output file name (.json for JSON, .html or other for HTML)")
-	rootCmd.Flags().StringVarP(&shared.FlagState.MemUnit, "mem-unit", "m", "B", "Memory unit available: b, B, KB, MB, GB")
-	rootCmd.Flags().StringVarP(&shared.FlagState.TimeUnit, "time-unit", "t", "ns", "Time unit available: ns, us, ms, s")
-	rootCmd.Flags().StringVarP(&shared.FlagState.NumberUnit, "number-unit", "u", "", "Number unit available: K, M, B, T (default: as-is)")
+	rootCmd.Flags().StringVarP(&shared.FlagState.MemUnit, "mem-unit", "M", "B", "Memory unit available: b, B, KB, MB, GB")
+	rootCmd.Flags().StringVarP(&shared.FlagState.TimeUnit, "time-unit", "T", "ns", "Time unit available: ns, us, ms, s")
+	rootCmd.Flags().StringVarP(&shared.FlagState.NumberUnit, "number-unit", "N", "", "Number unit available: K, M, B, T (default: as-is)")
 	rootCmd.Flags().StringVarP(&shared.FlagState.GroupPattern, "group-pattern", "p", "x", "Pattern to extract grouping information from benchmark names")
 	rootCmd.Flags().StringVarP(&shared.FlagState.GroupRegex, "group-regex", "r", "", "Regex pattern to extract grouping information from benchmark names")
 	rootCmd.Flags().StringVarP(&shared.FlagState.Sort, "sort", "s", "", "Sort in asc or desc order (default: as-is)")
@@ -56,7 +56,7 @@ func init() {
 	rootCmd.Flags().BoolVarP(&shared.FlagState.ShowLabels, "show-labels", "l", false, "Show labels on charts")
 	rootCmd.Flags().StringVarP(&shared.FlagState.FilterRegex, "filter", "f", "", "Regex pattern to include only matching benchmark names")
 	rootCmd.Flags().StringVarP(&shared.FlagState.Scale, "scale", "S", "linear", "Y-axis scale type (linear, log)")
-	rootCmd.Flags().StringVarP(&shared.FlagState.Tag, "tag", "T", "", "Tag/identifier for the benchmark")
+	rootCmd.Flags().StringVarP(&shared.FlagState.Tag, "tag", "t", "", "Tag/identifier for the benchmark")
 
 	// Add a hook to validate flags after parsing
 	cobra.OnInitialize(func() {

--- a/shared/bench.go
+++ b/shared/bench.go
@@ -13,8 +13,10 @@ type BenchmarkData struct {
 }
 
 type Benchmark struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
+	Tag         string            `json:"tag,omitempty"`
+	Name        string            `json:"name"`
+	Runtimes    map[string]string `json:"runtimes,omitempty"`
+	Description string            `json:"description,omitempty"`
 	CPU         struct {
 		Name  string `json:"name,omitempty"`
 		Cores int    `json:"cores,omitempty"`

--- a/shared/flag_state.go
+++ b/shared/flag_state.go
@@ -15,7 +15,7 @@ type flagState struct {
 	ShowLabels      bool
 	FilterRegex     string
 	Scale           string
-	InjectDimension string
+	TagAxis string
 }
 
 var FlagState flagState = flagState{}

--- a/shared/flag_state.go
+++ b/shared/flag_state.go
@@ -1,19 +1,21 @@
 package shared
 
 type flagState struct {
-	Name         string
-	OutputFile   string
-	MemUnit      string
-	TimeUnit     string
-	NumberUnit   string
-	Description  string
-	GroupPattern string
-	GroupRegex   string
-	Sort         string
-	Charts       []string
-	ShowLabels   bool
-	FilterRegex  string
-	Scale       string
+	Tag             string
+	Name            string
+	OutputFile      string
+	MemUnit         string
+	TimeUnit        string
+	NumberUnit      string
+	Description     string
+	GroupPattern    string
+	GroupRegex      string
+	Sort            string
+	Charts          []string
+	ShowLabels      bool
+	FilterRegex     string
+	Scale           string
+	InjectDimension string
 }
 
 var FlagState flagState = flagState{}

--- a/shared/merge.go
+++ b/shared/merge.go
@@ -99,11 +99,11 @@ func mergeRuntimes(benchmarks []Benchmark) map[string]string {
 	return result
 }
 
-func mergeData(benchmarks []Benchmark, injectDim string) []BenchmarkData {
+func mergeData(benchmarks []Benchmark, tagAxis string) []BenchmarkData {
 	var result []BenchmarkData
 	for _, bench := range benchmarks {
 		for _, item := range bench.Data {
-			result = append(result, injectTag(item, bench.Tag, injectDim))
+			result = append(result, injectTag(item, bench.Tag, tagAxis))
 		}
 	}
 	return result

--- a/shared/merge.go
+++ b/shared/merge.go
@@ -1,0 +1,141 @@
+package shared
+
+import "maps"
+
+// MergeBenchmarks performs tag-based smart merging on a slice of benchmarks.
+// Benchmarks with the same Name and valid Tag fields are deep-merged into a
+// single object. Benchmarks lacking a Tag are appended individually (legacy).
+// injectDim controls which inner data dimension receives the benchmark tag
+// annotation: "n" for Name, "x" for XAxis, "y" for YAxis.
+func MergeBenchmarks(benchmarks []Benchmark, injectDim string) []Benchmark {
+	groups := groupByName(benchmarks)
+	var result []Benchmark
+
+	for _, group := range groups {
+		noTag, withTag := splitByTag(group)
+		result = append(result, noTag...)
+
+		switch len(withTag) {
+		case 0:
+			continue
+		case 1:
+			result = append(result, withTag[0])
+		default:
+			result = append(result, tagBasedMerge(withTag, injectDim)...)
+		}
+	}
+
+	return result
+}
+
+func groupByName(benchmarks []Benchmark) map[string][]Benchmark {
+	groups := make(map[string][]Benchmark)
+	for _, bench := range benchmarks {
+		groups[bench.Name] = append(groups[bench.Name], bench)
+	}
+	return groups
+}
+
+func splitByTag(benchmarks []Benchmark) (noTag, withTag []Benchmark) {
+	for _, bench := range benchmarks {
+		if bench.Tag == "" {
+			noTag = append(noTag, bench)
+		} else {
+			withTag = append(withTag, bench)
+		}
+	}
+	return
+}
+
+func tagBasedMerge(benchmarks []Benchmark, injectDim string) []Benchmark {
+	latestIdx, tie := findLatest(benchmarks)
+	if tie {
+		return benchmarks
+	}
+
+	merged := deepCloneBenchmark(benchmarks[latestIdx])
+	merged.Runtimes = mergeRuntimes(benchmarks)
+	merged.Data = mergeData(benchmarks, injectDim)
+	return []Benchmark{merged}
+}
+
+func findLatest(benchmarks []Benchmark) (idx int, tie bool) {
+	var maxTS string
+	idx = -1
+
+	for i, bench := range benchmarks {
+		for _, ts := range bench.Runtimes {
+			if ts > maxTS {
+				maxTS = ts
+				idx = i
+				tie = false
+			} else if ts == maxTS && i != idx {
+				tie = true
+			}
+		}
+	}
+
+	return idx, tie
+}
+
+func deepCloneBenchmark(src Benchmark) Benchmark {
+	dst := src
+	dst.Data = make([]BenchmarkData, len(src.Data))
+	copy(dst.Data, src.Data)
+
+	if src.Runtimes != nil {
+		dst.Runtimes = make(map[string]string, len(src.Runtimes))
+		maps.Copy(dst.Runtimes, src.Runtimes)
+	}
+
+	return dst
+}
+
+func mergeRuntimes(benchmarks []Benchmark) map[string]string {
+	result := make(map[string]string)
+	for _, bench := range benchmarks {
+		maps.Copy(result, bench.Runtimes)
+	}
+	return result
+}
+
+func mergeData(benchmarks []Benchmark, injectDim string) []BenchmarkData {
+	var result []BenchmarkData
+	for _, bench := range benchmarks {
+		for _, item := range bench.Data {
+			result = append(result, injectTag(item, bench.Tag, injectDim))
+		}
+	}
+	return result
+}
+
+func injectTag(item BenchmarkData, tag string, dim string) BenchmarkData {
+	item = deepCloneData(item)
+
+	switch dim {
+	case "x":
+		item.XAxis = applyInjection(item.XAxis, tag)
+	case "y":
+		item.YAxis = applyInjection(item.YAxis, tag)
+	default:
+		item.Name = applyInjection(item.Name, tag)
+	}
+
+	return item
+}
+
+func applyInjection(existing string, tag string) string {
+	if existing == "" {
+		return tag
+	}
+	return existing + " - " + tag
+}
+
+func deepCloneData(src BenchmarkData) BenchmarkData {
+	dst := src
+	if src.Stats != nil {
+		dst.Stats = make([]Stat, len(src.Stats))
+		copy(dst.Stats, src.Stats)
+	}
+	return dst
+}

--- a/shared/merge_test.go
+++ b/shared/merge_test.go
@@ -1,0 +1,159 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func makeBench(tag, name string, runtimes map[string]string, data []BenchmarkData) Benchmark {
+	return Benchmark{
+		Tag:      tag,
+		Name:     name,
+		Runtimes: runtimes,
+		Data:     data,
+	}
+}
+
+func TestMergeBenchmarks_SmartMerge(t *testing.T) {
+	bench1 := makeBench("1", "My benchmark", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{
+		{Name: "", XAxis: "speed", YAxis: "1e4"},
+	})
+	bench2 := makeBench("2", "My benchmark", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{
+		{Name: "", XAxis: "speed", YAxis: "1e4"},
+	})
+
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "n")
+	assert.Len(t, result, 1)
+
+	merged := result[0]
+	assert.Equal(t, "2", merged.Tag)
+	assert.Equal(t, "My benchmark", merged.Name)
+	assert.Equal(t, map[string]string{
+		"1": "2026-05-13T10:00:00Z",
+		"2": "2026-05-13T10:05:00Z",
+	}, merged.Runtimes)
+	assert.Len(t, merged.Data, 2)
+	assert.Equal(t, "1", merged.Data[0].Name)
+	assert.Equal(t, "2", merged.Data[1].Name)
+}
+
+func TestMergeBenchmarks_MixedGroup(t *testing.T) {
+	bench1 := makeBench("1", "My benchmark", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{
+		{Name: "", XAxis: "speed", YAxis: "1e4"},
+	})
+	bench2 := makeBench("2", "My benchmark", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{
+		{Name: "", XAxis: "speed", YAxis: "1e4"},
+	})
+	noTagBench := Benchmark{
+		Tag:  "",
+		Name: "My benchmark",
+		Data: []BenchmarkData{{Name: "legacy", XAxis: "x", YAxis: "y"}},
+	}
+
+	result := MergeBenchmarks([]Benchmark{bench1, bench2, noTagBench}, "n")
+	assert.Len(t, result, 2)
+}
+
+func TestMergeBenchmarks_AllNoTag(t *testing.T) {
+	bench1 := Benchmark{Name: "Bench A", Data: []BenchmarkData{{Name: "a"}}}
+	bench2 := Benchmark{Name: "Bench A", Data: []BenchmarkData{{Name: "b"}}}
+
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "n")
+	assert.Len(t, result, 2)
+}
+
+func TestMergeBenchmarks_TimestampTie(t *testing.T) {
+	bench1 := makeBench("1", "Test", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "a"}})
+	bench2 := makeBench("2", "Test", map[string]string{"2": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "b"}})
+
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "n")
+	assert.Len(t, result, 2)
+}
+
+func TestMergeBenchmarks_SingleBenchmark(t *testing.T) {
+	bench := makeBench("1", "Solo", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "x"}})
+	result := MergeBenchmarks([]Benchmark{bench}, "n")
+	assert.Len(t, result, 1)
+	assert.Equal(t, "Solo", result[0].Name)
+}
+
+func TestMergeBenchmarks_PopulatedName(t *testing.T) {
+	bench1 := makeBench("1", "digits", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{
+		{Name: "digits", XAxis: "speed", YAxis: "1e4"},
+	})
+	bench2 := makeBench("2", "digits", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{
+		{Name: "digits", XAxis: "speed", YAxis: "1e4"},
+	})
+
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "n")
+	assert.Len(t, result, 1)
+	assert.Equal(t, "digits - 1", result[0].Data[0].Name)
+	assert.Equal(t, "digits - 2", result[0].Data[1].Name)
+}
+
+func TestMergeBenchmarks_InjectDimensionX(t *testing.T) {
+	bench1 := makeBench("1", "Test", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{
+		{XAxis: "", YAxis: "100"},
+	})
+	bench2 := makeBench("2", "Test", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{
+		{XAxis: "", YAxis: "200"},
+	})
+
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "x")
+	assert.Len(t, result, 1)
+	assert.Equal(t, "1", result[0].Data[0].XAxis)
+	assert.Equal(t, "2", result[0].Data[1].XAxis)
+	assert.Equal(t, "", result[0].Data[0].Name)
+}
+
+func TestMergeBenchmarks_InjectDimensionY(t *testing.T) {
+	bench1 := makeBench("1", "Test", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{
+		{XAxis: "x", YAxis: ""},
+	})
+	bench2 := makeBench("2", "Test", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{
+		{XAxis: "x", YAxis: ""},
+	})
+
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "y")
+	assert.Len(t, result, 1)
+	assert.Equal(t, "1", result[0].Data[0].YAxis)
+	assert.Equal(t, "2", result[0].Data[1].YAxis)
+}
+
+func TestMergeBenchmarks_RuntimeMerge(t *testing.T) {
+	bench1 := makeBench("1", "Test", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "a"}})
+	bench2 := makeBench("2", "Test", map[string]string{"2": "2026-05-13T10:05:00Z", "extra": "2026-05-13T11:00:00Z"}, []BenchmarkData{{Name: "b"}})
+
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "n")
+	assert.Len(t, result, 1)
+	assert.Len(t, result[0].Runtimes, 3)
+	assert.Equal(t, "2026-05-13T10:00:00Z", result[0].Runtimes["1"])
+	assert.Equal(t, "2026-05-13T10:05:00Z", result[0].Runtimes["2"])
+	assert.Equal(t, "2026-05-13T11:00:00Z", result[0].Runtimes["extra"])
+}
+
+func TestMergeBenchmarks_DifferentNames(t *testing.T) {
+	bench1 := makeBench("1", "Bench A", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "a"}})
+	bench2 := makeBench("2", "Bench B", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{{Name: "b"}})
+
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "n")
+	assert.Len(t, result, 2)
+}
+
+func TestMergeBenchmarks_EmptyInput(t *testing.T) {
+	result := MergeBenchmarks(nil, "n")
+	assert.Empty(t, result)
+}
+
+func TestMergeBenchmarks_NoMutation(t *testing.T) {
+	bench1 := makeBench("1", "Test", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "a"}})
+	bench2 := makeBench("2", "Test", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{{Name: "b"}})
+
+	original := []Benchmark{bench1, bench2}
+	result := MergeBenchmarks(original, "n")
+
+	assert.Equal(t, "a", original[0].Data[0].Name)
+	assert.Equal(t, "b", original[1].Data[0].Name)
+	assert.Len(t, result, 1)
+}


### PR DESCRIPTION
## Summary

Add tag-based merging to the `merge` subcommand. Benchmarks with the same name and different tags are deep-merged into a single object instead of being blindly appended. Designed for comparing performance across commits, releases, or environment variants.

## Changes

- **`shared/bench.go`** — Add `Tag` and `Runtimes` fields to `Benchmark` struct
- **`shared/merge.go`** (new) — `MergeBenchmarks` function implementing tag-based merge logic
- **`shared/merge_test.go`** (new) — 12 table-driven unit tests
- **`cmd/root.go`** — Register `--tag -t` flag, populate runtimes on benchmark generation
- **`cmd/merge.go`** — Register `--tag-axis -A` flag, wire `MergeBenchmarks`
- **`cmd/flag_validation_rules.go`** — Validate tag-axis values (`n`, `x`, `y`)
- **`README.md`** — Document tag-based merging workflow and commit comparison examples

## How it works

1. Tag benchmarks during generation: `vizb bench.txt -o main.json --tag main`
2. Merge with other tagged runs: `vizb merge main.json feature.json -o comparison.html`
3. Same-name benchmarks are deep-merged (latest timestamp wins), data arrays appended with tag annotations
4. Benchmarks without tags fall back to legacy append behavior

## Flags

| Flag | Command | Description |
|------|---------|-------------|
| `--tag -t` | root | Tag/identifier for the benchmark |
| `--tag-axis -A` | merge | Where to inject tag: `n` (name), `x` (xAxis), `y` (yAxis). Default: `n` |

## Breaking changes

- Unit shorthand flags (`-t`/`-m`/`-u` for time, memory, number) are now capitalized (`-T`/`-M`/`-N`)