### PR TITLE
fix: use json_file variable, drop Generate JSON step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,6 @@
 name: Vizb Action
 description: Run Go benchmarks and generate interactive HTML visualizations with vizb
+author: fahimfaisaal
 branding:
   icon: 'bar-chart-2'
   color: 'blue'
@@ -71,7 +72,7 @@ outputs:
     value: ${{ steps.generate-html.outputs.html }}
   output-file-json:
     description: Path to JSON output file
-    value: ${{ steps.generate-json.outputs.json }}
+    value: ${{ inputs.output-json }}
 
 runs:
   using: composite
@@ -176,6 +177,13 @@ runs:
           exit 1
         fi
 
+        OUT_JSON="${{ inputs.output-json }}"
+        if [ -n "$OUT_JSON" ]; then
+          echo "json_file=$OUT_JSON" >> "$GITHUB_OUTPUT"
+        else
+          echo "json_file=bench.json" >> "$GITHUB_OUTPUT"
+        fi
+
     # ── Convert to JSON ────────────────────────────────────────
 
     - name: Convert to JSON
@@ -205,7 +213,7 @@ runs:
           ${{ inputs.bench-cmd }} > bench-input.txt
         fi
 
-        vizb bench-input.txt -o bench.json "${VIZB_ARGS[@]}"
+        vizb bench-input.txt -o "${{ steps.resolve.outputs.json_file }}" "${VIZB_ARGS[@]}"
 
     # ── Merge ──────────────────────────────────────────────────
 
@@ -214,27 +222,19 @@ runs:
       id: merge
       shell: bash
       run: |
+        JSON_FILE="${{ steps.resolve.outputs.json_file }}"
         FILES=()
-        [ -f bench.json ] && FILES+=("bench.json")
+        [ -f "$JSON_FILE" ] && FILES+=("$JSON_FILE")
         [ -n "${{ inputs.merge-files }}" ] && FILES+=(${{ inputs.merge-files }})
         [ -n "${{ inputs.merge-dir }}" ] && FILES+=("${{ inputs.merge-dir }}")
-        vizb merge "${FILES[@]}" -o bench.json --tag-axis "${{ inputs.tag-axis }}"
+        vizb merge "${FILES[@]}" -o "$JSON_FILE" --tag-axis "${{ inputs.tag-axis }}"
 
-    # ── Generate output ────────────────────────────────────────
+    # ── Generate html  ────────────────────────────────────────
 
     - name: Generate HTML
       id: generate-html
       if: inputs.output-html != ''
       shell: bash
       run: |
-        vizb html bench.json -o "${{ inputs.output-html }}"
+        vizb html "${{ steps.resolve.outputs.json_file }}" -o "${{ inputs.output-html }}"
         echo "html=${{ inputs.output-html }}" >> "$GITHUB_OUTPUT"
-
-    - name: Generate JSON
-      id: generate-json
-      if: inputs.output-json != ''
-      shell: bash
-      run: |
-        mkdir -p "$(dirname "${{ inputs.output-json }}")"
-        cp bench.json "${{ inputs.output-json }}"
-        echo "json=${{ inputs.output-json }}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

Single `json_file` variable from the Resolve step replaces hardcoded `bench.json` throughout all steps. Wire `output-file-json` output directly to `${{ inputs.output-json }}` (no dummy Generate JSON step).

## Routes

- **`fix/json-file`** — use json_file variable, drop Generate JSON step
- **`fix/major-version`** (#89) — support @v0 major version tag

## Changes

### `action.yml`

- **Resolve step**: Compute `json_file` — `output-json` if set, else `bench.json`
- **All steps** (Convert, Merge, Generate HTML): Use `$json_file` instead of hardcoded `bench.json`
- **Drop Generate JSON step** (Option B): `output-file-json` wired directly to `${{ inputs.output-json }}`
- **No more `cp bench.json bench.json` bug** when `output-json: bench.json`