### PR TITLE
chore(action): improve docs, branding, and version visibility

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -137,8 +137,9 @@ runs:
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
     - name: Show vizb version
+      if: steps.version.outputs.is-latest == 'true'
       shell: bash
-      run: echo "::notice::vizb $(vizb -v 2>&1)"
+      run: echo "::notice::$(vizb -v 2>&1)"
 
     # ── Resolve input source ───────────────────────────────────
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,8 @@
 name: vizb
 description: Run Go benchmarks and generate interactive HTML visualizations with vizb
+branding:
+  icon: "bar-chart-2"
+  color: "blue"
 
 inputs:
   bench:

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: Run Go benchmarks and generate interactive HTML visualizations with
 
 inputs:
   bench:
-    description: "Benchmark command to run (e.g., go test -bench=.)"
+    description: "Benchmark command to run (e.g., go test -bench=.). Requires Go toolchain — add actions/setup-go before this action."
     default: ""
   bench-file:
     description: "Path to existing benchmark output file (takes priority over bench)"
@@ -135,6 +135,10 @@ runs:
         fi
 
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+    - name: Show vizb version
+      shell: bash
+      run: echo "::notice::vizb $(vizb -v 2>&1)"
 
     # ── Resolve input source ───────────────────────────────────
 


### PR DESCRIPTION
### Changes

- **`bench` input description** — Now warns that Go toolchain is required (`actions/setup-go` before this action)
- **Show vizb version via `::notice::`** — Displays the resolved vizb version when using `@latest` or no pinned version. Skipped when a specific version is pinned (user already knows)
- **Marketplace branding** — Added `icon: bar-chart-2` and `color: blue` for Marketplace listing card