### PR TITLE
ci: release approval gate, auto-deploy on release,

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -4,10 +4,12 @@ on:
     branches: [main]
     paths:
       - examples/bench/**
-      - pkg/template/ui/**
       - action.yml
       - .github/workflows/test-action.yml
       - .github/workflows/deploy-examples.yml
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
   workflow_dispatch:
 
 jobs:
@@ -110,6 +112,7 @@ jobs:
 
   merge-deploy:
     needs: convert
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,21 @@ on:
 
 permissions:
   contents: write
+  issues: write
+  actions: read
 
 jobs:
+  approve:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ secrets.GITHUB_TOKEN }}
+          approvers: fahimfaisaal
+          minimum-approvals: 1
+
   goreleaser:
-    environment: release
+    needs: approve
     runs-on: ubuntu-slim
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
+    environment: release
     runs-on: ubuntu-slim
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ Notable changes to Vizb documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.10.2] - 2026-05-20
+
+### Added
+
+- **Timestamp Badge**: Dashboard header now shows the benchmark's last update time with a calendar icon. Clicking reveals a popover with full tag history (all versions + timestamps) via radix-vue Popover ([#92](https://github.com/goptics/vizb/pull/92)).
+- **Reusable Badge Component**: New `Badge.vue` component (icon + label + value) replaces inline CPU badge for consistent header styling ([#92](https://github.com/goptics/vizb/pull/92)).
+- **Release Guard**: Manual approval gate via `trstringer/manual-approval` — tag push pauses the release workflow until explicitly approved in the Actions UI ([#93](https://github.com/goptics/vizb/pull/93)).
+- **Auto-Deploy on Release**: `deploy-examples` workflow now triggers automatically when a release completes successfully, ensuring examples use the newly published binary ([#93](https://github.com/goptics/vizb/pull/93)).
+
+### Changed
+
+- **Benchmark TS Types**: Added `HistoryEntry`, `tag`, `timestamp`, and `history` fields to the TypeScript `Benchmark` type to match the Go data model ([#92](https://github.com/goptics/vizb/pull/92)).
+- **PopoverContent**: Added optional `align` prop (`start` | `center` | `end`) to `PopoverContent.vue` for flexible popover positioning ([#92](https://github.com/goptics/vizb/pull/92)).
+- **Deploy Trigger Fix**: Removed `pkg/template/ui/**` from `deploy-examples` push trigger — UI-only changes on main no longer redeploy examples using a stale binary ([#93](https://github.com/goptics/vizb/pull/93)).
+- **Documents**: Updated README description and features to mention GitHub Action and release guard ([#93](https://github.com/goptics/vizb/pull/93)).
+
 # [0.10.1] - 2026-05-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   </p>
 
   <p>
-    A CLI tool that transforms Go benchmark raw output into interactive <strong>4D visualizations</strong>. It allows you to <a href="#merging-multiple-benchmarks">merge multiple benchmark data</a>, apply <a href="#advance-usage">advanced grouping logic</a>, and explore performance across four dimensions: Source, Group, and two customizable axes (X and Y). Available as both a <strong>CLI tool</strong> and a <strong>GitHub Action</strong> for seamless CI pipeline integration — all within a single deployable HTML file.
+    A CLI tool that transforms Go benchmark raw output into interactive <strong>4D visualizations</strong>. It allows you to <a href="#merging-multiple-benchmarks">merge multiple benchmark data</a>, apply <a href="#advance-usage">advanced grouping logic</a>, and explore performance across four dimensions: Source, Group, and two customizable axes (X and Y). Available as both a <strong>CLI tool</strong> and a <strong><a href="#github-action">GitHub Action</a></strong> for seamless CI pipeline integration — all within a single deployable HTML file.
   </p>
 </div>
 
@@ -34,73 +34,6 @@
 - **Export Options**: Generate `single-file` HTML/JSON and options to save charts as `JPEG`.
 - **GitHub Action**: First-class CI support — run benchmarks, tag releases, merge history, and deploy visualizations directly from your workflows with a single composite action.
 - **Release Guard**: Manual approval gate — push a tag, review in the Actions UI, and approve before GoReleaser publishes.
-
-## GitHub Action
-
-Vizb provides a composite GitHub Action to run benchmarks and generate visualizations in CI.
-
-### Basic Usage
-
-```yaml
-- uses: actions/setup-go@v6
-  with:
-    go-version-file: go.mod
-
-- uses: goptics/vizb@v0
-  with:
-    bench-cmd: "go test -bench=."
-    output-html: pages/index.html
-```
-
-### Tracking Performance Across Releases
-
-Tag benchmarks with release versions, merge historical data, and deploy charts:
-
-```yaml
-on:
-  push:
-    tags: ['v*']
-
-jobs:
-  bench:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Download previous benchmark data
-        uses: dawidd6/action-download-artifact@v21
-        continue-on-error: true
-        with:
-          workflow: bench.yml
-          name: merged.json
-          path: prev
-
-      - uses: goptics/vizb@v0
-        with:
-          bench-cmd: "go test -bench=."
-          tag: ${{ github.ref_name }}
-          merge-dir: prev
-          tag-axis: x
-          output-json: merged.json
-          output-html: pages/index.html
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: merged.json
-          path: merged.json
-
-      - uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: pages
-```
-
-> [!Note]
-> The `tag-axis` input controls which data dimension receives the tag annotation. Use `x` to show versions on the X-axis for clean progressive comparison.
 
 ## Installation
 
@@ -130,16 +63,6 @@ Generate charts from the benchmark:
 vizb bench.txt -o output.html
 ```
 
-### Using logarithmic scale
-
-For benchmarks with high variance in values (e.g., 1 to 1,000,000), use the logarithmic Y-axis scale:
-
-```bash
-vizb bench.txt -o output.html --scale log
-```
-
-The `--scale` flag accepts `linear` (default) or `log`. It works with bar and line charts; pie charts and 1D data automatically use linear scale.
-
 ### Direct piping
 
 Pipe benchmark results directly to vizb:
@@ -163,6 +86,16 @@ Generate charts from the standard JSON benchmark data:
 ```bash
 vizb output.json -o output.html
 ```
+
+### Using logarithmic scale
+
+For benchmarks with high variance in values (e.g., 1 to 1,000,000), use the logarithmic Y-axis scale:
+
+```bash
+vizb bench.txt -o output.html --scale log
+```
+
+The `--scale` flag accepts `linear` (default) or `log`. It works with bar and line charts; pie charts and 1D data automatically use linear scale.
 
 ### Merging multiple benchmarks
 
@@ -321,6 +254,74 @@ For more complex benchmark names where simple patterns aren't enough, you can us
 
 > [!Note]
 > You must specify at least one of the `x` and `y` axes when you use the `--group-[pattern|regex]` command. the `n` is optional.
+
+
+## GitHub Action
+
+Vizb provides a composite GitHub Action to run benchmarks and generate visualizations in CI.
+
+### Basic Usage
+
+```yaml
+- uses: actions/setup-go@v6
+  with:
+    go-version-file: go.mod
+
+- uses: goptics/vizb@v0
+  with:
+    bench-cmd: "go test -bench=."
+    output-html: pages/index.html
+```
+
+### Tracking Performance Across Releases
+
+Tag benchmarks with release versions, merge historical data, and deploy charts:
+
+```yaml
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Download previous benchmark data
+        uses: dawidd6/action-download-artifact@v21
+        continue-on-error: true
+        with:
+          workflow: bench.yml
+          name: merged.json
+          path: prev
+
+      - uses: goptics/vizb@v0
+        with:
+          bench-cmd: "go test -bench=."
+          tag: ${{ github.ref_name }}
+          merge-dir: prev
+          tag-axis: x
+          output-json: merged.json
+          output-html: pages/index.html
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: merged.json
+          path: merged.json
+
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: pages
+```
+
+> [!Note]
+> The `tag-axis` input controls which data dimension receives the tag annotation. Use `x` to show versions on the X-axis for clean progressive comparison.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   </p>
 
   <p>
-    A CLI tool that transforms Go benchmark raw output into interactive <strong>4D visualizations</strong>. It allows you to <a href="#merging-multiple-benchmarks">merge multiple benchmark data</a>, apply <a href="#advance-usage">advanced grouping logic</a>, and explore performance across four dimensions: Source, Group, and two customizable axes (X and Y). Available as both a <strong>CLI tool</strong> and a <strong><a href="#github-action">GitHub Action</a></strong> for seamless CI pipeline integration — all within a single deployable HTML file.
+    A CLI tool that transforms Go benchmark raw output into interactive <strong>4D visualizations</strong>. It allows you to <a href="#merging-multiple-benchmarks">merge multiple benchmark data</a>, apply <a href="#advance-usage">advanced grouping logic</a>, and explore performance across four dimensions: Source, Group, and two customizable axes (X and Y). Available <strong><a href="#github-action">GitHub Action</a></strong> for seamless CI pipeline integration — all within a single deployable HTML file.
   </p>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <img src="assests/logo.png" alt="vizb logo" width="120" height="auto" />
-  <h1>Vizb: Visualize Go Benchmarks in 4D</h1>
+  <h1>Vizb</h1>
 
   <p>
     <a href="https://github.com/avelino/awesome-go?tab=readme-ov-file#benchmarks"><img src="https://awesome.re/mentioned-badge-flat.svg" alt="Mentioned in Awesome Go" /></a>
@@ -14,7 +14,7 @@
   </p>
 
   <p>
-    Vizb is a CLI tool that transforms Go benchmark raw output into interactive <strong>4D visualizations</strong>. It allows you to <a href="#merging-multiple-benchmarks">merge multiple benchmark data</a>, apply <a href="#advance-usage">advanced grouping logic</a>, and explore performance across four dimensions: Source, Group, and two customizable axes (X and Y). All within a single and deployable HTML file.
+    A CLI tool that transforms Go benchmark raw output into interactive <strong>4D visualizations</strong>. It allows you to <a href="#merging-multiple-benchmarks">merge multiple benchmark data</a>, apply <a href="#advance-usage">advanced grouping logic</a>, and explore performance across four dimensions: Source, Group, and two customizable axes (X and Y). Available as both a <strong>CLI tool</strong> and a <strong>GitHub Action</strong> for seamless CI pipeline integration — all within a single deployable HTML file.
   </p>
 </div>
 
@@ -32,6 +32,8 @@
 - **Smart Grouping**: Extract grouping logic from benchmark names using regex and group patterns.
 - **Filtering**: Filter benchmarks to include only those matching a regex pattern.
 - **Export Options**: Generate `single-file` HTML/JSON and options to save charts as `JPEG`.
+- **GitHub Action**: First-class CI support — run benchmarks, tag releases, merge history, and deploy visualizations directly from your workflows with a single composite action.
+- **Release Guard**: Manual approval gate — push a tag, review in the Actions UI, and approve before GoReleaser publishes.
 
 ## GitHub Action
 


### PR DESCRIPTION
## Changes

### release.yml
- Replaced `environment: release` (requires org teams) with `trstringer/manual-approval@v1` — pauses on tag push, shows Review button in Actions UI
- You approve → GoReleaser publishes → deploy-examples auto-triggers

### deploy-examples.yml
- **Removed** `pkg/template/ui/**` from push trigger — UI-only changes on main shouldn't redeploy (uses committed binary, not WIP UI)
- **Added** `workflow_run` trigger on `Release` completion → examples auto-redeploy with the newly released binary
- **Added** conditional on `merge-deploy` → skips if release workflow failed/cancelled

### README.md
- Description now links to GitHub Action section
- Features: added two bullets for GitHub Action and Release Guard
- Changelog: added v0.10.2 entries for all changes from PRs #92 and #93

## How release approval works

1. Push a `v*.*.*` tag → workflow triggers
2. `approve` job runs → pauses with manual-approval action
3. You go to Actions → click the run → see Review button → approve
4. `goreleaser` runs → publishes release → `deploy-examples` auto-triggers