### PR TITLE
feat: support @v0 major version tag, simplify resolve logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*.*.*'
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Vizb provides a composite GitHub Action to run benchmarks and generate visualiza
   with:
     go-version-file: go.mod
 
-- uses: goptics/vizb@latest
+- uses: goptics/vizb@v0
   with:
     bench-cmd: "go test -bench=."
     output-html: pages/index.html
@@ -77,7 +77,7 @@ jobs:
           name: merged.json
           path: prev
 
-      - uses: goptics/vizb@latest
+      - uses: goptics/vizb@v0
         with:
           bench-cmd: "go test -bench=."
           tag: ${{ github.ref_name }}

--- a/action.yml
+++ b/action.yml
@@ -81,32 +81,25 @@ runs:
       shell: bash
       run: |
         REF="${{ github.action_ref }}"
-        if [ -z "$REF" ] || [ "$REF" = "latest" ]; then
-          PATH_REF=$(basename "${{ github.action_path }}")
-          if echo "$PATH_REF" | grep -qE '^v[0-9]'; then
-            REF="$PATH_REF"
-          fi
-        fi
         if [ -z "$REF" ]; then
-          REF="latest"
+          echo "::error::Pin to a version: @v0 for latest, @v0.10.1 for pinned."
+          exit 1
         fi
 
-        if [ "$REF" = "latest" ]; then
-          TAG=$(curl -sL -o /dev/null -w '%{url_effective}' \
-            https://github.com/goptics/vizb/releases/latest | sed 's|.*/tag/||')
-          if [ -z "$TAG" ] || [ "$TAG" = "latest" ]; then
-            echo "::error::No releases found. Pin to a specific version tag."
-            exit 1
-          fi
+        if echo "$REF" | grep -qE '^v[0-9]+$'; then
+          PREFIX="${REF#v}"
+          TAG=$(git ls-remote --tags --refs --sort='-version:refname' \
+            https://github.com/goptics/vizb "refs/tags/v${PREFIX}.*" | \
+            head -1 | sed 's|.*/||')
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "is-latest=true" >> "$GITHUB_OUTPUT"
+          echo "is-major=true" >> "$GITHUB_OUTPUT"
         else
           echo "tag=$REF" >> "$GITHUB_OUTPUT"
-          echo "is-latest=false" >> "$GITHUB_OUTPUT"
+          echo "is-major=false" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Cache vizb binary
-      if: steps.version.outputs.is-latest != 'true'
+      if: steps.version.outputs.is-major != 'true'
       id: cache-vizb
       uses: actions/cache@v5
       with:
@@ -146,7 +139,7 @@ runs:
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
     - name: Show vizb version
-      if: steps.version.outputs.is-latest == 'true'
+      if: steps.version.outputs.is-major == 'true'
       shell: bash
       run: echo "::notice::$(vizb -v 2>&1)"
 


### PR DESCRIPTION
## What

Drops `@latest` in favor of `@v0` (lightweight tag) as the recommended "latest" pin. Major version resolution uses `git ls-remote` instead of curl.

## Changes

### `action.yml` (3 edits)
- **Resolve step**: Replaced 27-line PATH_REF/curl logic with 14-line major version resolution using `git ls-remote`. `@v0` → latest `v0.*` tag. `@v0.10.1` → exact.
- **Cache condition**: `is-latest` → `is-major` (major tags skip cache, exact tags use cache)
- **Show version condition**: `is-latest` → `is-major`

### `release.yml` (1 edit)
- Tag trigger: `v*` → `v*.*.*` — lightweight tags like `v0`, `v1` no longer trigger goreleaser. Only full semver (`v0.10.1`, `v1.0.0`) build binaries.

### `README.md` (1 edit)
- `@latest` → `@v0` in usage examples

## How it works

| User pins | CI editor | goreleaser? | Downloads | Cache? |
|-----------|-----------|-------------|-----------|--------|
| `@v0` | Valid (lightweight tag) | No | Latest v0.* via git ls-remote | No |
| `@v0.10.1` | Valid (release tag) | Yes | Exact tag | Yes |

## After merge

```bash
git tag v0 v0.10.1
git push origin v0
```