### PR TITLE
chore: prepare v0.9.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Vizb project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.9.3] - 2026-05-14
+
+### Fix
+
+- Prevent tag re-injection into previously-merged benchmark data on incremental merges ([#73](https://github.com/goptics/vizb/pull/73))
+- Trim CPU name whitespace when extracting from benchmark input
+
 # [0.9.2] - 2026-05-14
 
 ### Fix


### PR DESCRIPTION
## Summary
Prepare v0.9.3 release with changelog entry for tag re-injection fix.