### PR TITLE
refactor(merge): replace Runtimes with Timestamp + History

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Vizb project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.9.5] - 2026-05-16
+
+### Changed
+
+- **Benchmark Timestamp**: Replaced `Runtimes map[string]string` with direct `Timestamp` field on each benchmark — each run carries its own timestamp instead of an indirect tag→timestamp map
+- **Benchmark History**: Added `History []HistoryEntry` to track old tag+timestamp pairs from previous merges; latest tag stays on the benchmark itself, history holds only older tags
+- **Merge Internals**: Removed `benchGroup` struct and `taggedEntry` wrapper — replaced with `map[string]map[string]*Benchmark` for simpler tag dedup and insertion
+
+### Removed
+
+- `Runtimes` field from `Benchmark` struct (replaced by `Timestamp` + `History`)
+- `latestRuntime` and `mergeRuntimes` helper functions (no longer needed)
+- `benchGroup` and `taggedEntry` internal types
+
 # [0.9.4] - 2026-05-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,15 @@
 # Changelog
 
-All notable changes to the Vizb project will be documented in this file.
+Notable changes to Vizb documented here.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [0.9.5] - 2026-05-16
 
 ### Changed
 
 - **Benchmark Timestamp**: Replaced `Runtimes map[string]string` with direct `Timestamp` field on each benchmark — each run carries its own timestamp instead of an indirect tag→timestamp map
-- **Benchmark History**: Added `History []HistoryEntry` to track old tag+timestamp pairs from previous merges; latest tag stays on the benchmark itself, history holds only older tags
+- **Benchmark History**: Added `History []HistoryEntry` to track old tag+timestamp pairs from previous merges; latest tag stays on benchmark itself, history holds only older tags
 - **Merge Internals**: Removed `benchGroup` struct and `taggedEntry` wrapper — replaced with `map[string]map[string]*Benchmark` for simpler tag dedup and insertion
 
 ### Removed
@@ -23,14 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Merge Dedup**: Benchmarks sharing the same name and tag are now deduplicated by latest runtime timestamp instead of merging both data sets ([#76](https://github.com/goptics/vizb/pull/76))
-- **Chronological Tag Ordering**: Tags are processed in chronological order during inner merge for deterministic data ordering ([#76](https://github.com/goptics/vizb/pull/76))
-- **Latest Tag Preserved**: Merged output now retains the latest tag (by runtime timestamp) instead of clearing it ([#76](https://github.com/goptics/vizb/pull/76))
+- **Merge Dedup**: Benchmarks sharing same name and tag now deduplicated by latest runtime timestamp instead of merging both data sets ([#76](https://github.com/goptics/vizb/pull/76))
+- **Chronological Tag Ordering**: Tags processed in chronological order during inner merge for deterministic data ordering ([#76](https://github.com/goptics/vizb/pull/76))
+- **Latest Tag Preserved**: Merged output retains latest tag (by runtime timestamp) instead of clearing it ([#76](https://github.com/goptics/vizb/pull/76))
 
 ### Changed
 
-- **Merge Internals**: Rewrote `MergeBenchmarks` with a two-level map (`Name → Tag → Benchmark`) for cleaner dedup and deterministic output (removed 4 unused helpers) ([#76](https://github.com/goptics/vizb/pull/76))
-- **Scale Selector Label**: Renamed "Y-Axis Scale" to "Data Scale" since the scale applies to all chart data, not just Y-axis ([#77](https://github.com/goptics/vizb/pull/77))
+- **Merge Internals**: Rewrote `MergeBenchmarks` with two-level map (`Name → Tag → Benchmark`) for cleaner dedup and deterministic output (removed 4 unused helpers) ([#76](https://github.com/goptics/vizb/pull/76))
+- **Scale Selector Label**: Renamed "Y-Axis Scale" to "Data Scale" — scale applies to all chart data, not just Y-axis ([#77](https://github.com/goptics/vizb/pull/77))
 - **Scale Selector Visibility**: Removed Y-axis data gating — scale selector now always visible for non-pie charts ([#77](https://github.com/goptics/vizb/pull/77))
 
 ### Fix
@@ -54,27 +53,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix json format as merged subcommand output ([#71](https://github.com/goptics/vizb/pull/71))
 
-
 # [0.9.0] - 2026-05-14
 
 ### Added
 
-- **Tag-Based Merging**: Benchmarks with the same name and different tags are now deep-merged when using the `merge` subcommand, enabling historical comparison across commits, releases, or environment variants ([#69](https://github.com/goptics/vizb/pull/69)).
-- **`--tag -t` Flag**: New root command flag to assign a label (e.g., commit hash, version number) to a benchmark run. Automatically populates a `runtimes` map with a UTC timestamp.
-- **`--tag-axis -A` Flag**: New merge subcommand flag to control which data dimension receives the tag annotation. Accepts `n` (name), `x` (xAxis), or `y` (yAxis). Defaults to `n`.
-- **Runtimes Tracking**: `Tag` and `Runtimes` fields added to the `Benchmark` struct for tracking benchmark provenance and timestamps.
+- **Tag-Based Merging**: Benchmarks with same name but different tags deep-merged via `merge` subcommand — enables historical comparison across commits, releases, or environment variants ([#69](https://github.com/goptics/vizb/pull/69)).
+- **`--tag -t` Flag**: New root command flag to assign label (e.g., commit hash, version number) to benchmark run. Auto-populates `runtimes` map with UTC timestamp.
+- **`--tag-axis -A` Flag**: New merge subcommand flag controlling which data dimension receives tag annotation. Accepts `n` (name), `x` (xAxis), or `y` (yAxis). Defaults to `n`.
+- **Runtimes Tracking**: `Tag` and `Runtimes` fields added to `Benchmark` struct for tracking provenance and timestamps.
 
 ### Breaking
 
-- **Unit Shorthand Flags**: Shorthand flags for time (`-t`→`-T`), memory (`-m`→`-M`), and number (`-n`→`-N`) are now capitalized.
+- **Unit Shorthand Flags**: Shorthand flags for time (`-t`→`-T`), memory (`-m`→`-M`), and number (`-n`→`-N`) now capitalized.
 
 # [0.8.0] - 2026-04-25
 
 ### Added
 
-- **Logarithmic Scale**: Added `--scale` flag (`linear|log`) for bar and line charts to better visualize benchmarks with high variance in values ([#66](https://github.com/goptics/vizb/pull/66)).
-- **URL Routing for Scale**: Log scale is now synced with the `sc` query parameter for shareable URLs.
-
+- **Logarithmic Scale**: Added `--scale` flag (`linear|log`) for bar and line charts — better visualization of benchmarks with high variance in values ([#66](https://github.com/goptics/vizb/pull/66)).
+- **URL Routing for Scale**: Log scale synced with `sc` query parameter for shareable URLs.
 
 # [0.7.1] - 2025-12-28
 
@@ -92,61 +89,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Filter Flag**: Added `-f/--filter` flag to filter benchmarks using regular expressions ([#58](https://github.com/goptics/vizb/pull/58)).
-- **Format Inference**: Output format is now automatically inferred from the file extension (e.g., `.json` for JSON, others for HTML) ([#58](https://github.com/goptics/vizb/pull/58)).
-- **URL Routing**: Implemented a lightweight URL router to sync UI state (sort, labels, chart type, selection) with query parameters ([#55](https://github.com/goptics/vizb/pull/55)).
-- **Dynamic Title**: Browser tab title now dynamically updates to show the active benchmark name ([#56](https://github.com/goptics/vizb/pull/56)).
+- **Filter Flag**: Added `-f/--filter` flag to filter benchmarks using regex ([#58](https://github.com/goptics/vizb/pull/58)).
+- **Format Inference**: Output format auto-inferred from file extension (e.g., `.json` for JSON, others for HTML) ([#58](https://github.com/goptics/vizb/pull/58)).
+- **URL Routing**: Lightweight URL router syncs UI state (sort, labels, chart type, selection) with query parameters ([#55](https://github.com/goptics/vizb/pull/55)).
+- **Dynamic Title**: Browser tab title dynamically updates to show active benchmark name ([#56](https://github.com/goptics/vizb/pull/56)).
 
 ### Changed
 
-- **Validation**: Enhanced validation logic and improved warning messages to provide specific reasons for failures ([#57](https://github.com/goptics/vizb/pull/57)).
-- **UI Architecture**: Refactored settings management to use a single reactive state object for better consistency ([#53](https://github.com/goptics/vizb/pull/53)).
-- **Internal**: Introduced generic `sortBy` function and removed unused dependencies ([#52](https://github.com/goptics/vizb/pull/52), [#54](https://github.com/goptics/vizb/pull/54)).
+- **Validation**: Enhanced validation logic, improved warning messages with specific failure reasons ([#57](https://github.com/goptics/vizb/pull/57)).
+- **UI Architecture**: Refactored settings management to single reactive state object for consistency ([#53](https://github.com/goptics/vizb/pull/53)).
+- **Internal**: Introduced generic `sortBy` function, removed unused dependencies ([#52](https://github.com/goptics/vizb/pull/52), [#54](https://github.com/goptics/vizb/pull/54)).
 
 ### Breaking Changes
 
-- **Format Flag Removed**: The `--format` flag has been removed in favor of automatic inference from the output filename.
-- **Short Flag Reassigned**: The `-f` shorthand flag is now used for `--filter` instead of `--format`.
+- **Format Flag Removed**: `--format` flag removed in favor of automatic inference from output filename.
+- **Short Flag Reassigned**: `-f` shorthand now used for `--filter` instead of `--format`.
 
 # [0.6.0] - 2025-12-03
 
 ### Added
 
-- **Standard Benchmark JSON Support**: Added support for using standard benchmark JSON files as input ([#47](https://github.com/goptics/vizb/pull/47)).
-- **Axis Swapping**: Implemented a new axis swapping feature that allows dynamic reordering of benchmark dimensions (name, xAxis, yAxis) with persistent state management ([#46](https://github.com/goptics/vizb/pull/46)).
-- **Advanced Grouping**: Introduced advanced benchmark grouping capabilities using regular expressions.([#40](https://github.com/goptics/vizb/pull/40))
-- **Benchmark Environment**: Added benchmark environment details to the results ([#39](https://github.com/goptics/vizb/pull/39)).
-- **Metric Extraction**: Added support for extracting and displaying benchmark iterations, throughput, and custom metrics ([#35](https://github.com/goptics/vizb/pull/35)).
-- Added a "Package Source" button to the dashboard and updated documentation with comprehensive examples.
+- **Standard Benchmark JSON Support**: Support for standard benchmark JSON files as input ([#47](https://github.com/goptics/vizb/pull/47)).
+- **Axis Swapping**: Dynamic reordering of benchmark dimensions (name, xAxis, yAxis) with persistent state management ([#46](https://github.com/goptics/vizb/pull/46)).
+- **Advanced Grouping**: Benchmark grouping via regex patterns ([#40](https://github.com/goptics/vizb/pull/40)).
+- **Benchmark Environment**: Added benchmark environment details to results ([#39](https://github.com/goptics/vizb/pull/39)).
+- **Metric Extraction**: Support for extracting and displaying benchmark iterations, throughput, and custom metrics ([#35](https://github.com/goptics/vizb/pull/35)).
+- Added "Package Source" button to dashboard, updated docs with comprehensive examples.
 
 ### Changed
 
-- **JSON Optimization**: Reduced JSON output size by 30% by removing redundant `unit` and `per` properties and using `omitempty` ([#43](https://github.com/goptics/vizb/pull/43), [#45](https://github.com/goptics/vizb/pull/45)).
-- **UI Performance**: Refactored UI components to reduce bundle size and improved dashboard layout ([#38](https://github.com/goptics/vizb/pull/38)).
-- **CI/CD**: Updated CI runners to `slim` versions and improved GoReleaser configuration for optimized builds ([#37](https://github.com/goptics/vizb/pull/37), e673195).
-- **Documentation**: Updated docs and info for the upcoming release ([#50](https://github.com/goptics/vizb/pull/50)).
-- **Build**: Updated favicon inline build script and added `format` task to Taskfile.yml.
+- **JSON Optimization**: Reduced JSON output size 30% by removing redundant `unit` and `per` properties, using `omitempty` ([#43](https://github.com/goptics/vizb/pull/43), [#45](https://github.com/goptics/vizb/pull/45)).
+- **UI Performance**: Refactored UI components to reduce bundle size, improved dashboard layout ([#38](https://github.com/goptics/vizb/pull/38)).
+- **CI/CD**: Updated CI runners to `slim` versions, improved GoReleaser config for optimized builds ([#37](https://github.com/goptics/vizb/pull/37), e673195).
+- **Documentation**: Updated docs for upcoming release ([#50](https://github.com/goptics/vizb/pull/50)).
+- **Build**: Updated favicon inline build script, added `format` task to Taskfile.yml.
 
 ### Fixed
 
 - **Label Rotation**: Fixed x-axis label rotation based on character length ([#48](https://github.com/goptics/vizb/pull/48)).
-- **Group Selection**: Resolved issues with group selection state not being preserved when switching benchmarks ([#41](https://github.com/goptics/vizb/pull/41), [#42](https://github.com/goptics/vizb/pull/42)).
-- **Flag Validation**: Resolved flag validation rules and updated tests ([#36](https://github.com/goptics/vizb/pull/36)).
+- **Group Selection**: Fixed group selection state not preserved when switching benchmarks ([#41](https://github.com/goptics/vizb/pull/41), [#42](https://github.com/goptics/vizb/pull/42)).
+- **Flag Validation**: Fixed flag validation rules and updated tests ([#36](https://github.com/goptics/vizb/pull/36)).
 
 # [0.5.0] - 2025-11-23
 
 ### Added
 
-- Completely new UI built with **Vue.js** for enhanced interactivity and modern design.
-- **Dark and Light Mode** support for the UI.
+- Completely new UI built with **Vue.js** — enhanced interactivity and modern design.
+- **Dark and Light Mode** support.
 - **Merge subcommand** for combining multiple benchmark JSON files into one report.
-- **New CLI flags** for advanced sorting and label control of benchmarks data.
+- **New CLI flags** for advanced sorting and label control.
 - Introduced chart types **Bar, Line, and Pie** for different metrics.
 
 ### Changed
 
-- Refactored UI embedding using vite in the UI and html template in cli.
-- CLI output visually enhanced with consistent styles for info, success, error, and warning messages.
+- Refactored UI embedding using vite in UI and html template in cli.
+- CLI output visually enhanced with consistent styles for info, success, error, warning messages.
 - Documentation expanded with improved examples and advanced group patterns.
 
 ### Fixed
@@ -164,32 +161,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Advanced pattern-based grouping system for extracting groups from benchmark names
-- Skip functionality for selective benchmark processing during data analysis
+- Advanced pattern-based grouping for extracting groups from benchmark names
+- Skip functionality for selective benchmark processing
 - Support for raw benchmark data processing
-- Comprehensive flag validation rules with enhanced error handling
-- Dynamic color assignment for chart subjects to ensure consistent coloring across benchmark groups
-- Enhanced temporary file management system
-- Extensive test coverage for previously untested functions including temp file creation, stdin processing, and output generation
+- Comprehensive flag validation with enhanced error handling
+- Dynamic color assignment for chart subjects — consistent coloring across groups
+- Enhanced temp file management
+- Extensive test coverage for previously untested functions (temp file creation, stdin processing, output generation)
 
 ### Changed
 
-- Enhanced flag validation to require subject parameter specification
-- Improved chart template UX with dynamic legend section resizing based on subject numbers
-- Updated documentation with advanced grouping examples and usage patterns
+- Enhanced flag validation to require subject parameter
+- Improved chart template UX with dynamic legend resizing based on subject count
+- Updated docs with advanced grouping examples
 - Refined benchmark progress real-time logic
-- Streamlined error handling and file operations with shared utility functions
+- Streamlined error handling and file ops with shared utility functions
 - Updated README with shorthand patterns to reduce table width
 
 ### Fixed
 
-- Improved chart template UX by hiding CPU number display when value is 0
-- Enhanced error handling in benchmark result parsing for group parsing
-- Resolved inconsistent color assignment issue when benchmark groups have different subject list lengths
+- Hide CPU number display when value is 0
+- Improved error handling in benchmark result parsing for group parsing
+- Fixed inconsistent color assignment when groups have different subject list lengths
 
 ### Breaking changes
 
-In this release the `--separator` flag is been replaced with `--group-pattern` to brings more flexibility.
+`--separator` flag replaced with `--group-pattern` for more flexibility.
 
 ## [0.3.2] - 2025-09-13
 
@@ -202,22 +199,22 @@ In this release the `--separator` flag is been replaced with `--group-pattern` t
 ### Fixed
 
 - Group bench name order issue resolved
-- Resolved grouping name when the split words len less then one
+- Fixed grouping name when split words len < 1
 
 ## [0.3.0] - 2025-06-21
 
 ### Added
 
-- Added improved documentation for `--format` flag in README
-- Added comprehensive test coverage for previously untested functions
-- Added dedicated tests for temp file creation, stdin processing, and output generation
-- Added example for JSON output format in documentation
+- Improved docs for `--format` flag in README
+- Comprehensive test coverage for previously untested functions
+- Dedicated tests for temp file creation, stdin processing, output generation
+- Example for JSON output format in docs
 
 ### Changed
 
 - Enhanced code testability with mock-friendly function variables
-- Optimized sidebar display logic in chart templates to only show with sufficient chart count
-- Standardized temporary file naming with consistent prefixes
+- Optimized sidebar display logic — only show with sufficient chart count
+- Standardized temp file naming with consistent prefixes
 
 ### Fixed
 
@@ -228,27 +225,27 @@ In this release the `--separator` flag is been replaced with `--group-pattern` t
 
 ### Added
 
-- Added benchmark indicator for easy navigation
-- Added allocation unit conversion support for benchmark charts
-- Added support for units lowercase input
+- Benchmark indicator for easy navigation
+- Allocation unit conversion support for benchmark charts
+- Support for units lowercase input
 - Enhanced grouping by adding bench name
-- Added CPU count suffix to the headline
+- CPU count suffix added to headline
 
 ### Changed
 
 - Adjusted chart bottom margin for better visualization
 - Optimized benchmark parsing logic in chart.go with cleaner control flow
-- Organized the post generation logs
-- Renamed license file and added attribution request
-- Updated documentation with bench group feature information
+- Organized post-generation logs
+- Renamed license file, added attribution request
+- Updated docs with bench group feature info
 - Added Vizb attribution in footer
 
 ### Fixed
 
 - Resolved extra line issue after pipe progress completed
-- Fixed test count display on pipe and changed the status
+- Fixed test count display on pipe, changed status
 - Corrected memory unit conversion from bytes to bits
-- Removed build script as it is no longer needed
+- Removed build script — no longer needed
 
 ## [0.1.1] - 2025-06-19
 
@@ -260,24 +257,24 @@ In this release the `--separator` flag is been replaced with `--group-pattern` t
 
 ### Added
 
-- Initial release of Vizb - Go Benchmark Visualization Tool
-- Interactive HTML charts generation from Go benchmark results
-- Support for multiple metrics:
+- Initial release of Vizb — Go Benchmark Visualization Tool
+- Interactive HTML charts from Go benchmark results
+- Multiple metric support:
   - Execution time visualization
   - Memory usage visualization
   - Allocation counts visualization
-- Customizable units for metrics:
+- Customizable units:
   - Time: ns, us, ms, s
   - Memory: B, KB, MB, GB
 - Customizable chart titles and descriptions
-- Responsive design for charts that work on any device
-- Export capability to save charts as PNG images
+- Responsive design for any device
+- Export charts as PNG images
 - Simple CLI interface with helpful flags:
   - Custom output file name
   - Custom chart name and description
   - Custom units for time and memory
   - Custom separator for benchmark grouping
-- Support for piped input to process benchmark data directly from stdin
+- Piped input support — process benchmark data from stdin
 - Benchmark grouping based on separator character (default: "/")
 - Organized visualization with workload and subject grouping
 - Development workflow using Task runner

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ vizb merge ./results/ -o all_results.html
 
 # Mix and match files and directories
 vizb merge ./old_results/ output.json -o comparison.html
+
+# To get json as an output for CI/CD
+vizb merge ./old_results/ output.json -o comparison.json
 ```
 
 Open the generated HTML file in your browser to view the interactive charts.
@@ -111,14 +114,14 @@ Open the generated HTML file in your browser to view the interactive charts.
 
 ### Tag-Based Merging
 
-Vizb supports tagging benchmarks to compare performance across multiple commits, releases, or environment variants. The `--tag` flag on the main command assigns a label (e.g., commit hash, version number) to a benchmark run. When merging, vizb groups benchmarks by `name` and deep-merges those sharing the same name but different tags into a single object, preserving all runtimes and data.
+Vizb supports tagging benchmarks to compare performance across multiple commits, releases, or environment variants. The `--tag` flag on the main command assigns a label (e.g., commit hash, version number) to a benchmark run. When merging, vizb groups benchmarks by `name` and deep-merges those sharing the same name but different tags into a single object, preserving all timestamps, history, and data.
 
 #### Tagging a benchmark run
 
 ```bash
-vizb bench.txt -o v1.json --tag v1 -n "Foo"
+vizb bench-v1.txt -o v1.json --tag v1 -n "Foo"
 
-vizb bench.txt -o v2.json --tag v2 -n "Foo"
+vizb bench-v2.txt -o v2.json --tag v2 -n "Foo"
 ```
 
 #### How tag-based merging works
@@ -131,10 +134,10 @@ vizb merge v1.json v2.json -o comparison.html
 
 Vizb groups benchmarks by name and processes each group as follows:
 
-1. **Deduplication** — If two entries share the same name and tag, only the one with the latest runtime timestamp is kept. Older entries are discarded.
-2. **Inner merge** — Entries with different tags are deep-merged into a single benchmark. Data points are sorted in chronological tag order and each is annotated with its originating tag.
-3. **Legacy entries** — Untagged benchmarks (no `--tag`) with the same name are deduplicated (first-seen wins) and their data is prepended before tagged entries.
-4. **Output** — The merged benchmark retains the latest tag (by runtime timestamp), combines all runtime maps, and includes data from all runs.
+1. **Deduplication**: If two entries share the same name and tag, only the one with the latest timestamp is kept. Older entries are discarded.
+2. **Inner merge**: Entries with different tags are deep-merged into a single benchmark. Data points are sorted in chronological tag order and each is annotated with its originating tag.
+3. **Legacy entries**: Untagged benchmarks (no `--tag`) with the same name are deduplicated (first-seen wins) and their data is prepended before tagged entries.
+4. **Output**: The merged benchmark retains the latest tag (by timestamp), carries a history of older tags, and includes data from all runs.
 
 #### Controlling where the tag is injected
 
@@ -157,9 +160,9 @@ Vizb creates charts that make sense by putting your benchmark data into logical 
 
 A group pattern tells vizb how to dissect your benchmark names into three key components:
 
-1.  **Name (n)**: The family or group the benchmark belongs to. Benchmarks with the same `Name` will be grouped together in the same chart. (optional)
-2.  **XAxis (x)**: The category that goes on the X-axis (e.g., input size, concurrency level).
-3.  **YAxis (y)**: The specific test case or variation (e.g., algorithm name, sub-test).
+1. **Name (n)**: The family or group the benchmark belongs to. Benchmarks with the same `Name` will be grouped together in the same chart. (optional)
+2. **XAxis (x)**: The category that goes on the X-axis (e.g., input size, concurrency level).
+3. **YAxis (y)**: The specific test case or variation (e.g., algorithm name, sub-test).
 
 ### Visualizing the Extraction
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -261,9 +261,7 @@ func prepareBenchmarkFromParsedResults(results []shared.BenchmarkData) *shared.B
 
 	if shared.FlagState.Tag != "" {
 		benchmark.Tag = shared.FlagState.Tag
-		benchmark.Runtimes = map[string]string{
-			benchmark.Tag: time.Now().UTC().Format(time.RFC3339),
-		}
+		benchmark.Timestamp = time.Now().UTC().Format(time.RFC3339)
 	}
 
 	return benchmark

--- a/shared/bench.go
+++ b/shared/bench.go
@@ -12,11 +12,17 @@ type BenchmarkData struct {
 	Stats []Stat `json:"stats"`
 }
 
+type HistoryEntry struct {
+	Tag       string `json:"tag"`
+	Timestamp string `json:"timestamp"`
+}
+
 type Benchmark struct {
-	Tag         string            `json:"tag,omitempty"`
-	Name        string            `json:"name"`
-	Runtimes    map[string]string `json:"runtimes,omitempty"`
-	Description string            `json:"description,omitempty"`
+	Tag         string         `json:"tag,omitempty"`
+	Timestamp   string         `json:"timestamp,omitempty"`
+	Name        string         `json:"name"`
+	History     []HistoryEntry `json:"history,omitempty"`
+	Description string         `json:"description,omitempty"`
 	CPU         struct {
 		Name  string `json:"name,omitempty"`
 		Cores int    `json:"cores,omitempty"`

--- a/shared/merge.go
+++ b/shared/merge.go
@@ -4,24 +4,7 @@ import (
 	"sort"
 )
 
-type benchGroup struct {
-	noTag  *Benchmark
-	tagged []Benchmark
-}
-
-func (g *benchGroup) addTagged(bench Benchmark) {
-	for i, t := range g.tagged {
-		if t.Tag != bench.Tag {
-			continue
-		}
-		if t.Timestamp >= bench.Timestamp {
-			return
-		}
-		g.tagged[i] = bench
-		return
-	}
-	g.tagged = append(g.tagged, bench)
-}
+const noTagKey = "__no_tag__"
 
 // MergeBenchmarks performs tag-based smart merging on a slice of benchmarks.
 // Benchmarks with the same Name and valid Tag fields are deep-merged into a
@@ -31,47 +14,53 @@ func (g *benchGroup) addTagged(bench Benchmark) {
 // dim controls which inner data dimension receives the benchmark tag annotation.
 func MergeBenchmarks(benchmarks []Benchmark, dim Dimension) []Benchmark {
 	nameOrder := make([]string, 0)
-	groups := make(map[string]*benchGroup)
+	groups := make(map[string]map[string]*Benchmark)
 
 	for _, bench := range benchmarks {
-		group, ok := groups[bench.Name]
+		tags, ok := groups[bench.Name]
 		if !ok {
-			group = new(benchGroup)
-			groups[bench.Name] = group
+			tags = make(map[string]*Benchmark)
+			groups[bench.Name] = tags
 			nameOrder = append(nameOrder, bench.Name)
 		}
 
-		if bench.Tag == "" {
-			if group.noTag == nil {
-				b := bench
-				group.noTag = &b
-			}
+		tag := bench.Tag
+		if tag == "" {
+			tag = noTagKey
+		}
+
+		if existing, exists := tags[tag]; exists && existing.Timestamp >= bench.Timestamp {
 			continue
 		}
 
-		group.addTagged(bench)
+		tags[tag] = &bench
 	}
 
 	result := make([]Benchmark, 0, len(nameOrder))
 
 	for _, name := range nameOrder {
-		group := groups[name]
+		tags := groups[name]
 
-		tagged := make([]Benchmark, len(group.tagged))
-		copy(tagged, group.tagged)
+		noTag := tags[noTagKey]
+		delete(tags, noTagKey)
+
+		tagged := make([]Benchmark, 0, len(tags))
+		for _, b := range tags {
+			tagged = append(tagged, *b)
+		}
 		sort.SliceStable(tagged, func(i, j int) bool {
 			return tagged[i].Timestamp < tagged[j].Timestamp
 		})
 
 		switch {
-		case group.noTag != nil && len(tagged) == 0:
-			result = append(result, *group.noTag)
+		case noTag != nil && len(tagged) == 0:
+			result = append(result, *noTag)
 		default:
-			if group.noTag != nil {
+			if noTag != nil {
 				allBenches := make([]Benchmark, 0, 1+len(tagged))
-				allBenches = append(allBenches, *group.noTag)
+				allBenches = append(allBenches, *noTag)
 				allBenches = append(allBenches, tagged...)
-				base := deepCloneBenchmark(*group.noTag)
+				base := deepCloneBenchmark(*noTag)
 				latest := tagged[len(tagged)-1]
 				base.Tag = latest.Tag
 				base.Timestamp = latest.Timestamp

--- a/shared/merge.go
+++ b/shared/merge.go
@@ -1,46 +1,26 @@
 package shared
 
 import (
-	"maps"
 	"sort"
 )
 
 type benchGroup struct {
 	noTag  *Benchmark
-	tagged []taggedEntry
-}
-
-type taggedEntry struct {
-	Benchmark Benchmark
-	timestamp string
+	tagged []Benchmark
 }
 
 func (g *benchGroup) addTagged(bench Benchmark) {
-	latest := latestRuntime(bench.Runtimes)
-	for i, e := range g.tagged {
-		if e.Benchmark.Tag != bench.Tag {
+	for i, t := range g.tagged {
+		if t.Tag != bench.Tag {
 			continue
 		}
-		if e.timestamp >= latest {
+		if t.Timestamp >= bench.Timestamp {
 			return
 		}
-		g.tagged[i] = taggedEntry{Benchmark: bench, timestamp: latest}
+		g.tagged[i] = bench
 		return
 	}
-	g.tagged = append(g.tagged, taggedEntry{Benchmark: bench, timestamp: latest})
-}
-
-// latestRuntime returns the latest (greatest) timestamp from a runtimes map.
-// Timestamps are expected to be in ISO 8601 / RFC 3339 format, which
-// sorts lexicographically in the same order as chronologically.
-func latestRuntime(runtimes map[string]string) string {
-	var latest string
-	for _, ts := range runtimes {
-		if ts > latest {
-			latest = ts
-		}
-	}
-	return latest
+	g.tagged = append(g.tagged, bench)
 }
 
 // MergeBenchmarks performs tag-based smart merging on a slice of benchmarks.
@@ -77,37 +57,35 @@ func MergeBenchmarks(benchmarks []Benchmark, dim Dimension) []Benchmark {
 	for _, name := range nameOrder {
 		group := groups[name]
 
-		tagged := make([]taggedEntry, len(group.tagged))
+		tagged := make([]Benchmark, len(group.tagged))
 		copy(tagged, group.tagged)
 		sort.SliceStable(tagged, func(i, j int) bool {
-			return tagged[i].timestamp < tagged[j].timestamp
+			return tagged[i].Timestamp < tagged[j].Timestamp
 		})
 
 		switch {
 		case group.noTag != nil && len(tagged) == 0:
 			result = append(result, *group.noTag)
 		default:
-			benches := make([]Benchmark, len(tagged))
-			for i, e := range tagged {
-				benches[i] = e.Benchmark
+			if group.noTag != nil {
+				allBenches := make([]Benchmark, 0, 1+len(tagged))
+				allBenches = append(allBenches, *group.noTag)
+				allBenches = append(allBenches, tagged...)
+				base := deepCloneBenchmark(*group.noTag)
+				latest := tagged[len(tagged)-1]
+				base.Tag = latest.Tag
+				base.Timestamp = latest.Timestamp
+				base.History = buildHistory(allBenches, latest.Tag)
+				base.Data = mergeData(allBenches, dim)
+				result = append(result, base)
+				continue
 			}
 
-			if group.noTag != nil {
-				allBenches := make([]Benchmark, 0, 1+len(benches))
-				allBenches = append(allBenches, *group.noTag)
-				allBenches = append(allBenches, benches...)
-				base := deepCloneBenchmark(*group.noTag)
-				base.Runtimes = mergeRuntimes(allBenches)
-				base.Data = mergeData(allBenches, dim)
-				base.Tag = benches[len(benches)-1].Tag
-				result = append(result, base)
-			} else {
-				base := deepCloneBenchmark(benches[len(benches)-1])
-				base.Runtimes = mergeRuntimes(benches)
-				base.Data = mergeData(benches, dim)
-				base.Tag = benches[len(benches)-1].Tag
-				result = append(result, base)
-			}
+			latest := tagged[len(tagged)-1]
+			base := deepCloneBenchmark(latest)
+			base.History = buildHistory(tagged, latest.Tag)
+			base.Data = mergeData(tagged, dim)
+			result = append(result, base)
 		}
 	}
 
@@ -121,20 +99,47 @@ func deepCloneBenchmark(src Benchmark) Benchmark {
 		dst.Data[i] = deepCloneData(src.Data[i])
 	}
 
-	if src.Runtimes != nil {
-		dst.Runtimes = make(map[string]string, len(src.Runtimes))
-		maps.Copy(dst.Runtimes, src.Runtimes)
+	if src.History != nil {
+		dst.History = make([]HistoryEntry, len(src.History))
+		copy(dst.History, src.History)
 	}
 
 	return dst
 }
 
-func mergeRuntimes(benchmarks []Benchmark) map[string]string {
-	result := make(map[string]string)
+// buildHistory collects tag+timestamp pairs from all benchmarks and their
+// existing History entries, excluding the latest tag. Entries are deduplicated
+// by tag (keeping the latest timestamp per tag) and sorted chronologically.
+func buildHistory(benchmarks []Benchmark, latestTag string) []HistoryEntry {
+	seen := make(map[string]string)
 	for _, bench := range benchmarks {
-		maps.Copy(result, bench.Runtimes)
+		if bench.Tag != "" && bench.Tag != latestTag {
+			if ts, ok := seen[bench.Tag]; !ok || bench.Timestamp > ts {
+				seen[bench.Tag] = bench.Timestamp
+			}
+		}
+		for _, entry := range bench.History {
+			if entry.Tag == latestTag {
+				continue
+			}
+			if ts, ok := seen[entry.Tag]; !ok || entry.Timestamp > ts {
+				seen[entry.Tag] = entry.Timestamp
+			}
+		}
 	}
-	return result
+
+	if len(seen) == 0 {
+		return nil
+	}
+
+	entries := make([]HistoryEntry, 0, len(seen))
+	for tag, ts := range seen {
+		entries = append(entries, HistoryEntry{Tag: tag, Timestamp: ts})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Timestamp < entries[j].Timestamp
+	})
+	return entries
 }
 
 func mergeData(benchmarks []Benchmark, dim Dimension) []BenchmarkData {

--- a/shared/merge.go
+++ b/shared/merge.go
@@ -6,14 +6,28 @@ import (
 )
 
 type benchGroup struct {
-	noTag       Benchmark
-	hasNoTag    bool
-	taggedByTag map[string]*taggedEntry
+	noTag  *Benchmark
+	tagged []taggedEntry
 }
 
 type taggedEntry struct {
-	benchmark Benchmark
+	Benchmark Benchmark
 	timestamp string
+}
+
+func (g *benchGroup) addTagged(bench Benchmark) {
+	latest := latestRuntime(bench.Runtimes)
+	for i, e := range g.tagged {
+		if e.Benchmark.Tag != bench.Tag {
+			continue
+		}
+		if e.timestamp >= latest {
+			return
+		}
+		g.tagged[i] = taggedEntry{Benchmark: bench, timestamp: latest}
+		return
+	}
+	g.tagged = append(g.tagged, taggedEntry{Benchmark: bench, timestamp: latest})
 }
 
 // latestRuntime returns the latest (greatest) timestamp from a runtimes map.
@@ -42,28 +56,20 @@ func MergeBenchmarks(benchmarks []Benchmark, dim Dimension) []Benchmark {
 	for _, bench := range benchmarks {
 		group, ok := groups[bench.Name]
 		if !ok {
-			group = &benchGroup{taggedByTag: make(map[string]*taggedEntry)}
+			group = new(benchGroup)
 			groups[bench.Name] = group
 			nameOrder = append(nameOrder, bench.Name)
 		}
 
 		if bench.Tag == "" {
-			if !group.hasNoTag {
-				group.noTag = bench
-				group.hasNoTag = true
+			if group.noTag == nil {
+				b := bench
+				group.noTag = &b
 			}
 			continue
 		}
 
-		latestTS := latestRuntime(bench.Runtimes)
-		if existing, exists := group.taggedByTag[bench.Tag]; exists && existing.timestamp >= latestTS {
-			continue
-		}
-
-		group.taggedByTag[bench.Tag] = &taggedEntry{
-			benchmark: bench,
-			timestamp: latestTS,
-		}
+		group.addTagged(bench)
 	}
 
 	result := make([]Benchmark, 0, len(nameOrder))
@@ -71,28 +77,26 @@ func MergeBenchmarks(benchmarks []Benchmark, dim Dimension) []Benchmark {
 	for _, name := range nameOrder {
 		group := groups[name]
 
-		tagged := make([]*taggedEntry, 0, len(group.taggedByTag))
-		for _, entry := range group.taggedByTag {
-			tagged = append(tagged, entry)
-		}
+		tagged := make([]taggedEntry, len(group.tagged))
+		copy(tagged, group.tagged)
 		sort.SliceStable(tagged, func(i, j int) bool {
 			return tagged[i].timestamp < tagged[j].timestamp
 		})
 
 		switch {
-		case group.hasNoTag && len(tagged) == 0:
-			result = append(result, group.noTag)
+		case group.noTag != nil && len(tagged) == 0:
+			result = append(result, *group.noTag)
 		default:
 			benches := make([]Benchmark, len(tagged))
 			for i, e := range tagged {
-				benches[i] = e.benchmark
+				benches[i] = e.Benchmark
 			}
 
-			if group.hasNoTag {
+			if group.noTag != nil {
 				allBenches := make([]Benchmark, 0, 1+len(benches))
-				allBenches = append(allBenches, group.noTag)
+				allBenches = append(allBenches, *group.noTag)
 				allBenches = append(allBenches, benches...)
-				base := deepCloneBenchmark(group.noTag)
+				base := deepCloneBenchmark(*group.noTag)
 				base.Runtimes = mergeRuntimes(allBenches)
 				base.Data = mergeData(allBenches, dim)
 				base.Tag = benches[len(benches)-1].Tag

--- a/shared/merge_test.go
+++ b/shared/merge_test.go
@@ -6,20 +6,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func makeBench(tag, name string, runtimes map[string]string, data []BenchmarkData) Benchmark {
+func makeBench(tag, name, timestamp string, data []BenchmarkData) Benchmark {
 	return Benchmark{
-		Tag:      tag,
-		Name:     name,
-		Runtimes: runtimes,
-		Data:     data,
+		Tag:       tag,
+		Timestamp: timestamp,
+		Name:      name,
+		Data:      data,
 	}
 }
 
 func TestMergeBenchmarks_SmartMerge(t *testing.T) {
-	bench1 := makeBench("1", "My benchmark", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{
+	bench1 := makeBench("1", "My benchmark", "2026-05-13T10:00:00Z", []BenchmarkData{
 		{Name: "", XAxis: "speed", YAxis: "1e4"},
 	})
-	bench2 := makeBench("2", "My benchmark", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{
+	bench2 := makeBench("2", "My benchmark", "2026-05-13T10:05:00Z", []BenchmarkData{
 		{Name: "", XAxis: "speed", YAxis: "1e4"},
 	})
 
@@ -29,20 +29,20 @@ func TestMergeBenchmarks_SmartMerge(t *testing.T) {
 	merged := result[0]
 	assert.Equal(t, "2", merged.Tag)
 	assert.Equal(t, "My benchmark", merged.Name)
-	assert.Equal(t, map[string]string{
-		"1": "2026-05-13T10:00:00Z",
-		"2": "2026-05-13T10:05:00Z",
-	}, merged.Runtimes)
+	assert.Equal(t, "2026-05-13T10:05:00Z", merged.Timestamp)
+	assert.Equal(t, []HistoryEntry{
+		{Tag: "1", Timestamp: "2026-05-13T10:00:00Z"},
+	}, merged.History)
 	assert.Len(t, merged.Data, 2)
 	assert.Equal(t, "1", merged.Data[0].Name)
 	assert.Equal(t, "2", merged.Data[1].Name)
 }
 
 func TestMergeBenchmarks_MixedGroup(t *testing.T) {
-	bench1 := makeBench("1", "My benchmark", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{
+	bench1 := makeBench("1", "My benchmark", "2026-05-13T10:00:00Z", []BenchmarkData{
 		{Name: "", XAxis: "speed", YAxis: "1e4"},
 	})
-	bench2 := makeBench("2", "My benchmark", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{
+	bench2 := makeBench("2", "My benchmark", "2026-05-13T10:05:00Z", []BenchmarkData{
 		{Name: "", XAxis: "speed", YAxis: "1e4"},
 	})
 	noTagBench := Benchmark{
@@ -60,6 +60,7 @@ func TestMergeBenchmarks_MixedGroup(t *testing.T) {
 	assert.Equal(t, "1", merged.Data[1].Name)
 	assert.Equal(t, "2", merged.Data[2].Name)
 	assert.Equal(t, "2", merged.Tag)
+	assert.Equal(t, "2026-05-13T10:05:00Z", merged.Timestamp)
 }
 
 func TestMergeBenchmarks_AllNoTag(t *testing.T) {
@@ -72,8 +73,8 @@ func TestMergeBenchmarks_AllNoTag(t *testing.T) {
 }
 
 func TestMergeBenchmarks_TimestampTie(t *testing.T) {
-	bench1 := makeBench("1", "Test", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "a"}})
-	bench2 := makeBench("2", "Test", map[string]string{"2": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "b"}})
+	bench1 := makeBench("1", "Test", "2026-05-13T10:00:00Z", []BenchmarkData{{Name: "a"}})
+	bench2 := makeBench("2", "Test", "2026-05-13T10:00:00Z", []BenchmarkData{{Name: "b"}})
 
 	result := MergeBenchmarks([]Benchmark{bench1, bench2}, DimensionName)
 	assert.Len(t, result, 1)
@@ -83,17 +84,19 @@ func TestMergeBenchmarks_TimestampTie(t *testing.T) {
 }
 
 func TestMergeBenchmarks_SingleBenchmark(t *testing.T) {
-	bench := makeBench("1", "Solo", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "x"}})
+	bench := makeBench("1", "Solo", "2026-05-13T10:00:00Z", []BenchmarkData{{Name: "x"}})
 	result := MergeBenchmarks([]Benchmark{bench}, DimensionName)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "Solo", result[0].Name)
+	assert.Equal(t, "2026-05-13T10:00:00Z", result[0].Timestamp)
+	assert.Nil(t, result[0].History)
 }
 
 func TestMergeBenchmarks_PopulatedName(t *testing.T) {
-	bench1 := makeBench("1", "digits", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{
+	bench1 := makeBench("1", "digits", "2026-05-13T10:00:00Z", []BenchmarkData{
 		{Name: "digits", XAxis: "speed", YAxis: "1e4"},
 	})
-	bench2 := makeBench("2", "digits", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{
+	bench2 := makeBench("2", "digits", "2026-05-13T10:05:00Z", []BenchmarkData{
 		{Name: "digits", XAxis: "speed", YAxis: "1e4"},
 	})
 
@@ -104,10 +107,10 @@ func TestMergeBenchmarks_PopulatedName(t *testing.T) {
 }
 
 func TestMergeBenchmarks_InjectDimensionX(t *testing.T) {
-	bench1 := makeBench("1", "Test", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{
+	bench1 := makeBench("1", "Test", "2026-05-13T10:00:00Z", []BenchmarkData{
 		{XAxis: "", YAxis: "100"},
 	})
-	bench2 := makeBench("2", "Test", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{
+	bench2 := makeBench("2", "Test", "2026-05-13T10:05:00Z", []BenchmarkData{
 		{XAxis: "", YAxis: "200"},
 	})
 
@@ -119,10 +122,10 @@ func TestMergeBenchmarks_InjectDimensionX(t *testing.T) {
 }
 
 func TestMergeBenchmarks_InjectDimensionY(t *testing.T) {
-	bench1 := makeBench("1", "Test", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{
+	bench1 := makeBench("1", "Test", "2026-05-13T10:00:00Z", []BenchmarkData{
 		{XAxis: "x", YAxis: ""},
 	})
-	bench2 := makeBench("2", "Test", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{
+	bench2 := makeBench("2", "Test", "2026-05-13T10:05:00Z", []BenchmarkData{
 		{XAxis: "x", YAxis: ""},
 	})
 
@@ -132,21 +135,26 @@ func TestMergeBenchmarks_InjectDimensionY(t *testing.T) {
 	assert.Equal(t, "2", result[0].Data[1].YAxis)
 }
 
-func TestMergeBenchmarks_RuntimeMerge(t *testing.T) {
-	bench1 := makeBench("1", "Test", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "a"}})
-	bench2 := makeBench("2", "Test", map[string]string{"2": "2026-05-13T10:05:00Z", "extra": "2026-05-13T11:00:00Z"}, []BenchmarkData{{Name: "b"}})
+func TestMergeBenchmarks_HistoryMerge(t *testing.T) {
+	bench1 := makeBench("1", "Test", "2026-05-13T10:00:00Z", []BenchmarkData{{Name: "a"}})
+	bench2 := makeBench("2", "Test", "2026-05-13T10:05:00Z", []BenchmarkData{{Name: "b"}})
+	bench2.History = []HistoryEntry{
+		{Tag: "extra", Timestamp: "2026-05-13T11:00:00Z"},
+	}
 
 	result := MergeBenchmarks([]Benchmark{bench1, bench2}, DimensionName)
 	assert.Len(t, result, 1)
-	assert.Len(t, result[0].Runtimes, 3)
-	assert.Equal(t, "2026-05-13T10:00:00Z", result[0].Runtimes["1"])
-	assert.Equal(t, "2026-05-13T10:05:00Z", result[0].Runtimes["2"])
-	assert.Equal(t, "2026-05-13T11:00:00Z", result[0].Runtimes["extra"])
+	assert.Equal(t, "2", result[0].Tag)
+	assert.Equal(t, "2026-05-13T10:05:00Z", result[0].Timestamp)
+	assert.Equal(t, []HistoryEntry{
+		{Tag: "1", Timestamp: "2026-05-13T10:00:00Z"},
+		{Tag: "extra", Timestamp: "2026-05-13T11:00:00Z"},
+	}, result[0].History)
 }
 
 func TestMergeBenchmarks_DifferentNames(t *testing.T) {
-	bench1 := makeBench("1", "Bench A", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "a"}})
-	bench2 := makeBench("2", "Bench B", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{{Name: "b"}})
+	bench1 := makeBench("1", "Bench A", "2026-05-13T10:00:00Z", []BenchmarkData{{Name: "a"}})
+	bench2 := makeBench("2", "Bench B", "2026-05-13T10:05:00Z", []BenchmarkData{{Name: "b"}})
 
 	result := MergeBenchmarks([]Benchmark{bench1, bench2}, DimensionName)
 	assert.Len(t, result, 2)
@@ -158,8 +166,8 @@ func TestMergeBenchmarks_EmptyInput(t *testing.T) {
 }
 
 func TestMergeBenchmarks_NoMutation(t *testing.T) {
-	bench1 := makeBench("1", "Test", map[string]string{"1": "2026-05-13T10:00:00Z"}, []BenchmarkData{{Name: "a"}})
-	bench2 := makeBench("2", "Test", map[string]string{"2": "2026-05-13T10:05:00Z"}, []BenchmarkData{{Name: "b"}})
+	bench1 := makeBench("1", "Test", "2026-05-13T10:00:00Z", []BenchmarkData{{Name: "a"}})
+	bench2 := makeBench("2", "Test", "2026-05-13T10:05:00Z", []BenchmarkData{{Name: "b"}})
 
 	original := []Benchmark{bench1, bench2}
 	result := MergeBenchmarks(original, DimensionName)
@@ -170,9 +178,9 @@ func TestMergeBenchmarks_NoMutation(t *testing.T) {
 }
 
 func TestMergeBenchmarks_SameNameSameTagDedup(t *testing.T) {
-	bench1 := makeBench("v1", "Bench", map[string]string{"run1": "2026-05-13T10:00:00Z"},
+	bench1 := makeBench("v1", "Bench", "2026-05-13T10:00:00Z",
 		[]BenchmarkData{{Name: "", XAxis: "speed", YAxis: "1e4"}})
-	bench2 := makeBench("v1", "Bench", map[string]string{"run2": "2026-05-14T10:00:00Z"},
+	bench2 := makeBench("v1", "Bench", "2026-05-14T10:00:00Z",
 		[]BenchmarkData{{Name: "", XAxis: "speed", YAxis: "1e4"}})
 
 	result := MergeBenchmarks([]Benchmark{bench1, bench2}, DimensionName)
@@ -180,9 +188,8 @@ func TestMergeBenchmarks_SameNameSameTagDedup(t *testing.T) {
 	assert.Len(t, result[0].Data, 1)
 	assert.Equal(t, "v1", result[0].Data[0].Name)
 	assert.Equal(t, "v1", result[0].Tag)
-	assert.Equal(t, map[string]string{
-		"run2": "2026-05-14T10:00:00Z",
-	}, result[0].Runtimes)
+	assert.Equal(t, "2026-05-14T10:00:00Z", result[0].Timestamp)
+	assert.Nil(t, result[0].History)
 }
 
 func TestMergeBenchmarks_SameNameNoTagDedup(t *testing.T) {
@@ -195,18 +202,23 @@ func TestMergeBenchmarks_SameNameNoTagDedup(t *testing.T) {
 }
 
 func TestMergeBenchmarks_TagOrderChronological(t *testing.T) {
-	bench1 := makeBench("v1", "Bench", map[string]string{"1": "2026-05-13T10:00:00Z"},
+	bench1 := makeBench("v1", "Bench", "2026-05-13T10:00:00Z",
 		[]BenchmarkData{{Name: "", XAxis: "speed", YAxis: "1e4"}})
-	bench2 := makeBench("v2", "Bench", map[string]string{"2": "2026-05-14T10:00:00Z"},
+	bench2 := makeBench("v2", "Bench", "2026-05-14T10:00:00Z",
 		[]BenchmarkData{{Name: "", XAxis: "speed", YAxis: "1e4"}})
-	bench3 := makeBench("v3", "Bench", map[string]string{"3": "2026-05-12T10:00:00Z"},
+	bench3 := makeBench("v3", "Bench", "2026-05-12T10:00:00Z",
 		[]BenchmarkData{{Name: "", XAxis: "speed", YAxis: "1e4"}})
 
 	result := MergeBenchmarks([]Benchmark{bench1, bench2, bench3}, DimensionName)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "v2", result[0].Tag)
+	assert.Equal(t, "2026-05-14T10:00:00Z", result[0].Timestamp)
 	assert.Len(t, result[0].Data, 3)
 	assert.Equal(t, "v3", result[0].Data[0].Name)
 	assert.Equal(t, "v1", result[0].Data[1].Name)
 	assert.Equal(t, "v2", result[0].Data[2].Name)
+	assert.Equal(t, []HistoryEntry{
+		{Tag: "v3", Timestamp: "2026-05-12T10:00:00Z"},
+		{Tag: "v1", Timestamp: "2026-05-13T10:00:00Z"},
+	}, result[0].History)
 }


### PR DESCRIPTION
## Summary

- Replace `Runtimes map[string]string` with direct `Timestamp` field on `Benchmark` and `History []HistoryEntry` for tracking older tag+timestamp pairs
- Remove `benchGroup` struct and `taggedEntry` wrapper — use `map[string]map[string]*Benchmark` for simpler tag dedup and insertion
- Remove `latestRuntime` and `mergeRuntimes` helpers (no longer needed)
- Update CHANGELOG for v0.9.5, fix README references to old `runtimes` terminology

## Test plan

- [x] `task test` passes all existing and new merge tests
- [x] No mutation tests verify input benchmarks remain unchanged after merge
- [x] History merge, chronological ordering, and dedup edge cases covered