### PR TITLE
fix(merge): accept array of benchmarks in input files

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -33,65 +34,91 @@ func runMerge(cmd *cobra.Command, args []string) {
 		shared.ExitWithError("No input files provided", nil)
 	}
 
-	var allFiles []string
+	files := collectJSONFiles(args)
+	if len(files) == 0 {
+		shared.ExitWithError("No valid files found to merge", nil)
+	}
 
-	// Expand directories and collect files
+	benches := readBenchmarks(files)
+	if len(benches) == 0 {
+		shared.ExitWithError("No valid benchmark files processed", nil)
+	}
+
+	merged := shared.MergeBenchmarks(benches, shared.Dimension(shared.FlagState.TagAxis))
+	writeMergeOutput(merged)
+}
+
+func collectJSONFiles(args []string) []string {
+	var files []string
 	for _, arg := range args {
 		info, err := os.Stat(arg)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, style.Warning.Render(fmt.Sprintf("Warning: cannot access %s: %v", arg, err)))
+			logWarn("cannot access %s: %v", arg, err)
 			continue
 		}
 
 		if info.IsDir() {
-			files, err := filepath.Glob(filepath.Join(arg, "*.json"))
+			found, err := filepath.Glob(filepath.Join(arg, "*.json"))
 			if err != nil {
-				fmt.Fprintln(os.Stderr, style.Warning.Render(fmt.Sprintf("Warning: error scanning directory %s: %v", arg, err)))
+				logWarn("error scanning directory %s: %v", arg, err)
 				continue
 			}
-			allFiles = append(allFiles, files...)
+			files = append(files, found...)
 		} else {
-			allFiles = append(allFiles, arg)
+			files = append(files, arg)
 		}
 	}
+	return files
+}
 
-	if len(allFiles) == 0 {
-		shared.ExitWithError("No valid files found to merge", nil)
-	}
-
-	var mergedBench []shared.Benchmark
-	validFilesCount := 0
-
-	for _, file := range allFiles {
-		content, err := os.ReadFile(file)
+func readBenchmarks(files []string) []shared.Benchmark {
+	var benches []shared.Benchmark
+	for _, file := range files {
+		parsed, err := parseBenchmarkFile(file)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, style.Warning.Render(fmt.Sprintf("Warning: cannot read file %s: %v", file, err)))
+			logWarn("%s: %v", file, err)
 			continue
 		}
+		benches = append(benches, parsed...)
+	}
+	return benches
+}
 
+func parseBenchmarkFile(file string) ([]shared.Benchmark, error) {
+	content, err := os.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read file: %w", err)
+	}
+
+	trimmed := bytes.TrimLeft(content, " \t\r\n")
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("file is empty")
+	}
+
+	switch trimmed[0] {
+	case '[':
+		var benches []shared.Benchmark
+		if err := json.Unmarshal(content, &benches); err != nil {
+			return nil, fmt.Errorf("invalid benchmark array: %w", err)
+		}
+		return benches, nil
+	case '{':
 		var bench shared.Benchmark
 		if err := json.Unmarshal(content, &bench); err != nil {
-			fmt.Fprintln(os.Stderr, style.Warning.Render(fmt.Sprintf("Warning: file %s does not satisfy Benchmark struct (JSON parse error), skipping.", file)))
-			continue
+			return nil, fmt.Errorf("invalid benchmark object: %w", err)
 		}
-
-		mergedBench = append(mergedBench, bench)
-		validFilesCount++
+		return []shared.Benchmark{bench}, nil
+	default:
+		return nil, fmt.Errorf("not valid JSON")
 	}
+}
 
-	mergedBench = shared.MergeBenchmarks(mergedBench, shared.FlagState.TagAxis)
-
-	if len(mergedBench) == 0 {
-		shared.ExitWithError("No valid benchmark files processed", nil)
-	}
-
-	// Generate Output
-	jsonData, err := json.Marshal(mergedBench)
+func writeMergeOutput(benches []shared.Benchmark) {
+	jsonData, err := json.Marshal(benches)
 	if err != nil {
 		shared.ExitWithError("Failed to marshal merged benchmark data: %v", err)
 	}
 
-	// Determine output file
 	outFile := shared.FlagState.OutputFile
 	if outFile == "" {
 		outFile = resolveOutputFileName(outFile)
@@ -114,4 +141,9 @@ func runMerge(cmd *cobra.Command, args []string) {
 		}
 		fmt.Println(style.Success.Render(fmt.Sprintf("🎉 Generated merged chart successfully: %s", outFile)))
 	}
+}
+
+func logWarn(format string, args ...interface{}) {
+	msg := fmt.Sprintf("Warning: "+format, args...)
+	fmt.Fprintln(os.Stderr, style.Warning.Render(msg))
 }

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -119,6 +119,47 @@ func TestMergeCmd_Directory(t *testing.T) {
 	assert.Contains(t, string(content), "Test1")
 }
 
+func TestMergeCmd_ArrayInput(t *testing.T) {
+	oldOsExit := shared.OsExit
+	defer func() { shared.OsExit = oldOsExit }()
+
+	var exitCode int
+	shared.OsExit = func(code int) { exitCode = code }
+
+	tmpDir, err := os.MkdirTemp("", "vizb-merge-array-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Single file with an array of 2 benchmarks
+	benches := []shared.Benchmark{
+		{Name: "Bench1", Data: []shared.BenchmarkData{{Name: "Test1", XAxis: "1", YAxis: "100"}}},
+		{Name: "Bench2", Data: []shared.BenchmarkData{{Name: "Test2", XAxis: "2", YAxis: "200"}}},
+	}
+	writeJSON(t, filepath.Join(tmpDir, "array.json"), benches)
+
+	outFile := filepath.Join(tmpDir, "merged_array.json")
+	shared.FlagState.OutputFile = outFile
+
+	rootCmd.SetArgs([]string{"merge", filepath.Join(tmpDir, "array.json")})
+	err = rootCmd.Execute()
+
+	if exitCode != 0 {
+		t.Errorf("OsExit called with code %d", exitCode)
+	}
+	assert.NoError(t, err)
+
+	content, err := os.ReadFile(outFile)
+	assert.NoError(t, err)
+
+	var parsed []shared.Benchmark
+	assert.NoError(t, json.Unmarshal(content, &parsed))
+	assert.Len(t, parsed, 2)
+	assert.Equal(t, "Bench1", parsed[0].Name)
+	assert.Equal(t, "Bench2", parsed[1].Name)
+}
+
 func writeJSON(t *testing.T, path string, v interface{}) {
 	data, err := json.Marshal(v)
 	if err != nil {

--- a/shared/dimension.go
+++ b/shared/dimension.go
@@ -1,0 +1,9 @@
+package shared
+
+type Dimension string
+
+const (
+	DimensionName  Dimension = "n"
+	DimensionXAxis Dimension = "x"
+	DimensionYAxis Dimension = "y"
+)

--- a/shared/merge.go
+++ b/shared/merge.go
@@ -5,9 +5,8 @@ import "maps"
 // MergeBenchmarks performs tag-based smart merging on a slice of benchmarks.
 // Benchmarks with the same Name and valid Tag fields are deep-merged into a
 // single object. Benchmarks lacking a Tag are appended individually (legacy).
-// injectDim controls which inner data dimension receives the benchmark tag
-// annotation: "n" for Name, "x" for XAxis, "y" for YAxis.
-func MergeBenchmarks(benchmarks []Benchmark, injectDim string) []Benchmark {
+// dim controls which inner data dimension receives the benchmark tag annotation.
+func MergeBenchmarks(benchmarks []Benchmark, dim Dimension) []Benchmark {
 	groups := groupByName(benchmarks)
 	var result []Benchmark
 
@@ -17,11 +16,10 @@ func MergeBenchmarks(benchmarks []Benchmark, injectDim string) []Benchmark {
 
 		switch len(withTag) {
 		case 0:
-			continue
 		case 1:
 			result = append(result, withTag[0])
 		default:
-			result = append(result, tagBasedMerge(withTag, injectDim)...)
+			result = append(result, tagBasedMerge(withTag, dim)...)
 		}
 	}
 
@@ -47,7 +45,7 @@ func splitByTag(benchmarks []Benchmark) (noTag, withTag []Benchmark) {
 	return
 }
 
-func tagBasedMerge(benchmarks []Benchmark, injectDim string) []Benchmark {
+func tagBasedMerge(benchmarks []Benchmark, dim Dimension) []Benchmark {
 	latestIdx, tie := findLatest(benchmarks)
 	if tie {
 		return benchmarks
@@ -55,33 +53,45 @@ func tagBasedMerge(benchmarks []Benchmark, injectDim string) []Benchmark {
 
 	merged := deepCloneBenchmark(benchmarks[latestIdx])
 	merged.Runtimes = mergeRuntimes(benchmarks)
-	merged.Data = mergeData(benchmarks, injectDim)
+	merged.Data = mergeData(benchmarks, dim)
 	return []Benchmark{merged}
 }
 
-func findLatest(benchmarks []Benchmark) (idx int, tie bool) {
+func findLatest(benchmarks []Benchmark) (int, bool) {
 	var maxTS string
-	idx = -1
 
-	for i, bench := range benchmarks {
-		for _, ts := range bench.Runtimes {
+	for _, b := range benchmarks {
+		for _, ts := range b.Runtimes {
 			if ts > maxTS {
 				maxTS = ts
-				idx = i
-				tie = false
-			} else if ts == maxTS && i != idx {
-				tie = true
 			}
 		}
 	}
 
-	return idx, tie
+	if maxTS == "" {
+		return -1, len(benchmarks) > 1
+	}
+
+	var latest, count int
+	for i, b := range benchmarks {
+		for _, ts := range b.Runtimes {
+			if ts == maxTS {
+				latest = i
+				count++
+				break
+			}
+		}
+	}
+
+	return latest, count > 1
 }
 
 func deepCloneBenchmark(src Benchmark) Benchmark {
 	dst := src
 	dst.Data = make([]BenchmarkData, len(src.Data))
-	copy(dst.Data, src.Data)
+	for i := range src.Data {
+		dst.Data[i] = deepCloneData(src.Data[i])
+	}
 
 	if src.Runtimes != nil {
 		dst.Runtimes = make(map[string]string, len(src.Runtimes))
@@ -99,23 +109,23 @@ func mergeRuntimes(benchmarks []Benchmark) map[string]string {
 	return result
 }
 
-func mergeData(benchmarks []Benchmark, tagAxis string) []BenchmarkData {
+func mergeData(benchmarks []Benchmark, dim Dimension) []BenchmarkData {
 	var result []BenchmarkData
 	for _, bench := range benchmarks {
 		for _, item := range bench.Data {
-			result = append(result, injectTag(item, bench.Tag, tagAxis))
+			result = append(result, injectTag(item, bench.Tag, dim))
 		}
 	}
 	return result
 }
 
-func injectTag(item BenchmarkData, tag string, dim string) BenchmarkData {
+func injectTag(item BenchmarkData, tag string, dim Dimension) BenchmarkData {
 	item = deepCloneData(item)
 
 	switch dim {
-	case "x":
+	case DimensionXAxis:
 		item.XAxis = applyInjection(item.XAxis, tag)
-	case "y":
+	case DimensionYAxis:
 		item.YAxis = applyInjection(item.YAxis, tag)
 	default:
 		item.Name = applyInjection(item.Name, tag)

--- a/shared/merge_test.go
+++ b/shared/merge_test.go
@@ -23,7 +23,7 @@ func TestMergeBenchmarks_SmartMerge(t *testing.T) {
 		{Name: "", XAxis: "speed", YAxis: "1e4"},
 	})
 
-	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "n")
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, DimensionName)
 	assert.Len(t, result, 1)
 
 	merged := result[0]
@@ -51,7 +51,7 @@ func TestMergeBenchmarks_MixedGroup(t *testing.T) {
 		Data: []BenchmarkData{{Name: "legacy", XAxis: "x", YAxis: "y"}},
 	}
 
-	result := MergeBenchmarks([]Benchmark{bench1, bench2, noTagBench}, "n")
+	result := MergeBenchmarks([]Benchmark{bench1, bench2, noTagBench}, DimensionName)
 	assert.Len(t, result, 2)
 }
 
@@ -59,7 +59,7 @@ func TestMergeBenchmarks_AllNoTag(t *testing.T) {
 	bench1 := Benchmark{Name: "Bench A", Data: []BenchmarkData{{Name: "a"}}}
 	bench2 := Benchmark{Name: "Bench A", Data: []BenchmarkData{{Name: "b"}}}
 
-	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "n")
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, DimensionName)
 	assert.Len(t, result, 2)
 }
 
@@ -67,13 +67,13 @@ func TestMergeBenchmarks_TimestampTie(t *testing.T) {
 	bench1 := makeBench("1", "Test", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "a"}})
 	bench2 := makeBench("2", "Test", map[string]string{"2": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "b"}})
 
-	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "n")
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, DimensionName)
 	assert.Len(t, result, 2)
 }
 
 func TestMergeBenchmarks_SingleBenchmark(t *testing.T) {
 	bench := makeBench("1", "Solo", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "x"}})
-	result := MergeBenchmarks([]Benchmark{bench}, "n")
+	result := MergeBenchmarks([]Benchmark{bench}, DimensionName)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "Solo", result[0].Name)
 }
@@ -86,7 +86,7 @@ func TestMergeBenchmarks_PopulatedName(t *testing.T) {
 		{Name: "digits", XAxis: "speed", YAxis: "1e4"},
 	})
 
-	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "n")
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, DimensionName)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "digits - 1", result[0].Data[0].Name)
 	assert.Equal(t, "digits - 2", result[0].Data[1].Name)
@@ -100,7 +100,7 @@ func TestMergeBenchmarks_InjectDimensionX(t *testing.T) {
 		{XAxis: "", YAxis: "200"},
 	})
 
-	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "x")
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, DimensionXAxis)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "1", result[0].Data[0].XAxis)
 	assert.Equal(t, "2", result[0].Data[1].XAxis)
@@ -115,7 +115,7 @@ func TestMergeBenchmarks_InjectDimensionY(t *testing.T) {
 		{XAxis: "x", YAxis: ""},
 	})
 
-	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "y")
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, DimensionYAxis)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "1", result[0].Data[0].YAxis)
 	assert.Equal(t, "2", result[0].Data[1].YAxis)
@@ -125,7 +125,7 @@ func TestMergeBenchmarks_RuntimeMerge(t *testing.T) {
 	bench1 := makeBench("1", "Test", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "a"}})
 	bench2 := makeBench("2", "Test", map[string]string{"2": "2026-05-13T10:05:00Z", "extra": "2026-05-13T11:00:00Z"}, []BenchmarkData{{Name: "b"}})
 
-	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "n")
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, DimensionName)
 	assert.Len(t, result, 1)
 	assert.Len(t, result[0].Runtimes, 3)
 	assert.Equal(t, "2026-05-13T10:00:00Z", result[0].Runtimes["1"])
@@ -137,12 +137,12 @@ func TestMergeBenchmarks_DifferentNames(t *testing.T) {
 	bench1 := makeBench("1", "Bench A", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "a"}})
 	bench2 := makeBench("2", "Bench B", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{{Name: "b"}})
 
-	result := MergeBenchmarks([]Benchmark{bench1, bench2}, "n")
+	result := MergeBenchmarks([]Benchmark{bench1, bench2}, DimensionName)
 	assert.Len(t, result, 2)
 }
 
 func TestMergeBenchmarks_EmptyInput(t *testing.T) {
-	result := MergeBenchmarks(nil, "n")
+	result := MergeBenchmarks(nil, DimensionName)
 	assert.Empty(t, result)
 }
 
@@ -151,7 +151,7 @@ func TestMergeBenchmarks_NoMutation(t *testing.T) {
 	bench2 := makeBench("2", "Test", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{{Name: "b"}})
 
 	original := []Benchmark{bench1, bench2}
-	result := MergeBenchmarks(original, "n")
+	result := MergeBenchmarks(original, DimensionName)
 
 	assert.Equal(t, "a", original[0].Data[0].Name)
 	assert.Equal(t, "b", original[1].Data[0].Name)


### PR DESCRIPTION
## Summary

Fixes the merge command to handle JSON files containing an **array** of benchmarks (`[{...}, {...}]`). Previously these files were silently skipped because the parser only expected a single `Benchmark` object per file.

### Changes

- **Array detection** — peek at the first JSON token: `[` → unmarshal as `[]Benchmark` and flatten, `{` → unmarshal as single `Benchmark` (existing behavior)
- **`shared/dimension.go`** (new) — typed `Dimension` constant (`DimensionName`/`DimensionXAxis`/`DimensionYAxis`) replacing magic strings `"n"`/`"x"`/`"y"`
- **`shared/merge.go`** — `findLatest` rewritten to two-pass for correctness; `deepCloneBenchmark` now fully deep-copies nested `BenchmarkData` elements
- **`cmd/merge.go`** — extracted 5 helpers from the 105-line god function `runMerge`: `collectJSONFiles`, `readBenchmarks`, `parseBenchmarkFile`, `writeMergeOutput`, `logWarn`
- **Tests** — added `TestMergeCmd_ArrayInput` covering the array case

### Backward compatibility

Zero behavioral changes for single-object files. All existing tests pass.