### PR TITLE
fix: publish release immediately instead of draft

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,4 +42,4 @@ snapshot:
   version_template: "{{ .Tag }}-next"
 
 release:
-  draft: true
+  draft: false


### PR DESCRIPTION
## Problem

GoReleaser creates **draft** releases (`draft: true`) which are not publicly accessible. When the release workflow completes and `deploy-examples` auto-triggers, the action's curl to `releases/download/...` gets a **404** because draft assets are hidden.

## Fix

Set `draft: false` in `.goreleaser.yml`. After the manual approval gate, GoReleaser publishes the release immediately, making binaries available for the downstream `deploy-examples` workflow.

## Flow after fix

1. Push `v*.*.*` tag → workflow triggers
2. Manual approval gate → approved
3. GoReleaser publishes **live** release (not draft)
4. `deploy-examples` auto-triggers → curl succeeds → examples redeploy