### PR TITLE
fix: default to v0 when running action locally (uses: ./)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,8 +83,7 @@ runs:
       run: |
         REF="${{ github.action_ref }}"
         if [ -z "$REF" ]; then
-          echo "::error::Pin to a version: @v0 for latest, @v0.10.1 for pinned."
-          exit 1
+          REF="v0"
         fi
 
         if echo "$REF" | grep -qE '^v[0-9]+$'; then


### PR DESCRIPTION
When `uses: ./` (local checkout), `github.action_ref` is empty. Default to `v0` — resolves latest `v0.*` tag — instead of erroring.

Fix for the `deploy-examples.yml` workflow which uses `uses: ./`.