### PR TITLE
feat: vizb html subcommand, merge JSON-only, action improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ Notable changes to Vizb documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.10.0] - 2026-05-18
+
+### Added
+
+- **GitHub Action** (`action.yml`): Composite action for running vizb in CI
+  - Auto-downloads vizb binary via curl with multi-OS support (linux, macos, windows)
+  - Binary caching for pinned versions
+  - Inputs: `bench-cmd`, `bench-file`, `tag`, `name`, `merge-files`, `merge-dir`, `tag-axis`, etc.
+  - Outputs: `output-file-html`, `output-file-json`
+  - Branding for GitHub Marketplace
+- **`vizb html` subcommand**: Render benchmark JSON to interactive HTML
+  - `vizb html <file.json> -o <output.html>`
+  - Pure render — no merge or tag injection
+  - Accepts single JSON object or array
+
+### Changed
+
+- **`vizb merge` JSON-only**: Merge command no longer generates HTML — outputs JSON only. Use `vizb html` for HTML rendering after merge.
+- **Input priority**: File argument now takes precedence over piped stdin, matching standard Unix convention (`grep`, `cat`, `jq`). Heredocs in CI no longer need `< /dev/null` workaround.
+- **`MustCreateFile`**: Auto-creates parent directories for output file paths.
+
 # [0.9.5] - 2026-05-16
 
 ### Changed

--- a/action.yml
+++ b/action.yml
@@ -5,11 +5,11 @@ branding:
   color: 'blue'
 
 inputs:
-  bench:
+  bench-cmd:
     description: "Benchmark command to run (e.g., go test -bench=.). Requires Go toolchain — add actions/setup-go before this action."
     default: ""
   bench-file:
-    description: "Path to existing benchmark output file (takes priority over bench)"
+    description: "Path to existing benchmark output file (takes priority over bench-cmd)"
     default: ""
   name:
     description: "Benchmark name (-n flag)"
@@ -81,6 +81,12 @@ runs:
       shell: bash
       run: |
         REF="${{ github.action_ref }}"
+        if [ -z "$REF" ] || [ "$REF" = "latest" ]; then
+          PATH_REF=$(basename "${{ github.action_path }}")
+          if echo "$PATH_REF" | grep -qE '^v[0-9]'; then
+            REF="$PATH_REF"
+          fi
+        fi
         if [ -z "$REF" ]; then
           REF="latest"
         fi
@@ -151,7 +157,7 @@ runs:
       shell: bash
       run: |
         BENCH_FILE="${{ inputs.bench-file }}"
-        BENCH_CMD="${{ inputs.bench }}"
+        BENCH_CMD="${{ inputs.bench-cmd }}"
         HAS_MERGE=""
         [ -n "${{ inputs.merge-files }}" ] && HAS_MERGE="true"
         [ -n "${{ inputs.merge-dir }}" ] && HAS_MERGE="true"
@@ -166,7 +172,7 @@ runs:
           echo "source=merge-only" >> "$GITHUB_OUTPUT"
           echo "has_input=false" >> "$GITHUB_OUTPUT"
         else
-          echo "::error::No input provided. Specify bench, bench-file, merge-files, or merge-dir."
+          echo "::error::No input provided. Specify bench-cmd, bench-file, merge-files, or merge-dir."
           exit 1
         fi
 
@@ -196,7 +202,7 @@ runs:
         if [ "${{ steps.resolve.outputs.source }}" = "file" ]; then
           cp "${{ inputs.bench-file }}" bench-input.txt
         else
-          ${{ inputs.bench }} > bench-input.txt
+          ${{ inputs.bench-cmd }} > bench-input.txt
         fi
 
         vizb bench-input.txt -o bench-new.json "${VIZB_ARGS[@]}"
@@ -233,7 +239,7 @@ runs:
         JSON_OUT=""
 
         if [ -n "${{ inputs.output-html }}" ]; then
-          vizb merge bench.json -o "${{ inputs.output-html }}"
+          vizb html bench.json -o "${{ inputs.output-html }}"
           HTML_OUT="${{ inputs.output-html }}"
         fi
 

--- a/cmd/html.go
+++ b/cmd/html.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/goptics/vizb/pkg/style"
+	"github.com/goptics/vizb/pkg/template"
+	"github.com/goptics/vizb/shared"
+	"github.com/spf13/cobra"
+)
+
+var htmlCmd = &cobra.Command{
+	Use:   "html [file]",
+	Short: "Generate HTML visualization from a benchmark JSON file",
+	Long: `Generate an interactive HTML chart from a benchmark JSON file.
+The input file must be a valid vizb benchmark JSON (single object or array).`,
+	Args: cobra.ExactArgs(1),
+	Run:  runHTML,
+}
+
+func init() {
+	rootCmd.AddCommand(htmlCmd)
+}
+
+func runHTML(cmd *cobra.Command, args []string) {
+	benches, err := parseBenchmarkFile(args[0])
+	if err != nil {
+		shared.ExitWithError("Failed to parse benchmark file: %v", err)
+	}
+
+	if len(benches) == 0 {
+		shared.ExitWithError("No benchmark data found in file", nil)
+	}
+
+	jsonData, err := json.Marshal(benches)
+	if err != nil {
+		shared.ExitWithError("Failed to marshal benchmark data: %v", err)
+	}
+
+	outFile := shared.FlagState.OutputFile
+	if outFile == "" {
+		outFile = resolveOutputFileName(outFile)
+	}
+
+	f := shared.MustCreateFile(outFile)
+	defer f.Close()
+	defer HandleOutputResult(f)
+
+	htmlContent := template.GenerateHTMLBenchmarkUI(jsonData, template.VizbHTMLTemplate)
+	if _, err := f.WriteString(htmlContent); err != nil {
+		shared.ExitWithError("Failed to write output file: %v", err)
+	}
+	fmt.Println(style.Success.Render(fmt.Sprintf("🎉 Generated HTML chart successfully: %s", outFile)))
+}

--- a/cmd/html_test.go
+++ b/cmd/html_test.go
@@ -1,0 +1,224 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goptics/vizb/shared"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHtmlCmd_SingleObject(t *testing.T) {
+	oldOsExit := shared.OsExit
+	defer func() { shared.OsExit = oldOsExit }()
+
+	var exitCode int
+	shared.OsExit = func(code int) { exitCode = code }
+
+	tmpDir, err := os.MkdirTemp("", "vizb-html-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	bench := shared.Benchmark{
+		Name: "Bench1",
+		Data: []shared.BenchmarkData{
+			{Name: "Test1", XAxis: "1", YAxis: "100"},
+		},
+	}
+	inputFile := filepath.Join(tmpDir, "bench.json")
+	writeJSON(t, inputFile, bench)
+
+	outFile := filepath.Join(tmpDir, "output.html")
+	shared.FlagState.OutputFile = outFile
+
+	rootCmd.SetArgs([]string{"html", inputFile})
+	err = rootCmd.Execute()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+
+	content, err := os.ReadFile(outFile)
+	assert.NoError(t, err)
+
+	htmlStr := string(content)
+	assert.Contains(t, htmlStr, "Bench1")
+	assert.Contains(t, htmlStr, "Test1")
+	assert.Contains(t, htmlStr, "<html")
+	assert.Contains(t, htmlStr, "</html>")
+}
+
+func TestHtmlCmd_ArrayInput(t *testing.T) {
+	oldOsExit := shared.OsExit
+	defer func() { shared.OsExit = oldOsExit }()
+
+	var exitCode int
+	shared.OsExit = func(code int) { exitCode = code }
+
+	tmpDir, err := os.MkdirTemp("", "vizb-html-array-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	benches := []shared.Benchmark{
+		{Name: "Bench1", Data: []shared.BenchmarkData{{Name: "Test1", XAxis: "1", YAxis: "100"}}},
+		{Name: "Bench2", Data: []shared.BenchmarkData{{Name: "Test2", XAxis: "2", YAxis: "200"}}},
+	}
+	inputFile := filepath.Join(tmpDir, "benches.json")
+	writeJSON(t, inputFile, benches)
+
+	outFile := filepath.Join(tmpDir, "output.html")
+	shared.FlagState.OutputFile = outFile
+
+	rootCmd.SetArgs([]string{"html", inputFile})
+	err = rootCmd.Execute()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+
+	content, err := os.ReadFile(outFile)
+	assert.NoError(t, err)
+
+	htmlStr := string(content)
+	assert.Contains(t, htmlStr, "Bench1")
+	assert.Contains(t, htmlStr, "Bench2")
+	assert.Contains(t, htmlStr, "Test1")
+	assert.Contains(t, htmlStr, "Test2")
+}
+
+func TestHtmlCmd_MissingFile(t *testing.T) {
+	oldOsExit := shared.OsExit
+	defer func() { shared.OsExit = oldOsExit }()
+
+	exitCode := 0
+	shared.OsExit = func(code int) { exitCode = code }
+
+	rootCmd.SetArgs([]string{"html", "/nonexistent/path.json"})
+	rootCmd.Execute()
+	assert.Equal(t, 1, exitCode)
+}
+
+func TestHtmlCmd_NoArgs(t *testing.T) {
+	rootCmd.SetArgs([]string{"html"})
+	err := rootCmd.Execute()
+	assert.Error(t, err)
+}
+
+func TestHtmlCmd_InvalidJSON(t *testing.T) {
+	oldOsExit := shared.OsExit
+	defer func() { shared.OsExit = oldOsExit }()
+
+	exitCode := 0
+	shared.OsExit = func(code int) { exitCode = code }
+
+	tmpDir, err := os.MkdirTemp("", "vizb-html-invalid-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	inputFile := filepath.Join(tmpDir, "invalid.json")
+	os.WriteFile(inputFile, []byte("not json"), 0644)
+
+	rootCmd.SetArgs([]string{"html", inputFile})
+	rootCmd.Execute()
+	assert.Equal(t, 1, exitCode)
+}
+
+func TestHtmlCmd_StdoutFallback(t *testing.T) {
+	oldOsExit := shared.OsExit
+	defer func() { shared.OsExit = oldOsExit }()
+
+	var exitCode int
+	shared.OsExit = func(code int) { exitCode = code }
+
+	tmpDir, err := os.MkdirTemp("", "vizb-html-stdout-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	bench := shared.Benchmark{
+		Name: "Bench1",
+		Data: []shared.BenchmarkData{
+			{Name: "Test1", XAxis: "1", YAxis: "100"},
+		},
+	}
+	inputFile := filepath.Join(tmpDir, "bench.json")
+	writeJSON(t, inputFile, bench)
+
+	shared.FlagState.OutputFile = ""
+
+	rootCmd.SetArgs([]string{"html", inputFile})
+	err = rootCmd.Execute()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+}
+
+func TestHtmlCmd_EmptyFile(t *testing.T) {
+	oldOsExit := shared.OsExit
+	defer func() { shared.OsExit = oldOsExit }()
+
+	exitCode := 0
+	shared.OsExit = func(code int) { exitCode = code }
+
+	tmpDir, err := os.MkdirTemp("", "vizb-html-empty-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	inputFile := filepath.Join(tmpDir, "empty.json")
+	os.WriteFile(inputFile, []byte(""), 0644)
+
+	rootCmd.SetArgs([]string{"html", inputFile})
+	rootCmd.Execute()
+	assert.Equal(t, 1, exitCode)
+}
+
+func TestHtmlCmd_MergedOutput(t *testing.T) {
+	oldOsExit := shared.OsExit
+	defer func() { shared.OsExit = oldOsExit }()
+
+	var exitCode int
+	shared.OsExit = func(code int) { exitCode = code }
+
+	tmpDir, err := os.MkdirTemp("", "vizb-html-merged-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	benches := []shared.Benchmark{
+		{
+			Tag:       "v1.0.0",
+			Timestamp: "2024-01-01T00:00:00Z",
+			Name:      "Sort Benchmarks",
+			History: []shared.HistoryEntry{
+				{Tag: "v0.9.0", Timestamp: "2023-12-01T00:00:00Z"},
+			},
+			Data: []shared.BenchmarkData{
+				{Name: "v1.0.0", XAxis: "v0.9.0", YAxis: "100"},
+			},
+		},
+	}
+	inputFile := filepath.Join(tmpDir, "merged.json")
+	writeJSON(t, inputFile, benches)
+
+	outFile := filepath.Join(tmpDir, "chart.html")
+	shared.FlagState.OutputFile = outFile
+
+	rootCmd.SetArgs([]string{"html", inputFile})
+	err = rootCmd.Execute()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+
+	content, err := os.ReadFile(outFile)
+	assert.NoError(t, err)
+
+	htmlStr := string(content)
+	assert.Contains(t, htmlStr, "v1.0.0")
+	assert.Contains(t, htmlStr, "v0.9.0")
+	assert.Contains(t, htmlStr, "Sort Benchmarks")
+}

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/goptics/vizb/pkg/style"
-	"github.com/goptics/vizb/pkg/template"
 	"github.com/goptics/vizb/shared"
 	"github.com/spf13/cobra"
 )
@@ -121,26 +119,20 @@ func writeMergeOutput(benches []shared.Benchmark) {
 
 	outFile := shared.FlagState.OutputFile
 	if outFile == "" {
-		outFile = resolveOutputFileName(outFile)
+		outFile = shared.MustCreateTempFile(shared.TempBenchFilePrefix, "json")
+		shared.TempFiles.Store(outFile)
+	} else if filepath.Ext(outFile) == "" {
+		outFile += ".json"
 	}
 
 	f := shared.MustCreateFile(outFile)
 	defer f.Close()
 	defer HandleOutputResult(f)
 
-	switch strings.ToLower(filepath.Ext(outFile)) {
-	case ".json":
-		if _, err := f.Write(jsonData); err != nil {
-			shared.ExitWithError("Failed to write JSON output: %v", err)
-		}
-		fmt.Println(style.Success.Render(fmt.Sprintf("🎉 Generated merged JSON successfully: %s", outFile)))
-	default:
-		htmlContent := template.GenerateHTMLBenchmarkUI(jsonData, template.VizbHTMLTemplate)
-		if _, err := f.WriteString(htmlContent); err != nil {
-			shared.ExitWithError("Failed to write output file: %v", err)
-		}
-		fmt.Println(style.Success.Render(fmt.Sprintf("🎉 Generated merged chart successfully: %s", outFile)))
+	if _, err := f.Write(jsonData); err != nil {
+		shared.ExitWithError("Failed to write JSON output: %v", err)
 	}
+	fmt.Println(style.Success.Render(fmt.Sprintf("🎉 Generated merged JSON successfully: %s", outFile)))
 }
 
 func logWarn(format string, args ...interface{}) {

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -52,7 +52,7 @@ func TestMergeCmd(t *testing.T) {
 	os.WriteFile(file3, []byte("{invalid json"), 0644)
 
 	// Output file
-	outFile := filepath.Join(tmpDir, "merged.html")
+	outFile := filepath.Join(tmpDir, "merged.json")
 
 	// Reset FlagState
 	shared.FlagState.OutputFile = outFile
@@ -72,10 +72,19 @@ func TestMergeCmd(t *testing.T) {
 	_, err = os.Stat(outFile)
 	assert.NoError(t, err)
 
-	content, _ := os.ReadFile(outFile)
-	htmlStr := string(content)
-	assert.Contains(t, htmlStr, "Test1")
-	assert.Contains(t, htmlStr, "Test2")
+	content, err := os.ReadFile(outFile)
+	assert.NoError(t, err)
+
+	var parsed []shared.Benchmark
+	assert.NoError(t, json.Unmarshal(content, &parsed))
+	assert.Len(t, parsed, 2)
+
+	names := make(map[string]bool)
+	for _, b := range parsed {
+		names[b.Name] = true
+	}
+	assert.True(t, names["Bench1"])
+	assert.True(t, names["Bench2"])
 }
 
 func TestMergeCmd_Directory(t *testing.T) {
@@ -100,7 +109,7 @@ func TestMergeCmd_Directory(t *testing.T) {
 	}
 	writeJSON(t, filepath.Join(tmpDir, "b1.json"), bench1)
 
-	outFile := filepath.Join(tmpDir, "merged_dir.html")
+	outFile := filepath.Join(tmpDir, "merged_dir.json")
 
 	// Reset FlagState
 	shared.FlagState.OutputFile = outFile
@@ -115,8 +124,13 @@ func TestMergeCmd_Directory(t *testing.T) {
 	}
 	assert.NoError(t, err)
 
-	content, _ := os.ReadFile(outFile)
-	assert.Contains(t, string(content), "Test1")
+	content, err := os.ReadFile(outFile)
+	assert.NoError(t, err)
+
+	var parsed []shared.Benchmark
+	assert.NoError(t, json.Unmarshal(content, &parsed))
+	assert.Len(t, parsed, 1)
+	assert.Equal(t, "Bench1", parsed[0].Name)
 }
 
 func TestMergeCmd_ArrayInput(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add CHANGELOG entry for v0.10.0
- New `vizb html` subcommand — renders JSON to HTML with no merge/tag injection
- `vizb merge` now outputs JSON only
- Action: `bench` renamed to `bench-cmd`, HTML generation uses `vizb html`
- Action: resolves version from `action_path` when `action_ref` is empty
- All tests pass