### PR TITLE
fix(shared): MustCreateFile creates parent directories

### DIFF
--- a/shared/os.go
+++ b/shared/os.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 var OsExit = os.Exit
@@ -21,6 +22,10 @@ func MustCreateTempFile(prefix, extension string) string {
 }
 
 func MustCreateFile(filePath string) *os.File {
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		ExitWithError("Error creating parent directories", err)
+	}
+
 	f, err := os.Create(filePath)
 	if err != nil {
 		ExitWithError("Error creating file", err)


### PR DESCRIPTION
### Problem
`MustCreateFile` uses `os.Create` which fails if parent directories don't exist (e.g., `pages/index.html` when `pages/` is missing).

### Fix
Add `os.MkdirAll(filepath.Dir(filePath), 0o755)` before `os.Create`. All existing tests pass — the "Nested directory" test had a manual `os.MkdirAll` that's now redundant but harmless.

### Impact
- `vizb bench.txt -o outdir/bench.json` → works without pre-existing `outdir/`
- `vizb merge bench.json -o pages/index.html` → works without `mkdir -p pages`
- No more `mkdir` steps needed in workflows/actions before vizb calls