### PR TITLE
ci: remove redundant setup-go and use go.mod in release

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -89,10 +89,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
       - uses: ./
         with:
           bench-file: ${{ matrix.bench-file }}
@@ -118,10 +114,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '^1.24'
+          go-version-file: go.mod
           cache: true
 
       - name: Download dependencies


### PR DESCRIPTION
## Changes

### deploy-examples.yml
- **Removed** `actions/setup-go@v6` from `convert` job — the composite action downloads the vizb binary via curl, no Go toolchain needed
- **Removed** `actions/setup-go@v6` from `merge-deploy` job — only runs `vizb html` + `peaceiris/actions-gh-pages@v4`, no Go needed

### release.yml
- **Replaced** hardcoded `go-version: '^1.24'` with `go-version-file: go.mod` for consistency with other workflows (ci.yml, deploy-examples.yml)

## Impact
- Faster deploy-examples runs (skips Go setup)
- Consistent Go version resolution across all workflows from `go.mod`