### PR TITLE
feat: add multi-language benchmark parser registry

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,3 +40,15 @@ checksum:
 
 snapshot:
   version_template: "{{ .Tag }}-next"
+
+winget:
+  - name: vizb
+    publisher: fahimfaisaal
+    short_description: "Multi-language benchmark visualization CLI"
+    repository:
+      owner: goptics
+      name: winget-pkgs
+    description: "Transform benchmark output from Go (go test -bench), Rust (cargo bench via Criterion/Divan), and JavaScript (Vitest/Tinybench) into interactive 4D HTML visualizations."
+    homepage: https://vizb.goptics.org
+    license: MIT
+    license_url: https://github.com/goptics/vizb/blob/main/LICENSE

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,4 +51,3 @@ winget:
     description: "Transform benchmark output from Go (go test -bench), Rust (cargo bench via Criterion/Divan), and JavaScript (Vitest/Tinybench) into interactive 4D HTML visualizations."
     homepage: https://vizb.goptics.org
     license: MIT
-    license_url: https://github.com/goptics/vizb/blob/main/LICENSE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ Notable changes to Vizb documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.11.0] - 2026-05-23
+
+### Added
+
+- **Multi-Language Parser Registry**: Vizb now supports benchmark output from Rust and JavaScript via a new parser registry. Ships with parsers for Rust (Criterion, Divan) and JavaScript (Vitest, TinyBench) — making Vizb a cross-language benchmark visualization tool.
+- **`--parser` Flag**: Explicitly select a parser for non-Go benchmark input (`--parser rs:criterion`, `--parser js:vitest`, etc.). Auto-detection based on file extension also supported.
+- **Rust Parsers**: Added parsers for Criterion (`rs:criterion`) and Divan (`rs:divan`) benchmark output formats.
+- **JavaScript Parsers**: Added parsers for Vitest (`js:vitest`) and TinyBench (`js:tinybench`) benchmark output formats.
+- **Quick Installation**: One-command install via `curl` (macOS/Linux) and `winget` (Windows) — no manual binary download needed.
+
+### Changed
+
+- **Tests migrated to testify**: Test suite standardized on `testify/assert` for consistent assertions and better failure messages.
+
 # [0.10.3] - 2026-05-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,25 +14,9 @@
   </p>
 
   <p>
-    A CLI tool that transforms Go benchmark raw output into interactive <strong>4D visualizations</strong>. Merge multiple benchmark runs, apply advanced grouping logic, and explore performance across four dimensions — all within a single deployable HTML file. Available <strong><a href="#github-action">GitHub Action</a></strong> for seamless CI pipeline integration.
+    A CLI tool that transforms benchmark output from <strong>Go</strong>, <strong>Rust</strong>, and <strong>JavaScript</strong> frameworks into interactive <strong>4D visualizations</strong>. Pipe in benchmark results, apply multi-dimensional grouping, merge across releases, and explore performance in a single self-contained HTML file — no server, no dependencies, no build step.
   </p>
 </div>
-
-## Features
-
-- **Modern Interactive UI**: Robust **Vue.js** application with a smooth and responsive experience.
-- **Multi-Chart**: Supports multiple charts (`bar`, `line` and `pie`) in a single place.
-- **Sorting**: Sort data (`asc`/`desc`) for comparison through UI settings or CLI flags.
-- **Swap Axis**: Swap the `n`, `x` and `y` axes for diverse comparison through UI settings.
-- **Logarithmic Scale**: Use `--scale log` for bar and line charts to better visualize benchmarks with high variance in values.
-- **Multi-Dimensional Grouping**: Merge multiple benchmark data for deep comparative analysis.
-- **Tag-Based Merging**: Tag benchmarks with commit hashes or version labels to compare performance across releases with automatic data merging.
-- **Flexible Input**: Automatically processes raw `go test -bench` output and the standard JSON output of `go test -bench -json`.
-- **Comprehensive Metrics**: Compare time, memory, and numbers with customizable units.
-- **Smart Grouping**: Extract grouping logic from benchmark names using regex and group patterns.
-- **Filtering**: Filter benchmarks to include only those matching a regex pattern.
-- **Export Options**: Generate `single-file` HTML/JSON and options to save charts as `JPEG`.
-- **GitHub Action**: First-class CI support — run benchmarks, tag releases, merge history, and deploy visualizations directly from your workflows with a single composite action.
 
 ## Installation
 
@@ -46,72 +30,16 @@ go install github.com/goptics/vizb@latest
 
 Pre-built binaries for Linux, macOS, and Windows are available on the [releases page](https://github.com/goptics/vizb/releases).
 
-## Quick Start
-
-### Direct piping
-
-```bash
-go test -bench . | vizb -o output.html
-```
-
-### From a saved file
-
-```bash
-go test -bench . > bench.txt
-vizb bench.txt -o output.html
-```
-
-### JSON output
-
-```bash
-go test -bench . -json | vizb -o output.html
-```
-
-### Merging multiple benchmarks
-
-```bash
-# Merge specific files
-vizb merge output.json output2.json -o merged.json
-
-# Merge all JSON files in a directory
-vizb merge ./results/ -o all.json
-
-# Generate HTML from merged JSON
-vizb html merged.json -o report.html
-```
-
-> [!Note]
-> The `merge` command requires JSON files as input, generated with `-o output.json`.
-
 ## Documentation
 
 Full documentation is available at **[vizb.goptics.org](https://vizb.goptics.org/)**:
 
+- [Getting Started](https://vizb.goptics.org/getting-started/)
+- [Parser Guide](https://vizb.goptics.org/guides/parsers/)
 - [CLI Commands](https://vizb.goptics.org/commands/root/)
 - [Grouping Guide](https://vizb.goptics.org/guides/grouping/)
 - [Merging Guide](https://vizb.goptics.org/guides/merging/)
 - [CI/CD Integration](https://vizb.goptics.org/ci-cd/github-action/)
-- [UI Features](https://vizb.goptics.org/ui/)
-
-## GitHub Action
-
-Vizb provides a composite GitHub Action to run benchmarks and generate visualizations in CI.
-
-### Run bench and generate HTML
-
-```yaml
-- uses: actions/setup-go@v6
-  with:
-    go-version-file: go.mod
-
-- uses: goptics/vizb@v0
-  with:
-    bench-cmd: "go test -bench=."
-    output-html: pages/index.html
-```
-
-> [!Note]
-> For full input reference, CI tutorials (stateless & stateful), and deployment guides, see the [CI/CD documentation](https://vizb.goptics.org/ci-cd/github-action/).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@
 
 ## Installation
 
+### Quick Install
+
+```bash
+# Linux / macOS
+curl -fsSL https://vizb.goptics.io/install.sh | bash
+
+# Windows
+winget install goptics.vizb
+```
+
 ### Go Toolchain
 
 ```bash

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,7 +56,7 @@ tasks:
   test:
     desc: Run all tests (no cache)
     cmds:
-      - go test -count=1 -v ./...
+      - go test -count=1 ./...
 
   lint:
     desc: Run linter

--- a/cmd/flag_validation_rules.go
+++ b/cmd/flag_validation_rules.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/goptics/vizb/pkg/parser"
@@ -69,4 +70,17 @@ var flagValidationRules = []utils.ValidationRule{
 		Normalizer: strings.ToLower,
 		Default:    "n",
 	},
+	{
+		Label:     "parser",
+		Value:     &shared.FlagState.Parser,
+		Validator: validateParser,
+		Default:   "go",
+	},
+}
+
+func validateParser(key string) error {
+	if _, ok := parser.Parsers[key]; !ok {
+		return fmt.Errorf("unknown parser '%s'; available: %v", key, parser.AvailableParsers())
+	}
+	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/goptics/vizb/pkg/parser"
 	goparser "github.com/goptics/vizb/pkg/parser/golang"
 	_ "github.com/goptics/vizb/pkg/parser/javascript"
+	_ "github.com/goptics/vizb/pkg/parser/rust"
 	"github.com/goptics/vizb/pkg/style"
 	"github.com/goptics/vizb/pkg/template"
 	"github.com/goptics/vizb/shared"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,7 +60,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&shared.FlagState.FilterRegex, "filter", "f", "", "Regex pattern to include only matching benchmark names")
 	rootCmd.Flags().StringVarP(&shared.FlagState.Scale, "scale", "S", "linear", "Scale type (linear, log)")
 	rootCmd.Flags().StringVarP(&shared.FlagState.Tag, "tag", "t", "", "Tag/identifier for the benchmark")
-	rootCmd.Flags().StringVarP(&shared.FlagState.Parser, "parser", "P", "go", "Benchmark parser to use: go, js:tinybench")
+	rootCmd.Flags().StringVarP(&shared.FlagState.Parser, "parser", "P", "go", "Benchmark parser to use (one of: "+strings.Join(parser.AvailableParsers(), ", ")+")")
 
 	// Add a hook to validate flags after parsing
 	cobra.OnInitialize(func() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/goptics/vizb/pkg/parser"
+	goparser "github.com/goptics/vizb/pkg/parser/golang"
+	_ "github.com/goptics/vizb/pkg/parser/javascript"
 	"github.com/goptics/vizb/pkg/style"
 	"github.com/goptics/vizb/pkg/template"
 	"github.com/goptics/vizb/shared"
@@ -57,6 +59,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&shared.FlagState.FilterRegex, "filter", "f", "", "Regex pattern to include only matching benchmark names")
 	rootCmd.Flags().StringVarP(&shared.FlagState.Scale, "scale", "S", "linear", "Scale type (linear, log)")
 	rootCmd.Flags().StringVarP(&shared.FlagState.Tag, "tag", "t", "", "Tag/identifier for the benchmark")
+	rootCmd.Flags().StringVarP(&shared.FlagState.Parser, "parser", "P", "go", "Benchmark parser to use: go, js:tinybench")
 
 	// Add a hook to validate flags after parsing
 	cobra.OnInitialize(func() {
@@ -206,8 +209,8 @@ func resolveOutputFileName(outFile string) string {
 
 // preprocessInputFile handles JSON → TXT conversion if needed
 func preprocessInputFile(filePath string) string {
-	if utils.IsBenchJSONFile(filePath) {
-		return parser.ConvertJsonBenchToText(filePath)
+	if shared.FlagState.Parser == "go" && utils.IsBenchJSONFile(filePath) {
+		return goparser.ConvertGoJsonBenchToText(filePath)
 	}
 
 	return filePath
@@ -215,7 +218,12 @@ func preprocessInputFile(filePath string) string {
 
 // prepareBenchmarkData parses benchmark results or exits on error
 func prepareBenchmarkData(filePath string) []shared.BenchmarkData {
-	data := parser.ParseBenchmarkData(filePath)
+	parseFn, err := parser.GetParser(shared.FlagState.Parser)
+	if err != nil {
+		shared.ExitWithError(err.Error(), nil)
+	}
+
+	data := parseFn(filePath)
 
 	if len(data) == 0 {
 		shared.ExitWithError("No benchmark data found", nil)

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -9,7 +9,7 @@ export default defineConfig({
 	integrations: [
 	starlight({
 		title: 'Benchmark visualization made simple',
-		description: 'A CLI tool that transforms Go benchmark raw output into interactive 4D visualizations. Merge multiple benchmark runs, apply advanced grouping logic, and explore performance across four dimensions — all within a single deployable HTML file. Available GitHub Action for seamless CI pipeline integration.',
+		description: 'Transform benchmark output from Go, Rust, and JavaScript frameworks into interactive 4D visualizations — a single self-contained HTML file.',
 		logo: {
 			dark: './src/assets/logo-dark.svg',
 			light: './src/assets/logo-light.svg',

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -41,6 +41,7 @@ export default defineConfig({
 				items: [
 					{ label: 'Grouping', slug: 'guides/grouping' },
 					{ label: 'Merging', slug: 'guides/merging' },
+					{ label: 'Parser Guide', slug: 'guides/parsers' },
 				],
 			},
 			{

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="goptics/vizb"
+BIN="vizb"
+INSTALL_DIR="/usr/local/bin"
+
+# ----- helpers -----
+die() { echo "error: $*" >&2; exit 1; }
+info() { echo " info: $*"; }
+
+# ----- detect platform -----
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$OS" in
+  linux)  ;;
+  darwin) ;;
+  *) die "unsupported OS: $OS (only linux and macOS are supported)" ;;
+esac
+
+case "$ARCH" in
+  x86_64|amd64) ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *) die "unsupported architecture: $ARCH" ;;
+esac
+
+# ----- check prerequisites -----
+command -v curl >/dev/null 2>&1 || die "curl is required but not installed"
+command -v tar >/dev/null 2>&1 || die "tar is required but not installed"
+
+# ----- fetch latest version -----
+info "fetching latest release…"
+LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+if [[ -z "$LATEST" ]]; then
+  die "failed to determine latest version"
+fi
+VERSION="${LATEST#v}"
+info "latest version: ${VERSION}"
+
+# ----- download & extract -----
+ARCHIVE="vizb@${VERSION}-${OS}-${ARCH}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/${LATEST}/${ARCHIVE}"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+info "downloading ${URL}…"
+curl -fsSL "$URL" -o "${TMPDIR}/${ARCHIVE}" || die "download failed"
+
+info "extracting…"
+tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$TMPDIR"
+if [[ ! -f "${TMPDIR}/${BIN}" ]]; then
+  die "binary not found in archive"
+fi
+
+# ----- install -----
+info "installing to ${INSTALL_DIR}…"
+if [[ -w "$INSTALL_DIR" ]]; then
+  cp "${TMPDIR}/${BIN}" "${INSTALL_DIR}/${BIN}"
+else
+  sudo cp "${TMPDIR}/${BIN}" "${INSTALL_DIR}/${BIN}"
+fi
+
+chmod +x "${INSTALL_DIR}/${BIN}"
+
+# ----- verify -----
+info "verifying installation…"
+if "${INSTALL_DIR}/${BIN}" --version >/dev/null 2>&1; then
+  info "vizb ${VERSION} installed successfully to ${INSTALL_DIR}/${BIN}"
+else
+  die "installation verification failed"
+fi

--- a/docs/src/content/docs/commands/root.mdx
+++ b/docs/src/content/docs/commands/root.mdx
@@ -5,7 +5,7 @@ description: Parse benchmark output and generate HTML or JSON visualizations.
 
 import { Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 
-The root command (`vizb`) is the primary entry point. It parses `go test -bench` output and generates interactive visualizations.
+The root command (`vizb`) is the primary entry point. It parses benchmark output from multiple frameworks and generates interactive visualizations.
 
 ## Usage
 
@@ -30,18 +30,39 @@ vizb [target] [flags]
   </TabItem>
   <TabItem label="JSON Auto-Detect">
   ```bash
-  # JSON bench events are auto-detected and converted
+  # JSON bench events are auto-detected and converted for Go
   go test -bench . -json | vizb -o output.html
   ```
-  Vizb automatically detects `go test -bench -json` format.
+  Vizb automatically detects `go test -bench -json` format when using `--parser go`.
   </TabItem>
 </Tabs>
+
+## Multi-Language Parsers
+
+Vizb supports Rust, JavaScript, and TypeScript benchmark frameworks in addition to Go. Use `--parser` to select the right one:
+
+```bash
+# Rust Criterion
+cargo bench 2>&1 | vizb --parser rs:criterion -o output.html
+
+# Rust Divan
+cargo bench 2>&1 | vizb --parser rs:divan -o output.html
+
+# Vitest
+npx vitest bench 2>&1 | vizb --parser js:vitest -o output.html
+
+# Tinybench
+node bench.js 2>&1 | vizb --parser js:tinybench -o output.html
+```
+
+See the [Parser Guide](/guides/parsers) for full details on each parser's metrics and configuration.
 
 ## Flags
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--output` | `-o` | *(stdout)* | Output file path. `.json` → JSON, else → HTML |
+| `--parser` | `-P` | `go` | Benchmark parser: `go`, `js:tinybench`, `js:vitest`, `rs:criterion`, `rs:divan` |
 | `--name` | `-n` | `Benchmarks` | Benchmark name |
 | `--description` | `-d` | `""` | Benchmark description |
 | `--tag` | `-t` | `""` | Tag identifier for release tracking |

--- a/docs/src/content/docs/features.mdx
+++ b/docs/src/content/docs/features.mdx
@@ -5,7 +5,7 @@ description: A detailed overview of everything vizb can do.
 
 import { CardGrid, Card, Aside } from '@astrojs/starlight/components';
 
-Vizb transforms `go test -bench` output into interactive 4D HTML visualizations. Here's what it offers.
+Vizb transforms benchmark output from Go, Rust, and JavaScript frameworks into interactive 4D HTML visualizations. Here's what it offers.
 
 <CardGrid stagger>
   <Card title="Modern Interactive UI" icon="laptop">
@@ -30,10 +30,10 @@ Vizb transforms `go test -bench` output into interactive 4D HTML visualizations.
     Tag benchmarks with version labels. Deep-merge across releases with chronological data ordering.
   </Card>
   <Card title="Flexible Input" icon="document">
-    Auto-detects raw text and `go test -bench -json` format. Accepts files or stdin pipes.
+    Reads benchmark output from Go, Rust (Criterion, Divan), and JavaScript (Vitest, Tinybench). Auto-detects text and JSON formats. Accepts files or stdin pipes.
   </Card>
   <Card title="Comprehensive Metrics" icon="information">
-    Time (ns/us/ms/s), memory (B/KB/MB/GB), allocations, and throughput with configurable units.
+    Time (ns/us/ms/s), memory (B/KB/MB/GB), allocations, throughput, and latency percentiles — with configurable units. Which metrics appear depends on the parser used.
   </Card>
   <Card title="Smart Filtering" icon="magnifier">
     Include only matching benchmarks with `--filter` regex pattern.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -63,7 +63,7 @@ import { Aside, LinkCard, CardGrid, Tabs, TabItem } from '@astrojs/starlight/com
   ```
 
   </TabItem>
-  <TabItem label="Vitest" icon="seti:vite">
+  <TabItem label="Vitest" icon="seti:javascript">
 
   **Pipe**
   ```bash

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -3,55 +3,105 @@ title: Getting Started
 description: Get up and running with vizb in under a minute.
 ---
 
-import { Aside, Steps, LinkCard, CardGrid } from '@astrojs/starlight/components';
+import { Aside, LinkCard, CardGrid, Tabs, TabItem } from '@astrojs/starlight/components';
 
-<Aside type="note">
-  Vizb requires **Go 1.24+** and a Go project with `go test -bench` benchmarks.
-</Aside>
+<Tabs syncKey="lang">
+  <TabItem label="Go" icon="seti:go">
 
-<Steps>
+  **Pipe**
+  ```bash
+  go test -bench . | vizb -o output.html
+  ```
 
-1. **Pipe benchmarks to vizb**
+  **From a saved file**
+  ```bash
+  go test -bench . > bench.txt
+  vizb bench.txt -o output.html
+  ```
 
-   Run your benchmarks and pipe the output directly:
+  **JSON pipeline**
+  ```bash
+  go test -bench . -json | vizb -o output.html
+  ```
 
-   ```bash
-   go test -bench . | vizb -o output.html
-   ```
+  Save as JSON for later merging:
+  ```bash
+  vizb bench.txt -o output.json
+  vizb output.json -o output.html
+  ```
 
-   Open `output.html` in your browser.
+  <Aside type="note">
+    To build from source, **Go 1.24+** is required. Pre-built binaries from the [installation page](/installation) need no Go runtime.
+  </Aside>
 
-2. **From a saved file**
+  </TabItem>
+  <TabItem label="Criterion" icon="seti:rust">
 
-   If you already have benchmark output saved:
+  **Pipe**
+  ```bash
+  cargo bench 2>&1 | vizb --parser rs:criterion -o output.html
+  ```
 
-   ```bash
-   go test -bench . > bench.txt
-   vizb bench.txt -o output.html
-   ```
+  **From a saved file**
+  ```bash
+  cargo bench 2>&1 > bench.txt
+  vizb --parser rs:criterion bench.txt -o output.html
+  ```
 
-3. **JSON pipeline**
+  </TabItem>
+  <TabItem label="Divan" icon="seti:rust">
 
-   Vizb auto-detects JSON format from `go test -bench -json`:
+  **Pipe**
+  ```bash
+  cargo bench 2>&1 | vizb --parser rs:divan -o output.html
+  ```
 
-   ```bash
-   go test -bench . -json | vizb -o output.html
-   ```
+  **From a saved file**
+  ```bash
+  cargo bench 2>&1 > bench.txt
+  vizb --parser rs:divan bench.txt -o output.html
+  ```
 
-   Save as JSON for later merging:
+  </TabItem>
+  <TabItem label="Vitest" icon="seti:vite">
 
-   ```bash
-   vizb bench.txt -o output.json
-   vizb output.json -o output.html
-   ```
+  **Pipe**
+  ```bash
+  npx vitest bench 2>&1 | vizb --parser js:vitest -o output.html
+  ```
 
-</Steps>
+  **From a saved file**
+  ```bash
+  npx vitest bench 2>&1 > bench.txt
+  vizb --parser js:vitest bench.txt -o output.html
+  ```
+
+  <Aside type="caution" title="Experimental">
+    Benchmarking in Vitest is experimental and does not follow SemVer. The parser was tested against v4.1.7. Future Vitest versions may change output format and break parser compatibility.
+  </Aside>
+
+  </TabItem>
+  <TabItem label="Tinybench" icon="seti:javascript">
+
+  **Pipe**
+  ```bash
+  node bench.js 2>&1 | vizb --parser js:tinybench -o output.html
+  ```
+
+  **From a saved file**
+  ```bash
+  node bench.js 2>&1 > bench.txt
+  vizb --parser js:tinybench bench.txt -o output.html
+  ```
+
+  </TabItem>
+</Tabs>
 
 ## Next Steps
 
 <CardGrid cols={2}>
   <LinkCard title="Installation" description="Go install, binary download, and PATH setup." href="/installation" />
+  <LinkCard title="Parser Guide" description="Choose the right parser for Go, Rust, or JavaScript benchmarks." href="/guides/parsers" />
   <LinkCard title="Commands" description="All CLI flags and options." href="/commands/root" />
   <LinkCard title="Grouping Guide" description="Multi-dimensional data with patterns and regex." href="/guides/grouping" />
-  <LinkCard title="CI/CD" description="GitHub Action and CI pipeline setup." href="/ci-cd/github-action" />
 </CardGrid>

--- a/docs/src/content/docs/guides/merging.mdx
+++ b/docs/src/content/docs/guides/merging.mdx
@@ -7,7 +7,7 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 
 ## What is Merging
 
-Merging combines multiple JSON benchmark files into a single dataset for visualization. This enables comparing benchmarks across different runs, machines, Go versions, or releases — all in one interactive chart.
+Merging combines multiple JSON benchmark files into a single dataset for visualization. This enables comparing benchmarks across different runs, machines, versions, or releases — all in one interactive chart.
 
 Without merging, each benchmark run is an isolated report. With merging, you can overlay results from `v1.0` and `v2.0`, compare performance across different machines, or track regressions over time.
 
@@ -87,7 +87,7 @@ The merge process handles tagged data as follows:
 
 ## Tag-Axis
 
-The `-A` (or `--tag-axis`) flag controls where the tag label is injected in the grouped dimensions. By default, tags are added to the **name** dimension, which creates separate charts per tag. Changing the axis lets you control how the comparison is visualized.
+The `-A` (or `--tag-axis`) flag controls where the tag label is **injected** in the grouped dimensions. By default, tags are added to the **name/n** dimension, which creates separate charts per tag. Changing the axis lets you control how the comparison is visualized.
 
 | Value | Axis | Effect |
 |---|---|---|

--- a/docs/src/content/docs/guides/parsers.mdx
+++ b/docs/src/content/docs/guides/parsers.mdx
@@ -1,0 +1,158 @@
+---
+title: Parser Guide
+description: Choose the right parser for your benchmark framework — Go, Rust Criterion, Divan, Vitest, or Tinybench.
+---
+
+import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+
+Vizb supports multiple benchmark frameworks through its parser registry. Use `--parser` to select the right one for your benchmark output.
+
+## Why Multiple Parsers
+
+Each benchmark framework produces output in a different format. Vizb's parser registry knows how to read them all and convert the results into a common structure — so your charts, grouping, filtering, and merging work identically regardless of where the benchmarks came from.
+
+## Choosing a Parser
+
+<Tabs syncKey="parser">
+  <TabItem label="Go" icon="seti:go">
+  Default parser. Reads `go test -bench` text or `-json` output.
+
+  ```bash
+  go test -bench . | vizb -o output.html
+  # or explicitly
+  go test -bench . | vizb --parser go -o output.html
+  ```
+
+  **When JSON auto-detection applies:** `--parser go` is required for JSON input (the `go test -bench -json` format).
+
+  **Metrics extracted:**
+
+  | Metric | Description |
+  |---|---|
+  | Execution time | ns/op, with configurable unit |
+  | Memory | B/op, with configurable unit |
+  | Allocations | allocs/op, with configurable unit |
+  | Throughput | MB/s, B/s, GB/s, or custom |
+  | Iterations | Number of iterations run |
+  </TabItem>
+
+  <TabItem label="Criterion" icon="seti:rust">
+  Parses `cargo bench` output from [Criterion](https://github.com/bheisler/criterion.rs).
+
+  ```bash
+  cargo bench 2>&1 | vizb --parser rs:criterion -o output.html
+  ```
+
+  **Metrics extracted:**
+
+  | Metric | Description |
+  |---|---|
+  | Latency avg | Mean time per iteration |
+  | Latency lower | Lower bound of confidence interval |
+  | Latency upper | Upper bound (±) |
+
+  <Aside type="note">
+    Criterion output contains ANSI color codes — vizb strips these automatically before parsing.
+  </Aside>
+  </TabItem>
+
+  <TabItem label="Divan" icon="seti:rust">
+  Parses `cargo bench` output from [Divan](https://github.com/nvzqz/divan).
+
+  ```bash
+  cargo bench 2>&1 | vizb --parser rs:divan -o output.html
+  ```
+
+  **Metrics extracted:**
+
+  | Metric | Description |
+  |---|---|
+  | Latency fastest | Fastest measured iteration |
+  | Latency slowest | Slowest measured iteration (±) |
+  | Latency median | Median across all samples |
+  | Latency mean | Mean across all samples |
+  | Samples | Number of samples collected |
+
+  <Aside type="note">
+    The `iters` column from Divan output is not extracted — it represents per-sample iteration counts rather than an aggregate metric.
+  </Aside>
+  </TabItem>
+
+  <TabItem label="Vitest" icon="seti:javascript">
+  Parses `vitest bench` output.
+
+  <Aside type="caution" title="Experimental">
+    Benchmarking in Vitest is experimental and does not follow SemVer. The parser was tested against v4.1.7. Output format changes in future Vitest versions may break parser compatibility.
+  </Aside>
+
+  ```bash
+  npx vitest bench 2>&1 | vizb --parser js:vitest -o output.html
+  ```
+
+  **Metrics extracted:**
+
+  | Metric | Description |
+  |---|---|
+  | Throughput | Operations per second (ops/s) |
+  | Latency min / max | Fastest and slowest run |
+  | Latency avg | Mean across all runs |
+  | Latency p75 / p99 / p995 / p999 | Percentile latency |
+  | RME | Relative margin of error (±) |
+  | Samples | Number of samples collected |
+
+  **Naming convention:** When `describe()` wraps `bench()` blocks, names are concatenated with `/`:
+
+  ```ts
+  describe('n=100', () => {
+    bench('bubbleSort', () => { ... })
+    bench('insertionSort', () => { ... })
+  })
+  ```
+
+  Produces names `n=100/bubbleSort` and `n=100/insertionSort`. Use `--group-pattern` with any valid 2D combination (`n/x`, `n/y`, `x/n`, `y/n`, `x/y`, `y/x`) to split the suite name into its own dimension.
+
+  See the [Grouping Guide](/guides/grouping) for detailed pattern and regex syntax.
+  </TabItem>
+
+  <TabItem label="Tinybench" icon="seti:javascript">
+  Parses [Tinybench](https://github.com/tinylibs/tinybench) `console.table()` output.
+
+  ```bash
+  node bench.js 2>&1 | vizb --parser js:tinybench -o output.html
+  ```
+
+  **Metrics extracted:**
+
+  | Metric | Description |
+  |---|---|
+  | Latency avg / med | Mean and median latency |
+  | Latency RME / MAD | Relative margin of error and median absolute deviation (±) |
+  | Throughput avg / med | Mean and median operations per second |
+  | Throughput RME / MAD | Relative margin of error (±) |
+  | Samples | Number of samples collected |
+  </TabItem>
+</Tabs>
+
+## All Parser Keys
+
+| Key | Framework | Language |
+|-----|-----------|----------|
+| `go` | Go testing (benchfmt) | Go |
+| `rs:criterion` | Criterion | Rust |
+| `rs:divan` | Divan | Rust |
+| `js:vitest` | Vitest | JavaScript / TypeScript |
+| `js:tinybench` | Tinybench | JavaScript / TypeScript |
+
+## Add a New Parser
+
+Want to add support for a benchmark framework or language not listed here? Parser contributions are welcome. Here's what the process looks like:
+
+1. **Choose a key** following the `<lang>:<framework>` convention (e.g., `py:pytest`, `java:jmh`)
+2. **Implement a parse function** that extracts `[]shared.BenchmarkData` from the framework's output
+3. **Register it** via `parser.Register("your-key", YourParseFunc)` in an `init()` block
+4. **Add tests** with real output samples and edge cases
+5. **Open a PR** on [GitHub](https://github.com/goptics/vizb) — the existing parsers in `pkg/parser/` are good references to follow
+
+<Aside type="tip">
+  The parser registry is designed to be extensible. As long as your parse function returns benchmark data with names, values, and optional metadata, everything else — grouping, filtering, merging, time unit conversion — works automatically.
+</Aside>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Vizb
 description: Transform benchmark output from Go, Rust, and JavaScript frameworks into interactive 4D visualizations
 template: splash
 hero:
-  tagline: Turns benchmark output from Go, Rust, and JavaScript into interactive charts you can explore in your browser. Single HTML file — no server, no dependencies, no build step.
+  tagline: Transforms benchmark output from Go, Rust, and JavaScript into interactive charts you can explore in your browser. Single HTML file — no server, no dependencies, no build step.
   image:
     file: ../../assets/logo.png
     alt: Vizb
@@ -18,9 +18,28 @@ hero:
       icon: right-arrow
 ---
 
-import { CardGrid, Card, LinkCard } from '@astrojs/starlight/components';
+import { CardGrid, Card, LinkCard, Tabs, TabItem } from '@astrojs/starlight/components';
 
+## Quick Install
 
+<Tabs syncKey="os" class="home-install">
+  <TabItem label="Linux / macOS">
+
+```bash
+curl -fsSL https://vizb.goptics.io/install.sh | bash
+```
+
+  </TabItem>
+  <TabItem label="Windows">
+
+```powershell
+winget install goptics.vizb
+```
+
+  </TabItem>
+</Tabs>
+
+## Features
 
 <CardGrid stagger>
   <Card title="Multi-Chart" icon="analytics">

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Vizb
-description: Transform Go benchmark output into interactive 4D visualizations
+description: Transform benchmark output from Go, Rust, and JavaScript frameworks into interactive 4D visualizations
 template: splash
 hero:
-  tagline: Vizb turns raw `go test -bench` output into interactive charts you can explore in your browser. Single HTML file — no server, no dependencies, no build step.
+  tagline: Turns benchmark output from Go, Rust, and JavaScript into interactive charts you can explore in your browser. Single HTML file — no server, no dependencies, no build step.
   image:
     file: ../../assets/logo.png
     alt: Vizb
@@ -39,7 +39,7 @@ import { CardGrid, Card, LinkCard } from '@astrojs/starlight/components';
     Vue.js-powered interface with sortable charts, axis swapping, scale toggles, and JPEG export. All in a single HTML file.
   </Card>
   <Card title="Flexible Input" icon="document">
-    Automatically detects raw text or JSON benchmark output. Pipe from `go test` or read from files.
+    Reads benchmark output from Go, Rust (Criterion, Divan), and JavaScript (Vitest, Tinybench). Auto-detects text and JSON formats. Pipe from CLI or read from files.
   </Card>
 </CardGrid>
 

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -6,7 +6,7 @@ description: Install vizb using Go toolchain or download a pre-built binary.
 import { Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 
 <Aside type="note">
-  Vizb requires **Go 1.24+**. Install Go from the [official site](https://go.dev/dl) or via [webi](https://webinstall.dev/go/).
+  To build from source, **Go 1.24+** is required. Install Go from the [official site](https://go.dev/dl) or via [webi](https://webinstall.dev/go/). If you use a pre-built binary (below), no Go installation is needed.
 </Aside>
 
 ## Go Install

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -1,12 +1,31 @@
 ---
 title: Installation
-description: Install vizb using Go toolchain or download a pre-built binary.
+description: Install vizb using a one-liner, Go toolchain, or download a pre-built binary.
 ---
 
 import { Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 
+## Quick Install
+
+<Tabs syncKey="os">
+  <TabItem label="Linux / macOS" icon="terminal">
+
+```bash
+curl -fsSL https://vizb.goptics.io/install.sh | bash
+```
+
+  </TabItem>
+  <TabItem label="Windows" icon="seti:windows">
+
+```powershell
+winget install goptics.vizb
+```
+
+  </TabItem>
+</Tabs>
+
 <Aside type="note">
-  To build from source, **Go 1.24+** is required. Install Go from the [official site](https://go.dev/dl) or via [webi](https://webinstall.dev/go/). If you use a pre-built binary (below), no Go installation is needed.
+  The installer script downloads the latest binary from GitHub Releases and places it in `/usr/local/bin`. Winget installs via the Windows Package Manager.
 </Aside>
 
 ## Go Install
@@ -14,6 +33,10 @@ import { Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 ```bash
 go install github.com/goptics/vizb@latest
 ```
+
+<Aside type="note">
+  Building from source requires **Go 1.24+**. Install Go from the [official site](https://go.dev/dl) or via [webi](https://webinstall.dev/go/). Pre-built binaries and the install script need no Go runtime.
+</Aside>
 
 ## Download Binary
 

--- a/docs/src/content/docs/roadmap.mdx
+++ b/docs/src/content/docs/roadmap.mdx
@@ -3,38 +3,34 @@ title: Roadmap
 description: Current capabilities and future plans for vizb.
 ---
 
-import { CardGrid, Card, Aside } from '@astrojs/starlight/components';
+import { CardGrid, Card } from '@astrojs/starlight/components';
 
 ## Current State
 
-Vizb currently supports:
+Vizb currently supports benchmark output from three languages across five frameworks:
 
-- **Go** — `go test -bench` output (raw text and JSON)
-- Single-file HTML output with embedded Vue.js visualization
-- Multi-dimensional grouping, tag-based merging, and GitHub Action integration
+- **Go** — `go test -bench` output (raw text and `-json`)
+- **Rust** — `cargo bench` via [Criterion](https://github.com/bheisler/criterion.rs) (`rs:criterion`) and [Divan](https://github.com/nvzqz/divan) (`rs:divan`)
+- **JavaScript / TypeScript** — [Vitest](https://vitest.dev) bench (`js:vitest`) and [Tinybench](https://github.com/tinylibs/tinybench) console.table (`js:tinybench`)
 
-## Future Language Support
+All parsers support multi-dimensional grouping, tag-based merging, time unit conversion, and filtering. See the [Parser Guide](/guides/parsers) for setup.
 
-Vizb aims to support benchmark output from other languages and tools:
+## Planned
 
 <CardGrid>
-  <Card title="Rust" icon="seti:rust">
-    Parse output from `cargo bench` and Criterion.rs. Bring the same multi-dimensional grouping and merge capabilities to Rust benchmarks.
-  </Card>
   <Card title="Python" icon="seti:python">
     Integrate with `pytest-benchmark` output. Generate interactive visualizations for Python performance testing.
   </Card>
-  <Card title="JavaScript / TypeScript" icon="seti:javascript">
-    Support benchmark.js and similar JS benchmarking tools. Visualize frontend and Node.js performance data.
+  <Card title="C++" icon="seti:cpp">
+    Parse output from Google Benchmark and similar C++ benchmarking frameworks. Bring multi-dimensional visualization to native performance testing.
+  </Card>
+  <Card title="Dart" icon="seti:dart">
+    Support the Dart benchmark harness (`benchmark_harness` package). Visualize Dart VM performance data.
   </Card>
   <Card title="Java" icon="seti:java">
     Parse output from JMH (Java Microbenchmark Harness) and similar Java benchmarking frameworks. Bring multi-dimensional visualization to JVM performance testing.
   </Card>
 </CardGrid>
-
-<Aside type="note">
-  Multi-language support is planned but not yet available. Contributions and feature requests are welcome on [GitHub](https://github.com/goptics/vizb/issues).
-</Aside>
 
 ## Contributing
 

--- a/docs/src/content/docs/ui/index.mdx
+++ b/docs/src/content/docs/ui/index.mdx
@@ -12,13 +12,13 @@ Vizb generates a single self-contained HTML file with a Vue.js-powered interacti
 Vizb supports three chart types, all rendered in a single view:
 
 <CardGrid>
-  <Card title="Bar Chart" icon="chart-bar">
+  <Card title="Bar Chart" icon="bars">
     Default chart type. Compare values across categories. Supports linear and logarithmic scale.
   </Card>
-  <Card title="Line Chart" icon="chart-line">
+  <Card title="Line Chart" icon="analytics">
     Track trends across X-axis values. Best for sequential data like input sizes or concurrency levels.
   </Card>
-  <Card title="Pie Chart" icon="pie">
+  <Card title="Pie Chart" icon="puzzle">
     Show proportional distribution. Useful for comparing relative sizes of benchmark results.
   </Card>
 </CardGrid>

--- a/pkg/parser/golang/golang.go
+++ b/pkg/parser/golang/golang.go
@@ -1,17 +1,21 @@
-package parser
+package golang
 
 import (
 	"bufio"
 	"encoding/json"
 	"io"
-	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/goptics/vizb/pkg/parser"
 	"github.com/goptics/vizb/shared"
 	"github.com/goptics/vizb/shared/utils"
 	"golang.org/x/perf/benchfmt"
 )
+
+func init() {
+	parser.Parsers["go"] = ParseGoBenchmark
+}
 
 func storeCpuCount(cpu string) {
 	if shared.CPUCount == 0 {
@@ -38,22 +42,7 @@ func parseBenchmarkName(name benchfmt.Name) (benchName string, cpu string) {
 	return
 }
 
-// shouldIncludeBenchmark returns true if the benchmark name should be included
-// based on the filter regex. If no filter is set, all benchmarks are included.
-func shouldIncludeBenchmark(benchName string) bool {
-	if shared.FlagState.FilterRegex == "" {
-		return true
-	}
-
-	filterRe, err := regexp.Compile(shared.FlagState.FilterRegex)
-	if err != nil {
-		shared.ExitWithError("Invalid filter regex", err)
-	}
-
-	return filterRe.MatchString(benchName)
-}
-
-func ParseBenchmarkData(filePath string) (results []shared.BenchmarkData) {
+func ParseGoBenchmark(filePath string) (results []shared.BenchmarkData) {
 	f := shared.MustOpenFile(filePath)
 	defer f.Close()
 
@@ -72,18 +61,11 @@ func ParseBenchmarkData(filePath string) (results []shared.BenchmarkData) {
 		shared.OS, shared.Arch, shared.Pkg, shared.CPU = result.GetConfig("goos"), result.GetConfig("goarch"), result.GetConfig("pkg"), result.GetConfig("cpu")
 		rawBenchName, cpuCore := parseBenchmarkName(result.Name)
 
-		if !shouldIncludeBenchmark(rawBenchName) {
+		if !parser.ShouldIncludeBenchmark(rawBenchName) {
 			continue
 		}
 
-		var group map[string]string
-		var err error
-
-		if shared.FlagState.GroupRegex != "" {
-			group, err = ParseBenchmarkNameWithRegex(rawBenchName, shared.FlagState.GroupRegex)
-		} else {
-			group, err = ParseBenchmarkNameToGroups(rawBenchName, shared.FlagState.GroupPattern)
-		}
+		group, err := parser.GroupBenchmarkName(rawBenchName)
 
 		if err != nil {
 			shared.ExitWithError("Error on parsing group from bench name", err)
@@ -115,8 +97,6 @@ func ParseBenchmarkData(filePath string) (results []shared.BenchmarkData) {
 					Value: utils.FormatNumber(value.Value, shared.FlagState.NumberUnit),
 				}
 			case "B/s", "MB/s", "GB/s":
-				// benchfmt only populates OrigValue/OrigUnit for MB/s
-				// For B/s and GB/s, fall back to Value/Unit
 				val, unit := value.OrigValue, value.OrigUnit
 
 				if val == 0 || unit == "" {
@@ -176,11 +156,7 @@ func ParseBenchmarkData(filePath string) (results []shared.BenchmarkData) {
 	return
 }
 
-// ConvertJsonBenchToText converts a JSON benchmark file to text format.
-// It reads JSON benchmark events from the input file and extracts the "output" field
-// from each event to create a text representation of the benchmark results.
-// Returns the path to the temporary text file containing the converted data.
-func ConvertJsonBenchToText(filePath string) string {
+func ConvertGoJsonBenchToText(filePath string) string {
 	f := shared.MustOpenFile(filePath)
 	tempFilePath := shared.MustCreateTempFile(shared.TempBenchFilePrefix, "txt")
 	tempFile := shared.MustCreateFile(tempFilePath)

--- a/pkg/parser/golang/golang_test.go
+++ b/pkg/parser/golang/golang_test.go
@@ -1,4 +1,4 @@
-package parser
+package golang
 
 import (
 	"bufio"
@@ -7,12 +7,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/goptics/vizb/pkg/parser"
 	"github.com/goptics/vizb/shared"
 )
 
 type testBlock struct {
 	name           string
-	benchContent   []string // List of events to encode as JSON
+	benchContent   []string
 	pattern        string
 	timeUnit       string
 	memUnit        string
@@ -22,13 +23,11 @@ type testBlock struct {
 	expectCPUCount int
 }
 
-func TestParseBenchmarkData(t *testing.T) {
-	// Save original flag state to restore after tests
+func TestParseGoBenchmark(t *testing.T) {
 	origTimeUnit := shared.FlagState.TimeUnit
 	origMemUnit := shared.FlagState.MemUnit
 	origAllocUnit := shared.FlagState.NumberUnit
 
-	// Restore flag state after tests
 	defer func() {
 		shared.FlagState.TimeUnit = origTimeUnit
 		shared.FlagState.MemUnit = origMemUnit
@@ -81,9 +80,9 @@ func TestParseBenchmarkData(t *testing.T) {
 					XAxis: "",
 					YAxis: "WithMem",
 					Stats: []shared.Stat{
-						{Type: "Execution Time (ms/op)", Value: 0.00}, // 123.45ns -> 0.00012345ms -> 0.00
-						{Type: "Memory Usage (KB/op)", Value: 0.06},   // 64B -> 0.0625KB -> 0.06
-						{Type: "Allocations (K/op)", Value: 0.00},     // 2 allocs -> 0.002K -> 0.00
+						{Type: "Execution Time (ms/op)", Value: 0.00},
+						{Type: "Memory Usage (KB/op)", Value: 0.06},
+						{Type: "Allocations (K/op)", Value: 0.00},
 					},
 				},
 			},
@@ -107,7 +106,7 @@ func TestParseBenchmarkData(t *testing.T) {
 					YAxis: "SubjectA",
 					Stats: []shared.Stat{
 						{Type: "Execution Time (ns/op)", Value: 123.45},
-						{Type: "Memory Usage (b/op)", Value: 512.0}, // 64*8=512 bits
+						{Type: "Memory Usage (b/op)", Value: 512.0},
 						{Type: "Allocations/op", Value: 2.0},
 					},
 				},
@@ -117,7 +116,7 @@ func TestParseBenchmarkData(t *testing.T) {
 					YAxis: "SubjectB",
 					Stats: []shared.Stat{
 						{Type: "Execution Time (ns/op)", Value: 234.56},
-						{Type: "Memory Usage (b/op)", Value: 1024.0}, // 128*8=1024 bits
+						{Type: "Memory Usage (b/op)", Value: 1024.0},
 						{Type: "Allocations/op", Value: 4.0},
 					},
 				},
@@ -314,18 +313,15 @@ func TestParseBenchmarkData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set up flag state for this test
 			shared.FlagState.TimeUnit = tt.timeUnit
 			shared.FlagState.MemUnit = tt.memUnit
 			shared.FlagState.NumberUnit = tt.allocUnit
 			shared.FlagState.GroupPattern = tt.pattern
 			shared.CPUCount = 0
 
-			// Create a temporary JSON file
 			tempDir := t.TempDir()
 			filePath := filepath.Join(tempDir, "bench.txt")
 
-			// Create JSON file with test content
 			file, err := os.Create(filePath)
 			if err != nil {
 				t.Fatalf("Failed to create test file: %v", err)
@@ -333,7 +329,8 @@ func TestParseBenchmarkData(t *testing.T) {
 
 			writer := bufio.NewWriter(file)
 			for _, event := range tt.benchContent {
-				writer.WriteString(event + "\n")
+				writer.WriteString(event)
+				writer.WriteString("\n")
 			}
 
 			if err := writer.Flush(); err != nil {
@@ -342,12 +339,10 @@ func TestParseBenchmarkData(t *testing.T) {
 
 			file.Close()
 
-			// Call the function under test
-			results := ParseBenchmarkData(filePath)
+			results := ParseGoBenchmark(filePath)
 
-			// Check results
 			if len(results) != len(tt.expected) {
-				t.Errorf("ParseBenchmarkData() returned %d results, expected %d", len(results), len(tt.expected))
+				t.Errorf("ParseGoBenchmark() returned %d results, expected %d", len(results), len(tt.expected))
 				return
 			}
 
@@ -368,7 +363,6 @@ func TestParseBenchmarkData(t *testing.T) {
 					t.Errorf("Result[%d].YAxis = %q, expected %q", i, actual.YAxis, expected.YAxis)
 				}
 
-				// Check stats
 				if len(actual.Stats) != len(expected.Stats) {
 					t.Errorf("Result[%d] has %d stats, expected %d", i, len(actual.Stats), len(expected.Stats))
 					continue
@@ -384,7 +378,6 @@ func TestParseBenchmarkData(t *testing.T) {
 					if actualStat.Type != expectedStat.Type {
 						t.Errorf("Result[%d].Stats[%d].Type = %q, expected %q", i, j, actualStat.Type, expectedStat.Type)
 					}
-					// For float comparisons, allow a small epsilon
 					if !almostEqual(actualStat.Value, expectedStat.Value, 0.001) {
 						t.Errorf("Result[%d].Stats[%d].Value = %f, expected %f", i, j, actualStat.Value, expectedStat.Value)
 					}
@@ -398,7 +391,6 @@ func TestParseBenchmarkData(t *testing.T) {
 	}
 }
 
-// Helper function to compare float values with tolerance
 func almostEqual(a, b, epsilon float64) bool {
 	diff := a - b
 	if diff < 0 {
@@ -407,19 +399,19 @@ func almostEqual(a, b, epsilon float64) bool {
 	return diff < epsilon
 }
 
-func TestConvertJsonBenchToText(t *testing.T) {
+func TestConvertGoJsonBenchToText(t *testing.T) {
 	tempDir := t.TempDir()
 
 	t.Run("Valid JSON events", func(t *testing.T) {
 		jsonFile := filepath.Join(tempDir, "events.json")
 		content := `{"Action":"output","Output":"BenchmarkA 100 100 ns/op\n"}
-{"Action":"output","Output":"BenchmarkB 200 200 ns/op\n"}`
+	{"Action":"output","Output":"BenchmarkB 200 200 ns/op\n"}`
 		err := os.WriteFile(jsonFile, []byte(content), 0644)
 		if err != nil {
 			t.Fatalf("Failed to write json file: %v", err)
 		}
 
-		txtFile := ConvertJsonBenchToText(jsonFile)
+		txtFile := ConvertGoJsonBenchToText(jsonFile)
 		defer os.Remove(txtFile)
 
 		txtContent, err := os.ReadFile(txtFile)
@@ -436,14 +428,14 @@ func TestConvertJsonBenchToText(t *testing.T) {
 	t.Run("Mixed actions", func(t *testing.T) {
 		jsonFile := filepath.Join(tempDir, "mixed.json")
 		content := `{"Action":"run","Test":"BenchmarkA"}
-{"Action":"output","Output":"BenchmarkA 100 100 ns/op\n"}
-{"Action":"pass","Test":"BenchmarkA"}`
+	{"Action":"output","Output":"BenchmarkA 100 100 ns/op\n"}
+	{"Action":"pass","Test":"BenchmarkA"}`
 		err := os.WriteFile(jsonFile, []byte(content), 0644)
 		if err != nil {
 			t.Fatalf("Failed to write json file: %v", err)
 		}
 
-		txtFile := ConvertJsonBenchToText(jsonFile)
+		txtFile := ConvertGoJsonBenchToText(jsonFile)
 		defer os.Remove(txtFile)
 
 		txtContent, err := os.ReadFile(txtFile)
@@ -459,7 +451,6 @@ func TestConvertJsonBenchToText(t *testing.T) {
 }
 
 func TestShouldIncludeBenchmark(t *testing.T) {
-	// Save original filter state
 	origFilter := shared.FlagState.FilterRegex
 	defer func() {
 		shared.FlagState.FilterRegex = origFilter
@@ -572,9 +563,10 @@ func TestShouldIncludeBenchmark(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			shared.FlagState.FilterRegex = tt.filter
-			result := shouldIncludeBenchmark(tt.benchName)
+
+			result := parser.ShouldIncludeBenchmark(tt.benchName)
 			if result != tt.expected {
-				t.Errorf("shouldIncludeBenchmark(%q) with filter %q = %v, expected %v",
+				t.Errorf("ShouldIncludeBenchmark(%q) with filter %q = %v, expected %v",
 					tt.benchName, tt.filter, result, tt.expected)
 			}
 		})

--- a/pkg/parser/golang/golang_test.go
+++ b/pkg/parser/golang/golang_test.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/goptics/vizb/pkg/parser"
 	"github.com/goptics/vizb/shared"
 )
@@ -323,9 +326,7 @@ func TestParseGoBenchmark(t *testing.T) {
 			filePath := filepath.Join(tempDir, "bench.txt")
 
 			file, err := os.Create(filePath)
-			if err != nil {
-				t.Fatalf("Failed to create test file: %v", err)
-			}
+			require.NoError(t, err, "Failed to create test file")
 
 			writer := bufio.NewWriter(file)
 			for _, event := range tt.benchContent {
@@ -333,7 +334,8 @@ func TestParseGoBenchmark(t *testing.T) {
 				writer.WriteString("\n")
 			}
 
-			if err := writer.Flush(); err != nil {
+			err = writer.Flush()
+			if err != nil {
 				log.Fatal(err)
 			}
 
@@ -341,62 +343,26 @@ func TestParseGoBenchmark(t *testing.T) {
 
 			results := ParseGoBenchmark(filePath)
 
-			if len(results) != len(tt.expected) {
-				t.Errorf("ParseGoBenchmark() returned %d results, expected %d", len(results), len(tt.expected))
-				return
-			}
+			require.Len(t, results, len(tt.expected), "ParseGoBenchmark() returned %d results, expected %d", len(results), len(tt.expected))
 
 			for i, expected := range tt.expected {
-				if i >= len(results) {
-					t.Errorf("Missing expected result at index %d", i)
-					continue
-				}
-
 				actual := results[i]
-				if actual.Name != expected.Name {
-					t.Errorf("Result[%d].Name = %q, expected %q", i, actual.Name, expected.Name)
-				}
-				if actual.XAxis != expected.XAxis {
-					t.Errorf("Result[%d].XAxis = %q, expected %q", i, actual.XAxis, expected.XAxis)
-				}
-				if actual.YAxis != expected.YAxis {
-					t.Errorf("Result[%d].YAxis = %q, expected %q", i, actual.YAxis, expected.YAxis)
-				}
+				assert.Equal(t, expected.Name, actual.Name, "Result[%d].Name mismatch", i)
+				assert.Equal(t, expected.XAxis, actual.XAxis, "Result[%d].XAxis mismatch", i)
+				assert.Equal(t, expected.YAxis, actual.YAxis, "Result[%d].YAxis mismatch", i)
 
-				if len(actual.Stats) != len(expected.Stats) {
-					t.Errorf("Result[%d] has %d stats, expected %d", i, len(actual.Stats), len(expected.Stats))
-					continue
-				}
+				require.Len(t, actual.Stats, len(expected.Stats), "Result[%d] stats count mismatch", i)
 
 				for j, expectedStat := range expected.Stats {
-					if j >= len(actual.Stats) {
-						t.Errorf("Missing expected stat at result[%d].Stats[%d]", i, j)
-						continue
-					}
-
 					actualStat := actual.Stats[j]
-					if actualStat.Type != expectedStat.Type {
-						t.Errorf("Result[%d].Stats[%d].Type = %q, expected %q", i, j, actualStat.Type, expectedStat.Type)
-					}
-					if !almostEqual(actualStat.Value, expectedStat.Value, 0.001) {
-						t.Errorf("Result[%d].Stats[%d].Value = %f, expected %f", i, j, actualStat.Value, expectedStat.Value)
-					}
+					assert.Equal(t, expectedStat.Type, actualStat.Type, "Result[%d].Stats[%d].Type mismatch", i, j)
+					assert.InDelta(t, expectedStat.Value, actualStat.Value, 0.001, "Result[%d].Stats[%d].Value mismatch", i, j)
 				}
 			}
 
-			if shared.CPUCount != tt.expectCPUCount {
-				t.Errorf("shared.CPUCount = %d, expected %d", shared.CPUCount, tt.expectCPUCount)
-			}
+			assert.Equal(t, tt.expectCPUCount, shared.CPUCount, "CPUCount mismatch")
 		})
 	}
-}
-
-func almostEqual(a, b, epsilon float64) bool {
-	diff := a - b
-	if diff < 0 {
-		diff = -diff
-	}
-	return diff < epsilon
 }
 
 func TestConvertGoJsonBenchToText(t *testing.T) {
@@ -407,22 +373,16 @@ func TestConvertGoJsonBenchToText(t *testing.T) {
 		content := `{"Action":"output","Output":"BenchmarkA 100 100 ns/op\n"}
 	{"Action":"output","Output":"BenchmarkB 200 200 ns/op\n"}`
 		err := os.WriteFile(jsonFile, []byte(content), 0644)
-		if err != nil {
-			t.Fatalf("Failed to write json file: %v", err)
-		}
+		require.NoError(t, err, "Failed to write json file")
 
 		txtFile := ConvertGoJsonBenchToText(jsonFile)
 		defer os.Remove(txtFile)
 
 		txtContent, err := os.ReadFile(txtFile)
-		if err != nil {
-			t.Fatalf("Failed to read result file: %v", err)
-		}
+		require.NoError(t, err, "Failed to read result file")
 
 		expected := "BenchmarkA 100 100 ns/op\nBenchmarkB 200 200 ns/op\n"
-		if string(txtContent) != expected {
-			t.Errorf("Expected content %q, got %q", expected, string(txtContent))
-		}
+		assert.Equal(t, expected, string(txtContent))
 	})
 
 	t.Run("Mixed actions", func(t *testing.T) {
@@ -431,22 +391,16 @@ func TestConvertGoJsonBenchToText(t *testing.T) {
 	{"Action":"output","Output":"BenchmarkA 100 100 ns/op\n"}
 	{"Action":"pass","Test":"BenchmarkA"}`
 		err := os.WriteFile(jsonFile, []byte(content), 0644)
-		if err != nil {
-			t.Fatalf("Failed to write json file: %v", err)
-		}
+		require.NoError(t, err, "Failed to write json file")
 
 		txtFile := ConvertGoJsonBenchToText(jsonFile)
 		defer os.Remove(txtFile)
 
 		txtContent, err := os.ReadFile(txtFile)
-		if err != nil {
-			t.Fatalf("Failed to read result file: %v", err)
-		}
+		require.NoError(t, err, "Failed to read result file")
 
 		expected := "BenchmarkA 100 100 ns/op\n"
-		if string(txtContent) != expected {
-			t.Errorf("Expected content %q, got %q", expected, string(txtContent))
-		}
+		assert.Equal(t, expected, string(txtContent))
 	})
 }
 
@@ -565,10 +519,7 @@ func TestShouldIncludeBenchmark(t *testing.T) {
 			shared.FlagState.FilterRegex = tt.filter
 
 			result := parser.ShouldIncludeBenchmark(tt.benchName)
-			if result != tt.expected {
-				t.Errorf("ShouldIncludeBenchmark(%q) with filter %q = %v, expected %v",
-					tt.benchName, tt.filter, result, tt.expected)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/parser/javascript/tinybench.go
+++ b/pkg/parser/javascript/tinybench.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/goptics/vizb/pkg/parser"
 	"github.com/goptics/vizb/shared"
+	"github.com/goptics/vizb/shared/utils"
 )
 
 func init() {
@@ -106,10 +107,10 @@ func ParseTinyBenchBenchmark(filename string) []shared.BenchmarkData {
 			XAxis: xAxis,
 			YAxis: yAxis,
 			Stats: []shared.Stat{
-				{Type: "Latency avg (ns)", Value: latencyAvg},
+				{Type: utils.CreateStatType("Latency avg", shared.FlagState.TimeUnit, ""), Value: utils.FormatTime(latencyAvg, shared.FlagState.TimeUnit)},
 				{Type: "Latency RME (%)", Value: latencyRME, Symbol: "±"},
-				{Type: "Latency med (ns)", Value: latencyMed},
-				{Type: "Latency MAD (ns)", Value: latencyMAD, Symbol: "±"},
+				{Type: utils.CreateStatType("Latency med", shared.FlagState.TimeUnit, ""), Value: utils.FormatTime(latencyMed, shared.FlagState.TimeUnit)},
+				{Type: utils.CreateStatType("Latency MAD", shared.FlagState.TimeUnit, ""), Value: utils.FormatTime(latencyMAD, shared.FlagState.TimeUnit), Symbol: "±"},
 				{Type: "Throughput avg (ops/s)", Value: throughputAvg},
 				{Type: "Throughput RME (%)", Value: throughputRME, Symbol: "±"},
 				{Type: "Throughput med (ops/s)", Value: throughputMed},

--- a/pkg/parser/javascript/tinybench.go
+++ b/pkg/parser/javascript/tinybench.go
@@ -1,0 +1,127 @@
+package javascript
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/goptics/vizb/pkg/parser"
+	"github.com/goptics/vizb/shared"
+)
+
+func init() {
+	parser.Parsers["js:tinybench"] = ParseTinyBenchBenchmark
+}
+
+var dataRowRe = regexp.MustCompile(`│\s*\d+\s*│\s*(.+)\s*│`)
+
+func parseMeanWithRME(s string) (mean, rme float64) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "'")
+	s = strings.TrimSuffix(s, "'")
+
+	parts := strings.Split(s, "±")
+	if len(parts) == 2 {
+		mean, _ = strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+		rmeStr := strings.TrimSpace(parts[1])
+		rmeStr = strings.TrimSuffix(rmeStr, "%")
+		rme, _ = strconv.ParseFloat(rmeStr, 64)
+	} else {
+		mean, _ = strconv.ParseFloat(strings.TrimSpace(s), 64)
+	}
+	return
+}
+
+func parseMedWithMAD(s string) (med, mad float64) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "'")
+	s = strings.TrimSuffix(s, "'")
+
+	parts := strings.Split(s, "±")
+	if len(parts) == 2 {
+		med, _ = strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+		mad, _ = strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+	} else {
+		med, _ = strconv.ParseFloat(strings.TrimSpace(s), 64)
+	}
+	return
+}
+
+func ParseTinyBenchBenchmark(filename string) []shared.BenchmarkData {
+	f, err := os.Open(filename)
+	if err != nil {
+		shared.ExitWithError("Error opening file", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	var results []shared.BenchmarkData
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if !strings.Contains(line, "│") || strings.Contains(line, "Task name") || strings.Contains(line, "┌") || strings.Contains(line, "├") || strings.Contains(line, "└") {
+			continue
+		}
+
+		match := dataRowRe.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+
+		columns := strings.Split(match[1], "│")
+		if len(columns) < 6 {
+			continue
+		}
+
+		taskName := strings.Trim(columns[0], " '")
+
+		if !parser.ShouldIncludeBenchmark(taskName) {
+			continue
+		}
+
+		latencyAvgStr := strings.Trim(columns[1], " '")
+		latencyMedStr := strings.Trim(columns[2], " '")
+		throughputAvgStr := strings.Trim(columns[3], " '")
+		throughputMedStr := strings.Trim(columns[4], " '")
+		samplesStr := strings.Trim(columns[5], " ")
+
+		latencyAvg, latencyRME := parseMeanWithRME(latencyAvgStr)
+		latencyMed, latencyMAD := parseMedWithMAD(latencyMedStr)
+		throughputAvg, throughputRME := parseMeanWithRME(throughputAvgStr)
+		throughputMed, throughputMAD := parseMedWithMAD(throughputMedStr)
+		samples, _ := strconv.ParseFloat(samplesStr, 64)
+
+		group, groupErr := parser.GroupBenchmarkName(taskName)
+		if groupErr != nil {
+			shared.ExitWithError("Error parsing tinybench name", groupErr)
+		}
+
+		benchName, xAxis, yAxis := group["name"], group["xAxis"], group["yAxis"]
+
+		results = append(results, shared.BenchmarkData{
+			Name:  benchName,
+			XAxis: xAxis,
+			YAxis: yAxis,
+			Stats: []shared.Stat{
+				{Type: "Latency avg (ns)", Value: latencyAvg},
+				{Type: "Latency RME (%)", Value: latencyRME, Symbol: "±"},
+				{Type: "Latency med (ns)", Value: latencyMed},
+				{Type: "Latency MAD (ns)", Value: latencyMAD, Symbol: "±"},
+				{Type: "Throughput avg (ops/s)", Value: throughputAvg},
+				{Type: "Throughput RME (%)", Value: throughputRME, Symbol: "±"},
+				{Type: "Throughput med (ops/s)", Value: throughputMed},
+				{Type: "Throughput MAD (ops/s)", Value: throughputMAD, Symbol: "±"},
+				{Type: "Samples", Value: samples},
+			},
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		shared.ExitWithError("failed to read file", err)
+	}
+
+	return results
+}

--- a/pkg/parser/javascript/tinybench_test.go
+++ b/pkg/parser/javascript/tinybench_test.go
@@ -1,0 +1,131 @@
+package javascript
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goptics/vizb/shared"
+)
+
+var testSortingTable = `┌─────────┬─────────────────────┬─────────────────────┬──────────────────┬────────────────────────┬────────────────────────┬─────────┐
+│ (index) │ Task name           │ Latency avg (ns)    │ Latency med (ns) │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
+├─────────┼─────────────────────┼─────────────────────┼──────────────────┼────────────────────────┼────────────────────────┼─────────┤
+│ 0       │ 'bubbleSort/100'    │ '3741.5 ± 0.18%'   │ '3703.0 ± 32.00' │ '268758 ± 0.02%'       │ '270051 ± 2354'        │ 267270  │
+│ 1       │ 'insertionSort/100' │ '1197.1 ± 0.11%'   │ '1170.0 ± 4.00'  │ '842678 ± 0.01%'       │ '854701 ± 2912'        │ 835384  │
+└─────────┴─────────────────────┴─────────────────────┴──────────────────┴────────────────────────┴────────────────────────┴─────────┘
+┌─────────┬─────────────────────┬──────────────────┬───────────────────┬────────────────────────┬────────────────────────┬─────────┐
+│ (index) │ Task name           │ Latency avg (ns) │ Latency med (ns)  │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
+├─────────┼─────────────────────┼──────────────────┼───────────────────┼────────────────────────┼────────────────────────┼─────────┤
+│ 0       │ 'bubbleSort/500'    │ '128536 ± 0.04%' │ '128559 ± 1105.5' │ '7782 ± 0.03%'         │ '7779 ± 67'            │ 7780    │
+│ 1       │ 'insertionSort/500' │ '32902 ± 0.09%'  │ '32676 ± 207.00'  │ '30427 ± 0.02%'        │ '30604 ± 194'          │ 30394   │
+└─────────┴─────────────────────┴──────────────────┴───────────────────┴────────────────────────┴────────────────────────┴─────────┘
+┌─────────┬──────────────────────┬───────────────────┬───────────────────┬────────────────────────┬────────────────────────┬─────────┐
+│ (index) │ Task name            │ Latency avg (ns)  │ Latency med (ns)  │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
+├─────────┼──────────────────────┼───────────────────┼───────────────────┼────────────────────────┼────────────────────────┼─────────┤
+│ 0       │ 'bubbleSort/2000'    │ '1731347 ± 0.11%' │ '1724439 ± 13108' │ '578 ± 0.10%'          │ '580 ± 4'              │ 578     │
+│ 1       │ 'insertionSort/2000' │ '512841 ± 0.05%'  │ '510806 ± 1017.5' │ '1950 ± 0.04%'         │ '1958 ± 4'             │ 1950    │
+└─────────┴──────────────────────┴───────────────────┴───────────────────┴────────────────────────┴────────────────────────┴─────────┘
+`
+
+func writeTestFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "bench.txt")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestParseTinyBenchBenchmark(t *testing.T) {
+	origPattern := shared.FlagState.GroupPattern
+	origFilter := shared.FlagState.FilterRegex
+	defer func() {
+		shared.FlagState.GroupPattern = origPattern
+		shared.FlagState.FilterRegex = origFilter
+	}()
+
+	t.Run("Real tinybench output from sorting.txt", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "n/y"
+		shared.FlagState.FilterRegex = ""
+
+		results := ParseTinyBenchBenchmark(writeTestFile(t, testSortingTable))
+
+		if len(results) == 0 {
+			t.Fatal("expected results, got none")
+		}
+
+		// Expect 6 rows: 2 sort algorithms x 3 sizes
+		if len(results) != 6 {
+			t.Fatalf("expected 6 results, got %d", len(results))
+		}
+
+		// First row: bubbleSort/100
+		assertStat(t, results[0].Stats[0], "Latency avg (ns)", 3741.5, "")
+		assertStat(t, results[0].Stats[1], "Latency RME (%)", 0.18, "±")
+		assertStat(t, results[0].Stats[2], "Latency med (ns)", 3703.0, "")
+		assertStat(t, results[0].Stats[3], "Latency MAD (ns)", 32.00, "±")
+		assertStat(t, results[0].Stats[4], "Throughput avg (ops/s)", 268758, "")
+		assertStat(t, results[0].Stats[5], "Throughput RME (%)", 0.02, "±")
+		assertStat(t, results[0].Stats[6], "Throughput med (ops/s)", 270051, "")
+		assertStat(t, results[0].Stats[7], "Throughput MAD (ops/s)", 2354, "±")
+		assertStat(t, results[0].Stats[8], "Samples", 267270, "")
+
+		if results[0].Name != "bubbleSort" {
+			t.Errorf("Name = %q, want %q", results[0].Name, "bubbleSort")
+		}
+		if results[0].YAxis != "100" {
+			t.Errorf("YAxis = %q, want %q", results[0].YAxis, "100")
+		}
+
+		// Last row: insertionSort/2000
+		last := results[5]
+		if last.Name != "insertionSort" {
+			t.Errorf("Name = %q, want %q", last.Name, "insertionSort")
+		}
+		if last.YAxis != "2000" {
+			t.Errorf("YAxis = %q, want %q", last.YAxis, "2000")
+		}
+		assertStat(t, last.Stats[0], "Latency avg (ns)", 512841, "")
+		assertStat(t, last.Stats[8], "Samples", 1950, "")
+	})
+
+	t.Run("Filter regex", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "n/y"
+		shared.FlagState.FilterRegex = "bubbleSort"
+
+		results := ParseTinyBenchBenchmark(writeTestFile(t, testSortingTable))
+
+		if len(results) != 3 {
+			t.Fatalf("expected 3 bubbleSort results, got %d", len(results))
+		}
+		for _, r := range results {
+			if r.Name != "bubbleSort" {
+				t.Errorf("unexpected Name = %q", r.Name)
+			}
+		}
+	})
+
+	t.Run("Empty file", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "y"
+		shared.FlagState.FilterRegex = ""
+
+		results := ParseTinyBenchBenchmark(writeTestFile(t, ""))
+		if len(results) != 0 {
+			t.Errorf("expected 0 results for empty file, got %d", len(results))
+		}
+	})
+}
+
+func assertStat(t *testing.T, s shared.Stat, expectedType string, expectedValue float64, expectedSymbol string) {
+	t.Helper()
+	if s.Type != expectedType {
+		t.Errorf("Stat type = %q, want %q", s.Type, expectedType)
+	}
+	if s.Value != expectedValue {
+		t.Errorf("Stat value = %f, want %f", s.Value, expectedValue)
+	}
+	if s.Symbol != expectedSymbol {
+		t.Errorf("Stat symbol = %q, want %q", s.Symbol, expectedSymbol)
+	}
+}

--- a/pkg/parser/javascript/tinybench_test.go
+++ b/pkg/parser/javascript/tinybench_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/goptics/vizb/shared"
+	"github.com/stretchr/testify/assert"
 )
 
 var testSortingTable = `┌─────────┬─────────────────────┬─────────────────────┬──────────────────┬────────────────────────┬────────────────────────┬─────────┐
@@ -37,6 +38,7 @@ func writeTestFile(t *testing.T, content string) string {
 	return path
 }
 
+
 func TestParseTinyBenchBenchmark(t *testing.T) {
 	origPattern := shared.FlagState.GroupPattern
 	origFilter := shared.FlagState.FilterRegex
@@ -53,14 +55,7 @@ func TestParseTinyBenchBenchmark(t *testing.T) {
 		shared.FlagState.TimeUnit = "ns"
 
 		results := ParseTinyBenchBenchmark(writeTestFile(t, testSortingTable))
-
-		if len(results) == 0 {
-			t.Fatal("expected results, got none")
-		}
-
-		if len(results) != 6 {
-			t.Fatalf("expected 6 results, got %d", len(results))
-		}
+		assert.Len(t, results, 6)
 
 		assertStat(t, results[0].Stats[0], "Latency avg (ns)", 3741.5, "")
 		assertStat(t, results[0].Stats[1], "Latency RME (%)", 0.18, "±")
@@ -72,20 +67,12 @@ func TestParseTinyBenchBenchmark(t *testing.T) {
 		assertStat(t, results[0].Stats[7], "Throughput MAD (ops/s)", 2354, "±")
 		assertStat(t, results[0].Stats[8], "Samples", 267270, "")
 
-		if results[0].Name != "bubbleSort" {
-			t.Errorf("Name = %q, want %q", results[0].Name, "bubbleSort")
-		}
-		if results[0].YAxis != "100" {
-			t.Errorf("YAxis = %q, want %q", results[0].YAxis, "100")
-		}
+		assert.Equal(t, "bubbleSort", results[0].Name)
+		assert.Equal(t, "100", results[0].YAxis)
 
 		last := results[5]
-		if last.Name != "insertionSort" {
-			t.Errorf("Name = %q, want %q", last.Name, "insertionSort")
-		}
-		if last.YAxis != "2000" {
-			t.Errorf("YAxis = %q, want %q", last.YAxis, "2000")
-		}
+		assert.Equal(t, "insertionSort", last.Name)
+		assert.Equal(t, "2000", last.YAxis)
 		assertStat(t, last.Stats[0], "Latency avg (ns)", 512841, "")
 		assertStat(t, last.Stats[8], "Samples", 1950, "")
 	})
@@ -96,12 +83,8 @@ func TestParseTinyBenchBenchmark(t *testing.T) {
 		shared.FlagState.TimeUnit = "us"
 
 		results := ParseTinyBenchBenchmark(writeTestFile(t, testSortingTable))
+		assert.Len(t, results, 6)
 
-		if len(results) != 6 {
-			t.Fatalf("expected 6 results, got %d", len(results))
-		}
-
-		// 3741.5 ns → 3.74 us
 		assertStat(t, results[0].Stats[0], "Latency avg (us)", 3.74, "")
 		assertStat(t, results[0].Stats[2], "Latency med (us)", 3.7, "")
 	})
@@ -112,14 +95,9 @@ func TestParseTinyBenchBenchmark(t *testing.T) {
 		shared.FlagState.TimeUnit = "ns"
 
 		results := ParseTinyBenchBenchmark(writeTestFile(t, testSortingTable))
-
-		if len(results) != 3 {
-			t.Fatalf("expected 3 bubbleSort results, got %d", len(results))
-		}
+		assert.Len(t, results, 3)
 		for _, r := range results {
-			if r.Name != "bubbleSort" {
-				t.Errorf("unexpected Name = %q", r.Name)
-			}
+			assert.Equal(t, "bubbleSort", r.Name)
 		}
 	})
 
@@ -129,21 +107,6 @@ func TestParseTinyBenchBenchmark(t *testing.T) {
 		shared.FlagState.TimeUnit = "ns"
 
 		results := ParseTinyBenchBenchmark(writeTestFile(t, ""))
-		if len(results) != 0 {
-			t.Errorf("expected 0 results for empty file, got %d", len(results))
-		}
+		assert.Empty(t, results)
 	})
-}
-
-func assertStat(t *testing.T, s shared.Stat, expectedType string, expectedValue float64, expectedSymbol string) {
-	t.Helper()
-	if s.Type != expectedType {
-		t.Errorf("Stat type = %q, want %q", s.Type, expectedType)
-	}
-	if s.Value != expectedValue {
-		t.Errorf("Stat value = %f, want %f", s.Value, expectedValue)
-	}
-	if s.Symbol != expectedSymbol {
-		t.Errorf("Stat symbol = %q, want %q", s.Symbol, expectedSymbol)
-	}
 }

--- a/pkg/parser/javascript/tinybench_test.go
+++ b/pkg/parser/javascript/tinybench_test.go
@@ -40,14 +40,17 @@ func writeTestFile(t *testing.T, content string) string {
 func TestParseTinyBenchBenchmark(t *testing.T) {
 	origPattern := shared.FlagState.GroupPattern
 	origFilter := shared.FlagState.FilterRegex
+	origTimeUnit := shared.FlagState.TimeUnit
 	defer func() {
 		shared.FlagState.GroupPattern = origPattern
 		shared.FlagState.FilterRegex = origFilter
+		shared.FlagState.TimeUnit = origTimeUnit
 	}()
 
 	t.Run("Real tinybench output from sorting.txt", func(t *testing.T) {
 		shared.FlagState.GroupPattern = "n/y"
 		shared.FlagState.FilterRegex = ""
+		shared.FlagState.TimeUnit = "ns"
 
 		results := ParseTinyBenchBenchmark(writeTestFile(t, testSortingTable))
 
@@ -55,12 +58,10 @@ func TestParseTinyBenchBenchmark(t *testing.T) {
 			t.Fatal("expected results, got none")
 		}
 
-		// Expect 6 rows: 2 sort algorithms x 3 sizes
 		if len(results) != 6 {
 			t.Fatalf("expected 6 results, got %d", len(results))
 		}
 
-		// First row: bubbleSort/100
 		assertStat(t, results[0].Stats[0], "Latency avg (ns)", 3741.5, "")
 		assertStat(t, results[0].Stats[1], "Latency RME (%)", 0.18, "±")
 		assertStat(t, results[0].Stats[2], "Latency med (ns)", 3703.0, "")
@@ -78,7 +79,6 @@ func TestParseTinyBenchBenchmark(t *testing.T) {
 			t.Errorf("YAxis = %q, want %q", results[0].YAxis, "100")
 		}
 
-		// Last row: insertionSort/2000
 		last := results[5]
 		if last.Name != "insertionSort" {
 			t.Errorf("Name = %q, want %q", last.Name, "insertionSort")
@@ -90,9 +90,26 @@ func TestParseTinyBenchBenchmark(t *testing.T) {
 		assertStat(t, last.Stats[8], "Samples", 1950, "")
 	})
 
+	t.Run("Unit conversion to us", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "n/y"
+		shared.FlagState.FilterRegex = ""
+		shared.FlagState.TimeUnit = "us"
+
+		results := ParseTinyBenchBenchmark(writeTestFile(t, testSortingTable))
+
+		if len(results) != 6 {
+			t.Fatalf("expected 6 results, got %d", len(results))
+		}
+
+		// 3741.5 ns → 3.74 us
+		assertStat(t, results[0].Stats[0], "Latency avg (us)", 3.74, "")
+		assertStat(t, results[0].Stats[2], "Latency med (us)", 3.7, "")
+	})
+
 	t.Run("Filter regex", func(t *testing.T) {
 		shared.FlagState.GroupPattern = "n/y"
 		shared.FlagState.FilterRegex = "bubbleSort"
+		shared.FlagState.TimeUnit = "ns"
 
 		results := ParseTinyBenchBenchmark(writeTestFile(t, testSortingTable))
 
@@ -109,6 +126,7 @@ func TestParseTinyBenchBenchmark(t *testing.T) {
 	t.Run("Empty file", func(t *testing.T) {
 		shared.FlagState.GroupPattern = "y"
 		shared.FlagState.FilterRegex = ""
+		shared.FlagState.TimeUnit = "ns"
 
 		results := ParseTinyBenchBenchmark(writeTestFile(t, ""))
 		if len(results) != 0 {

--- a/pkg/parser/javascript/vitest.go
+++ b/pkg/parser/javascript/vitest.go
@@ -63,7 +63,7 @@ func ParseVitestBenchmark(filename string) []shared.BenchmarkData {
 
 		name := fields[0]
 		if currentSuite != "" {
-			name = name + "/" + currentSuite
+			name = currentSuite + "/" + name
 		}
 
 		if !parser.ShouldIncludeBenchmark(name) {

--- a/pkg/parser/javascript/vitest.go
+++ b/pkg/parser/javascript/vitest.go
@@ -1,0 +1,117 @@
+package javascript
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/goptics/vizb/pkg/parser"
+	"github.com/goptics/vizb/shared"
+)
+
+func init() {
+	parser.Parsers["js:vitest"] = ParseVitestBenchmark
+}
+
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func parseNum(s string) float64 {
+	s = strings.ReplaceAll(s, ",", "")
+	n, _ := strconv.ParseFloat(s, 64)
+	return n
+}
+
+func ParseVitestBenchmark(filename string) []shared.BenchmarkData {
+	f, err := os.Open(filename)
+	if err != nil {
+		shared.ExitWithError("Error opening file", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	var results []shared.BenchmarkData
+	var currentSuite string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		line = ansiRe.ReplaceAllString(line, "")
+		line = strings.TrimLeftFunc(line, unicode.IsSpace)
+
+		if idx := strings.Index(line, ">"); idx >= 0 && strings.Contains(line, "ms") {
+			after := strings.TrimSpace(line[idx+1:])
+			parts := strings.Fields(after)
+			if len(parts) >= 2 {
+				currentSuite = strings.Join(parts[:len(parts)-1], " ")
+			}
+			continue
+		}
+
+		if !strings.HasPrefix(line, "·") {
+			continue
+		}
+
+		line = strings.TrimPrefix(line, "·")
+		line = strings.TrimSpace(line)
+
+		fields := strings.Fields(line)
+		if len(fields) < 11 {
+			continue
+		}
+
+		name := fields[0]
+		if currentSuite != "" {
+			name = name + "/" + currentSuite
+		}
+
+		if !parser.ShouldIncludeBenchmark(name) {
+			continue
+		}
+
+		hz := parseNum(fields[1])
+		minVal := parseNum(fields[2])
+		maxVal := parseNum(fields[3])
+		mean := parseNum(fields[4])
+		p75 := parseNum(fields[5])
+		p99 := parseNum(fields[6])
+		p995 := parseNum(fields[7])
+		p999 := parseNum(fields[8])
+		rmeStr := strings.TrimPrefix(fields[9], "±")
+		rmeStr = strings.TrimSuffix(rmeStr, "%")
+		rme := parseNum(rmeStr)
+		samples := parseNum(fields[10])
+
+		group, groupErr := parser.GroupBenchmarkName(name)
+		if groupErr != nil {
+			shared.ExitWithError("Error parsing vitest benchmark name", groupErr)
+		}
+
+		benchName, xAxis, yAxis := group["name"], group["xAxis"], group["yAxis"]
+
+		results = append(results, shared.BenchmarkData{
+			Name:  benchName,
+			XAxis: xAxis,
+			YAxis: yAxis,
+			Stats: []shared.Stat{
+				{Type: "Throughput avg (ops/s)", Value: hz},
+				{Type: "Latency min (ms)", Value: minVal},
+				{Type: "Latency max (ms)", Value: maxVal},
+				{Type: "Latency avg (ms)", Value: mean},
+				{Type: "Latency p75 (ms)", Value: p75},
+				{Type: "Latency p99 (ms)", Value: p99},
+				{Type: "Latency p995 (ms)", Value: p995},
+				{Type: "Latency p999 (ms)", Value: p999},
+				{Type: "RME (%)", Value: rme, Symbol: "±"},
+				{Type: "Samples", Value: samples},
+			},
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		shared.ExitWithError("failed to read file", err)
+	}
+
+	return results
+}

--- a/pkg/parser/javascript/vitest.go
+++ b/pkg/parser/javascript/vitest.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/goptics/vizb/pkg/parser"
 	"github.com/goptics/vizb/shared"
+	"github.com/goptics/vizb/shared/utils"
 )
 
 func init() {
@@ -96,13 +97,13 @@ func ParseVitestBenchmark(filename string) []shared.BenchmarkData {
 			YAxis: yAxis,
 			Stats: []shared.Stat{
 				{Type: "Throughput avg (ops/s)", Value: hz},
-				{Type: "Latency min (ms)", Value: minVal},
-				{Type: "Latency max (ms)", Value: maxVal},
-				{Type: "Latency avg (ms)", Value: mean},
-				{Type: "Latency p75 (ms)", Value: p75},
-				{Type: "Latency p99 (ms)", Value: p99},
-				{Type: "Latency p995 (ms)", Value: p995},
-				{Type: "Latency p999 (ms)", Value: p999},
+				{Type: utils.CreateStatType("Latency min", shared.FlagState.TimeUnit, ""), Value: utils.ConvertTime(minVal, "ms", shared.FlagState.TimeUnit)},
+				{Type: utils.CreateStatType("Latency max", shared.FlagState.TimeUnit, ""), Value: utils.ConvertTime(maxVal, "ms", shared.FlagState.TimeUnit)},
+				{Type: utils.CreateStatType("Latency avg", shared.FlagState.TimeUnit, ""), Value: utils.ConvertTime(mean, "ms", shared.FlagState.TimeUnit)},
+				{Type: utils.CreateStatType("Latency p75", shared.FlagState.TimeUnit, ""), Value: utils.ConvertTime(p75, "ms", shared.FlagState.TimeUnit)},
+				{Type: utils.CreateStatType("Latency p99", shared.FlagState.TimeUnit, ""), Value: utils.ConvertTime(p99, "ms", shared.FlagState.TimeUnit)},
+				{Type: utils.CreateStatType("Latency p995", shared.FlagState.TimeUnit, ""), Value: utils.ConvertTime(p995, "ms", shared.FlagState.TimeUnit)},
+				{Type: utils.CreateStatType("Latency p999", shared.FlagState.TimeUnit, ""), Value: utils.ConvertTime(p999, "ms", shared.FlagState.TimeUnit)},
 				{Type: "RME (%)", Value: rme, Symbol: "±"},
 				{Type: "Samples", Value: samples},
 			},

--- a/pkg/parser/javascript/vitest_test.go
+++ b/pkg/parser/javascript/vitest_test.go
@@ -1,0 +1,115 @@
+package javascript
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goptics/vizb/shared"
+)
+
+var testVitestTable = ` ✓ sort.bench.js > n=100 1356ms
+     name                   hz     min     max    mean     p75     p99    p995    p999     rme  samples
+   · bubbleSort     264,413.96  0.0037  0.0974  0.0038  0.0038  0.0049  0.0060  0.0076  ±0.09%   132207
+   · insertionSort  639,846.68  0.0015  0.1212  0.0016  0.0016  0.0024  0.0025  0.0034  ±0.14%   319924
+
+ ✓ sort.bench.js > n=500 1212ms
+     name                  hz     min     max    mean     p75     p99    p995    p999     rme  samples
+   · bubbleSort      7,715.01  0.1235  1.6623  0.1296  0.1298  0.1663  0.1713  0.1744  ±0.61%     3858
+   · insertionSort  30,632.50  0.0320  0.1858  0.0326  0.0329  0.0345  0.0357  0.0441  ±0.09%    15317
+
+ ✓ sort.bench.js > n=2000 1211ms
+     name                 hz     min     max    mean     p75     p99    p995    p999     rme  samples
+   · bubbleSort       581.49  1.6942  1.8435  1.7197  1.7342  1.8244  1.8252  1.8435  ±0.15%      291
+   · insertionSort  1,933.38  0.5139  0.5336  0.5172  0.5181  0.5278  0.5288  0.5336  ±0.05%      967
+`
+
+func TestParseVitestBenchmark(t *testing.T) {
+	origPattern := shared.FlagState.GroupPattern
+	origFilter := shared.FlagState.FilterRegex
+	defer func() {
+		shared.FlagState.GroupPattern = origPattern
+		shared.FlagState.FilterRegex = origFilter
+	}()
+
+	t.Run("Real vitest output from sort.bench.js", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "n/y"
+		shared.FlagState.FilterRegex = ""
+
+		results := ParseVitestBenchmark(writeVitestTestFile(t, testVitestTable))
+
+		if len(results) == 0 {
+			t.Fatal("expected results, got none")
+		}
+
+		// Expect 6 rows: 2 sort algorithms x 3 sizes
+		if len(results) != 6 {
+			t.Fatalf("expected 6 results, got %d", len(results))
+		}
+
+		// First row: n=100/bubbleSort → name=bubbleSort, yAxis=n=100
+		assertStat(t, results[0].Stats[0], "Throughput avg (ops/s)", 264413.96, "")
+		assertStat(t, results[0].Stats[1], "Latency min (ms)", 0.0037, "")
+		assertStat(t, results[0].Stats[2], "Latency max (ms)", 0.0974, "")
+		assertStat(t, results[0].Stats[3], "Latency avg (ms)", 0.0038, "")
+		assertStat(t, results[0].Stats[4], "Latency p75 (ms)", 0.0038, "")
+		assertStat(t, results[0].Stats[5], "Latency p99 (ms)", 0.0049, "")
+		assertStat(t, results[0].Stats[6], "Latency p995 (ms)", 0.006, "")
+		assertStat(t, results[0].Stats[7], "Latency p999 (ms)", 0.0076, "")
+		assertStat(t, results[0].Stats[8], "RME (%)", 0.09, "±")
+		assertStat(t, results[0].Stats[9], "Samples", 132207, "")
+
+		if results[0].Name != "bubbleSort" {
+			t.Errorf("Name = %q, want %q", results[0].Name, "bubbleSort")
+		}
+		if results[0].YAxis != "n=100" {
+			t.Errorf("YAxis = %q, want %q", results[0].YAxis, "n=100")
+		}
+
+		// Last row: n=2000/insertionSort
+		last := results[5]
+		if last.Name != "insertionSort" {
+			t.Errorf("Name = %q, want %q", last.Name, "insertionSort")
+		}
+		if last.YAxis != "n=2000" {
+			t.Errorf("YAxis = %q, want %q", last.YAxis, "n=2000")
+		}
+		assertStat(t, last.Stats[0], "Throughput avg (ops/s)", 1933.38, "")
+		assertStat(t, last.Stats[9], "Samples", 967, "")
+	})
+
+	t.Run("Filter regex", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "n/y"
+		shared.FlagState.FilterRegex = "bubbleSort"
+
+		results := ParseVitestBenchmark(writeVitestTestFile(t, testVitestTable))
+
+		if len(results) != 3 {
+			t.Fatalf("expected 3 bubbleSort results, got %d", len(results))
+		}
+		for _, r := range results {
+			if r.Name != "bubbleSort" {
+				t.Errorf("unexpected Name = %q", r.Name)
+			}
+		}
+	})
+
+	t.Run("Empty file", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "y"
+		shared.FlagState.FilterRegex = ""
+
+		results := ParseVitestBenchmark(writeVitestTestFile(t, ""))
+		if len(results) != 0 {
+			t.Errorf("expected 0 results for empty file, got %d", len(results))
+		}
+	})
+}
+
+func writeVitestTestFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "bench.txt")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/pkg/parser/javascript/vitest_test.go
+++ b/pkg/parser/javascript/vitest_test.go
@@ -27,14 +27,17 @@ var testVitestTable = ` ✓ sort.bench.js > n=100 1356ms
 func TestParseVitestBenchmark(t *testing.T) {
 	origPattern := shared.FlagState.GroupPattern
 	origFilter := shared.FlagState.FilterRegex
+	origTimeUnit := shared.FlagState.TimeUnit
 	defer func() {
 		shared.FlagState.GroupPattern = origPattern
 		shared.FlagState.FilterRegex = origFilter
+		shared.FlagState.TimeUnit = origTimeUnit
 	}()
 
 	t.Run("Real vitest output from sort.bench.js", func(t *testing.T) {
 		shared.FlagState.GroupPattern = "y/n"
 		shared.FlagState.FilterRegex = ""
+		shared.FlagState.TimeUnit = "ms"
 
 		results := ParseVitestBenchmark(writeVitestTestFile(t, testVitestTable))
 
@@ -42,12 +45,10 @@ func TestParseVitestBenchmark(t *testing.T) {
 			t.Fatal("expected results, got none")
 		}
 
-		// Expect 6 rows: 2 sort algorithms x 3 sizes
 		if len(results) != 6 {
 			t.Fatalf("expected 6 results, got %d", len(results))
 		}
 
-		// First row: n=100/bubbleSort → name=bubbleSort, yAxis=n=100
 		assertStat(t, results[0].Stats[0], "Throughput avg (ops/s)", 264413.96, "")
 		assertStat(t, results[0].Stats[1], "Latency min (ms)", 0.0037, "")
 		assertStat(t, results[0].Stats[2], "Latency max (ms)", 0.0974, "")
@@ -66,7 +67,6 @@ func TestParseVitestBenchmark(t *testing.T) {
 			t.Errorf("YAxis = %q, want %q", results[0].YAxis, "n=100")
 		}
 
-		// Last row: n=2000/insertionSort
 		last := results[5]
 		if last.Name != "insertionSort" {
 			t.Errorf("Name = %q, want %q", last.Name, "insertionSort")
@@ -78,9 +78,27 @@ func TestParseVitestBenchmark(t *testing.T) {
 		assertStat(t, last.Stats[9], "Samples", 967, "")
 	})
 
+	t.Run("Unit conversion to us", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "y/n"
+		shared.FlagState.FilterRegex = ""
+		shared.FlagState.TimeUnit = "us"
+
+		results := ParseVitestBenchmark(writeVitestTestFile(t, testVitestTable))
+
+		if len(results) != 6 {
+			t.Fatalf("expected 6 results, got %d", len(results))
+		}
+
+		// 0.0038 ms → 3.8 us
+		assertStat(t, results[0].Stats[3], "Latency avg (us)", 3.8, "")
+		// 0.0049 ms → 4.9 us
+		assertStat(t, results[0].Stats[5], "Latency p99 (us)", 4.9, "")
+	})
+
 	t.Run("Filter regex", func(t *testing.T) {
 		shared.FlagState.GroupPattern = "y/n"
 		shared.FlagState.FilterRegex = "bubbleSort"
+		shared.FlagState.TimeUnit = "ms"
 
 		results := ParseVitestBenchmark(writeVitestTestFile(t, testVitestTable))
 
@@ -97,6 +115,7 @@ func TestParseVitestBenchmark(t *testing.T) {
 	t.Run("Empty file", func(t *testing.T) {
 		shared.FlagState.GroupPattern = "y"
 		shared.FlagState.FilterRegex = ""
+		shared.FlagState.TimeUnit = "ms"
 
 		results := ParseVitestBenchmark(writeVitestTestFile(t, ""))
 		if len(results) != 0 {

--- a/pkg/parser/javascript/vitest_test.go
+++ b/pkg/parser/javascript/vitest_test.go
@@ -33,7 +33,7 @@ func TestParseVitestBenchmark(t *testing.T) {
 	}()
 
 	t.Run("Real vitest output from sort.bench.js", func(t *testing.T) {
-		shared.FlagState.GroupPattern = "n/y"
+		shared.FlagState.GroupPattern = "y/n"
 		shared.FlagState.FilterRegex = ""
 
 		results := ParseVitestBenchmark(writeVitestTestFile(t, testVitestTable))
@@ -79,7 +79,7 @@ func TestParseVitestBenchmark(t *testing.T) {
 	})
 
 	t.Run("Filter regex", func(t *testing.T) {
-		shared.FlagState.GroupPattern = "n/y"
+		shared.FlagState.GroupPattern = "y/n"
 		shared.FlagState.FilterRegex = "bubbleSort"
 
 		results := ParseVitestBenchmark(writeVitestTestFile(t, testVitestTable))

--- a/pkg/parser/javascript/vitest_test.go
+++ b/pkg/parser/javascript/vitest_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/goptics/vizb/shared"
+	"github.com/stretchr/testify/assert"
 )
 
 var testVitestTable = ` ✓ sort.bench.js > n=100 1356ms
@@ -24,6 +25,22 @@ var testVitestTable = ` ✓ sort.bench.js > n=100 1356ms
    · insertionSort  1,933.38  0.5139  0.5336  0.5172  0.5181  0.5278  0.5288  0.5336  ±0.05%      967
 `
 
+func writeVitestTestFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "bench.txt")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func assertStat(t *testing.T, s shared.Stat, expectedType string, expectedValue float64, expectedSymbol string) {
+	t.Helper()
+	assert.Equal(t, expectedType, s.Type, "stat type mismatch")
+	assert.Equal(t, expectedValue, s.Value, "stat value mismatch")
+	assert.Equal(t, expectedSymbol, s.Symbol, "stat symbol mismatch")
+}
+
 func TestParseVitestBenchmark(t *testing.T) {
 	origPattern := shared.FlagState.GroupPattern
 	origFilter := shared.FlagState.FilterRegex
@@ -40,14 +57,7 @@ func TestParseVitestBenchmark(t *testing.T) {
 		shared.FlagState.TimeUnit = "ms"
 
 		results := ParseVitestBenchmark(writeVitestTestFile(t, testVitestTable))
-
-		if len(results) == 0 {
-			t.Fatal("expected results, got none")
-		}
-
-		if len(results) != 6 {
-			t.Fatalf("expected 6 results, got %d", len(results))
-		}
+		assert.Len(t, results, 6)
 
 		assertStat(t, results[0].Stats[0], "Throughput avg (ops/s)", 264413.96, "")
 		assertStat(t, results[0].Stats[1], "Latency min (ms)", 0.0037, "")
@@ -60,20 +70,12 @@ func TestParseVitestBenchmark(t *testing.T) {
 		assertStat(t, results[0].Stats[8], "RME (%)", 0.09, "±")
 		assertStat(t, results[0].Stats[9], "Samples", 132207, "")
 
-		if results[0].Name != "bubbleSort" {
-			t.Errorf("Name = %q, want %q", results[0].Name, "bubbleSort")
-		}
-		if results[0].YAxis != "n=100" {
-			t.Errorf("YAxis = %q, want %q", results[0].YAxis, "n=100")
-		}
+		assert.Equal(t, "bubbleSort", results[0].Name)
+		assert.Equal(t, "n=100", results[0].YAxis)
 
 		last := results[5]
-		if last.Name != "insertionSort" {
-			t.Errorf("Name = %q, want %q", last.Name, "insertionSort")
-		}
-		if last.YAxis != "n=2000" {
-			t.Errorf("YAxis = %q, want %q", last.YAxis, "n=2000")
-		}
+		assert.Equal(t, "insertionSort", last.Name)
+		assert.Equal(t, "n=2000", last.YAxis)
 		assertStat(t, last.Stats[0], "Throughput avg (ops/s)", 1933.38, "")
 		assertStat(t, last.Stats[9], "Samples", 967, "")
 	})
@@ -84,14 +86,9 @@ func TestParseVitestBenchmark(t *testing.T) {
 		shared.FlagState.TimeUnit = "us"
 
 		results := ParseVitestBenchmark(writeVitestTestFile(t, testVitestTable))
+		assert.Len(t, results, 6)
 
-		if len(results) != 6 {
-			t.Fatalf("expected 6 results, got %d", len(results))
-		}
-
-		// 0.0038 ms → 3.8 us
 		assertStat(t, results[0].Stats[3], "Latency avg (us)", 3.8, "")
-		// 0.0049 ms → 4.9 us
 		assertStat(t, results[0].Stats[5], "Latency p99 (us)", 4.9, "")
 	})
 
@@ -101,14 +98,9 @@ func TestParseVitestBenchmark(t *testing.T) {
 		shared.FlagState.TimeUnit = "ms"
 
 		results := ParseVitestBenchmark(writeVitestTestFile(t, testVitestTable))
-
-		if len(results) != 3 {
-			t.Fatalf("expected 3 bubbleSort results, got %d", len(results))
-		}
+		assert.Len(t, results, 3)
 		for _, r := range results {
-			if r.Name != "bubbleSort" {
-				t.Errorf("unexpected Name = %q", r.Name)
-			}
+			assert.Equal(t, "bubbleSort", r.Name)
 		}
 	})
 
@@ -118,17 +110,6 @@ func TestParseVitestBenchmark(t *testing.T) {
 		shared.FlagState.TimeUnit = "ms"
 
 		results := ParseVitestBenchmark(writeVitestTestFile(t, ""))
-		if len(results) != 0 {
-			t.Errorf("expected 0 results for empty file, got %d", len(results))
-		}
+		assert.Empty(t, results)
 	})
-}
-
-func writeVitestTestFile(t *testing.T, content string) string {
-	t.Helper()
-	path := filepath.Join(t.TempDir(), "bench.txt")
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-		t.Fatal(err)
-	}
-	return path
 }

--- a/pkg/parser/parse_pattern.go
+++ b/pkg/parser/parse_pattern.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/goptics/vizb/shared"
 )
 
 var separatorRegex = regexp.MustCompile(`[_/]`)
@@ -164,4 +166,12 @@ func ParseBenchmarkNameWithRegex(name, pattern string) (map[string]string, error
 	}
 
 	return result, nil
+}
+
+func GroupBenchmarkName(name string) (map[string]string, error) {
+	if shared.FlagState.GroupRegex != "" {
+		return ParseBenchmarkNameWithRegex(name, shared.FlagState.GroupRegex)
+	}
+
+	return ParseBenchmarkNameToGroups(name, shared.FlagState.GroupPattern)
 }

--- a/pkg/parser/parse_pattern_test.go
+++ b/pkg/parser/parse_pattern_test.go
@@ -1,8 +1,10 @@
 package parser
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseNameToGroups(t *testing.T) {
@@ -80,7 +82,6 @@ func TestParseNameToGroups(t *testing.T) {
 			},
 			expectError: false,
 		},
-		// Subject and workload without name
 		{
 			name:          "yAxis and xAxis without name: y/x pattern",
 			benchmarkName: "Rivet_GPlusStatic/100k",
@@ -92,7 +93,6 @@ func TestParseNameToGroups(t *testing.T) {
 			},
 			expectError: false,
 		},
-		// Complex name with multiple underscores
 		{
 			name:          "Complex name: name_yAxis pattern with multi-part name",
 			benchmarkName: "MyLib_ComplexFunction_TestCase",
@@ -104,7 +104,6 @@ func TestParseNameToGroups(t *testing.T) {
 			},
 			expectError: false,
 		},
-		// Empty pattern
 		{
 			name:          "Empty pattern",
 			benchmarkName: "Rivet",
@@ -113,7 +112,6 @@ func TestParseNameToGroups(t *testing.T) {
 			expectError:   true,
 			errorContains: "pattern cannot be empty",
 		},
-		// Mixed separators
 		{
 			name:          "Mixed separators: underscore and slash",
 			benchmarkName: "Rivet_GPlusStatic/100k_extra",
@@ -135,7 +133,6 @@ func TestParseNameToGroups(t *testing.T) {
 				"xAxis": "Workload",
 			},
 		},
-		// Not enough parts in benchmark name
 		{
 			name:          "Not enough parts in benchmark name",
 			benchmarkName: "Rivet",
@@ -154,24 +151,15 @@ func TestParseNameToGroups(t *testing.T) {
 			result, err := ParseBenchmarkNameToGroups(tt.benchmarkName, tt.pattern)
 
 			if tt.expectError {
-				if err == nil {
-					t.Errorf("Expected error but got none")
-					return
-				}
-				if tt.errorContains != "" && !contains(err.Error(), tt.errorContains) {
-					t.Errorf("Expected error to contain '%s', but got '%s'", tt.errorContains, err.Error())
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
 				}
 				return
 			}
 
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-				return
-			}
-
-			if !reflect.DeepEqual(result, tt.expected) {
-				t.Errorf("Expected %v, but got %v", tt.expected, result)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
@@ -218,18 +206,18 @@ func TestValidateGroupPattern(t *testing.T) {
 		{
 			name:        "Valid pattern: xAxis without yAxis",
 			pattern:     "name_xAxis",
-			expectError: false, // Only requires xAxis OR yAxis
+			expectError: false,
 		},
 		{
 			name:          "Invalid pattern: name only (missing xAxis and yAxis)",
 			pattern:       "name",
-			expectError:   true, // Must have xAxis or yAxis
+			expectError:   true,
 			errorContains: "pattern must contain xAxis (x) or yAxis (y)",
 		},
 		{
 			name:        "Valid pattern: xAxis only",
 			pattern:     "xAxis",
-			expectError: false, // Only requires xAxis OR yAxis
+			expectError: false,
 		},
 	}
 
@@ -238,19 +226,14 @@ func TestValidateGroupPattern(t *testing.T) {
 			err := ValidateGroupPattern(tt.pattern)
 
 			if tt.expectError {
-				if err == nil {
-					t.Errorf("Expected error but got none")
-					return
-				}
-				if tt.errorContains != "" && !contains(err.Error(), tt.errorContains) {
-					t.Errorf("Expected error to contain '%s', but got '%s'", tt.errorContains, err.Error())
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
 				}
 				return
 			}
 
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-			}
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -271,27 +254,9 @@ func TestExpandShorthand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			result := expandShorthand(tt.input)
-			if result != tt.expected {
-				t.Errorf("expandShorthand(%s) = %s, want %s", tt.input, result, tt.expected)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
-}
-
-// Helper function to check if a string contains a substring
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || (len(s) > len(substr) &&
-		(s[:len(substr)] == substr || s[len(s)-len(substr):] == substr ||
-			indexOfSubstring(s, substr) >= 0)))
-}
-
-func indexOfSubstring(s, substr string) int {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return i
-		}
-	}
-	return -1
 }
 
 func TestParseNameWithRegex(t *testing.T) {
@@ -347,7 +312,7 @@ func TestParseNameWithRegex(t *testing.T) {
 		{
 			name:          "Invalid Regex Syntax",
 			benchmarkName: "Hashing64MD5",
-			pattern:       `(?<n>Hashing64)(?<y>.*`, // Missing closing parenthesis
+			pattern:       `(?<n>Hashing64)(?<y>.*`,
 			expected:      nil,
 			expectError:   true,
 			errorContains: "invalid regex pattern",
@@ -397,24 +362,15 @@ func TestParseNameWithRegex(t *testing.T) {
 			result, err := ParseBenchmarkNameWithRegex(tt.benchmarkName, tt.pattern)
 
 			if tt.expectError {
-				if err == nil {
-					t.Errorf("Expected error but got none")
-					return
-				}
-				if tt.errorContains != "" && !contains(err.Error(), tt.errorContains) {
-					t.Errorf("Expected error to contain '%s', but got '%s'", tt.errorContains, err.Error())
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
 				}
 				return
 			}
 
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-				return
-			}
-
-			if !reflect.DeepEqual(result, tt.expected) {
-				t.Errorf("Expected %v, but got %v", tt.expected, result)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/parser/registry.go
+++ b/pkg/parser/registry.go
@@ -1,0 +1,43 @@
+package parser
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+
+	"github.com/goptics/vizb/shared"
+)
+
+type ParseFunc func(filename string) []shared.BenchmarkData
+
+var Parsers = map[string]ParseFunc{}
+
+func GetParser(key string) (ParseFunc, error) {
+	fn, ok := Parsers[key]
+	if !ok {
+		return nil, fmt.Errorf("unknown parser '%s'; available parsers: %v", key, AvailableParsers())
+	}
+	return fn, nil
+}
+
+func AvailableParsers() []string {
+	keys := make([]string, 0, len(Parsers))
+	for k := range Parsers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func ShouldIncludeBenchmark(benchName string) bool {
+	if shared.FlagState.FilterRegex == "" {
+		return true
+	}
+
+	filterRe, err := regexp.Compile(shared.FlagState.FilterRegex)
+	if err != nil {
+		shared.ExitWithError("Invalid filter regex", err)
+	}
+
+	return filterRe.MatchString(benchName)
+}

--- a/pkg/parser/rust/cargo.go
+++ b/pkg/parser/rust/cargo.go
@@ -1,0 +1,97 @@
+package rust
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/goptics/vizb/pkg/parser"
+	"github.com/goptics/vizb/shared"
+	"github.com/goptics/vizb/shared/utils"
+)
+
+func init() {
+	parser.Parsers["rs:cargo"] = ParseCargoBenchmark
+}
+
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+var criterionRe = regexp.MustCompile(`^(\S+)\s+time:\s+\[([\d.]+)\s*(ns|µs|μs|ms|s)\s+([\d.]+)\s*(ns|µs|μs|ms|s)\s+([\d.]+)\s*(ns|µs|μs|ms|s)\]`)
+
+func toNsMultiplier(unit string) float64 {
+	switch unit {
+	case "ns":
+		return 1
+	case "µs", "μs":
+		return 1e3
+	case "ms":
+		return 1e6
+	case "s":
+		return 1e9
+	}
+	return 1
+}
+
+func parseNum(s string) float64 {
+	s = strings.ReplaceAll(s, ",", "")
+	n, _ := strconv.ParseFloat(s, 64)
+	return n
+}
+
+func ParseCargoBenchmark(filename string) []shared.BenchmarkData {
+	f, err := os.Open(filename)
+	if err != nil {
+		shared.ExitWithError("Error opening file", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	var results []shared.BenchmarkData
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		line = ansiRe.ReplaceAllString(line, "")
+		line = strings.TrimLeftFunc(line, unicode.IsSpace)
+
+		match := criterionRe.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+
+		name := match[1]
+		if !parser.ShouldIncludeBenchmark(name) {
+			continue
+		}
+
+		lowerNs := parseNum(match[2]) * toNsMultiplier(match[3])
+		estimateNs := parseNum(match[4]) * toNsMultiplier(match[5])
+		upperNs := parseNum(match[6]) * toNsMultiplier(match[7])
+
+		group, groupErr := parser.GroupBenchmarkName(name)
+		if groupErr != nil {
+			shared.ExitWithError("Error parsing cargo benchmark name", groupErr)
+		}
+
+		benchName, xAxis, yAxis := group["name"], group["xAxis"], group["yAxis"]
+
+		results = append(results, shared.BenchmarkData{
+			Name:  benchName,
+			XAxis: xAxis,
+			YAxis: yAxis,
+			Stats: []shared.Stat{
+				{Type: utils.CreateStatType("Latency avg", shared.FlagState.TimeUnit, ""), Value: utils.ConvertTime(estimateNs, "ns", shared.FlagState.TimeUnit)},
+				{Type: utils.CreateStatType("Latency lower", shared.FlagState.TimeUnit, ""), Value: utils.ConvertTime(lowerNs, "ns", shared.FlagState.TimeUnit)},
+				{Type: utils.CreateStatType("Latency upper", shared.FlagState.TimeUnit, ""), Value: utils.ConvertTime(upperNs, "ns", shared.FlagState.TimeUnit), Symbol: "±"},
+			},
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		shared.ExitWithError("failed to read file", err)
+	}
+
+	return results
+}

--- a/pkg/parser/rust/cargo_test.go
+++ b/pkg/parser/rust/cargo_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/goptics/vizb/shared"
+	"github.com/stretchr/testify/assert"
 )
 
 var testCargoTable = `running 0 tests
@@ -64,15 +65,9 @@ func writeTestFile(t *testing.T, content string) string {
 
 func assertStat(t *testing.T, s shared.Stat, expectedType string, expectedValue float64, expectedSymbol string) {
 	t.Helper()
-	if s.Type != expectedType {
-		t.Errorf("Stat type = %q, want %q", s.Type, expectedType)
-	}
-	if s.Value != expectedValue {
-		t.Errorf("Stat value = %f, want %f", s.Value, expectedValue)
-	}
-	if s.Symbol != expectedSymbol {
-		t.Errorf("Stat symbol = %q, want %q", s.Symbol, expectedSymbol)
-	}
+	assert.Equal(t, expectedType, s.Type, "stat type mismatch")
+	assert.Equal(t, expectedValue, s.Value, "stat value mismatch")
+	assert.Equal(t, expectedSymbol, s.Symbol, "stat symbol mismatch")
 }
 
 func TestParseCargoBenchmark(t *testing.T) {
@@ -91,22 +86,15 @@ func TestParseCargoBenchmark(t *testing.T) {
 		shared.FlagState.TimeUnit = "ns"
 
 		results := ParseCargoBenchmark(writeTestFile(t, testCargoTable))
-
-		if len(results) != 6 {
-			t.Fatalf("expected 6 results, got %d", len(results))
-		}
+		assert.Len(t, results, 6)
 
 		// First: bubbleSort/n=100 → 3.0524 µs = 3052.4 ns
 		assertStat(t, results[0].Stats[0], "Latency avg (ns)", 3052.4, "")
 		assertStat(t, results[0].Stats[1], "Latency lower (ns)", 3042.4, "")
 		assertStat(t, results[0].Stats[2], "Latency upper (ns)", 3063.7, "±")
 
-		if results[0].Name != "bubbleSort" {
-			t.Errorf("Name = %q, want %q", results[0].Name, "bubbleSort")
-		}
-		if results[0].YAxis != "n=100" {
-			t.Errorf("YAxis = %q, want %q", results[0].YAxis, "n=100")
-		}
+		assert.Equal(t, "bubbleSort", results[0].Name)
+		assert.Equal(t, "n=100", results[0].YAxis)
 
 		// Second: insertionSort/n=100 → 821.61 ns (already in ns)
 		assertStat(t, results[1].Stats[0], "Latency avg (ns)", 821.61, "")
@@ -118,12 +106,8 @@ func TestParseCargoBenchmark(t *testing.T) {
 
 		// Last: insertionSort/n=2000 → 300.19 µs = 300190 ns
 		assertStat(t, results[5].Stats[0], "Latency avg (ns)", 300190, "")
-		if results[5].Name != "insertionSort" {
-			t.Errorf("Name = %q, want %q", results[5].Name, "insertionSort")
-		}
-		if results[5].YAxis != "n=2000" {
-			t.Errorf("YAxis = %q, want %q", results[5].YAxis, "n=2000")
-		}
+		assert.Equal(t, "insertionSort", results[5].Name)
+		assert.Equal(t, "n=2000", results[5].YAxis)
 	})
 
 	t.Run("Unit conversion to us", func(t *testing.T) {
@@ -132,16 +116,10 @@ func TestParseCargoBenchmark(t *testing.T) {
 		shared.FlagState.TimeUnit = "us"
 
 		results := ParseCargoBenchmark(writeTestFile(t, testCargoTable))
+		assert.Len(t, results, 6)
 
-		if len(results) != 6 {
-			t.Fatalf("expected 6 results, got %d", len(results))
-		}
-
-		// 3052.4 ns → 3.05 us
 		assertStat(t, results[0].Stats[0], "Latency avg (us)", 3.05, "")
-		// 821.61 ns → 0.82 us
 		assertStat(t, results[1].Stats[0], "Latency avg (us)", 0.82, "")
-		// 1382700 ns → 1382.7 us
 		assertStat(t, results[4].Stats[0], "Latency avg (us)", 1382.7, "")
 	})
 
@@ -151,14 +129,9 @@ func TestParseCargoBenchmark(t *testing.T) {
 		shared.FlagState.TimeUnit = "ns"
 
 		results := ParseCargoBenchmark(writeTestFile(t, testCargoTable))
-
-		if len(results) != 3 {
-			t.Fatalf("expected 3 bubbleSort results, got %d", len(results))
-		}
+		assert.Len(t, results, 3)
 		for _, r := range results {
-			if r.Name != "bubbleSort" {
-				t.Errorf("unexpected Name = %q", r.Name)
-			}
+			assert.Equal(t, "bubbleSort", r.Name)
 		}
 	})
 
@@ -168,8 +141,6 @@ func TestParseCargoBenchmark(t *testing.T) {
 		shared.FlagState.TimeUnit = "ns"
 
 		results := ParseCargoBenchmark(writeTestFile(t, ""))
-		if len(results) != 0 {
-			t.Errorf("expected 0 results for empty file, got %d", len(results))
-		}
+		assert.Empty(t, results)
 	})
 }

--- a/pkg/parser/rust/cargo_test.go
+++ b/pkg/parser/rust/cargo_test.go
@@ -1,0 +1,175 @@
+package rust
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goptics/vizb/shared"
+)
+
+var testCargoTable = `running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+bubbleSort/n=100        time:   [3.0424 µs 3.0524 µs 3.0637 µs]
+                        change: [+3.5450% +4.5929% +5.7731%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 12 outliers among 100 measurements (12.00%)
+  3 (3.00%) high mild
+  9 (9.00%) high severe
+
+insertionSort/n=100     time:   [819.49 ns 821.61 ns 824.50 ns]
+                        change: [+31.070% +32.526% +33.878%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 22 outliers among 100 measurements (22.00%)
+  1 (1.00%) low severe
+  11 (11.00%) low mild
+  2 (2.00%) high mild
+  8 (8.00%) high severe
+
+bubbleSort/n=500        time:   [104.13 µs 104.31 µs 104.48 µs]
+                        change: [+0.5028% +0.6664% +0.8369%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 8 outliers among 100 measurements (8.00%)
+  4 (4.00%) low severe
+  3 (3.00%) low mild
+  1 (1.00%) high severe
+
+insertionSort/n=500     time:   [21.731 µs 21.780 µs 21.836 µs]
+                        change: [+1.2200% +1.5261% +1.8205%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+
+bubbleSort/n=2000       time:   [1.3804 ms 1.3827 ms 1.3851 ms]
+                        change: [+1.1242% +1.8427% +2.9253%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 2 outliers among 100 measurements (2.00%)
+  2 (2.00%) high severe
+
+insertionSort/n=2000    time:   [299.74 µs 300.19 µs 300.69 µs]
+                        change: [+0.9356% +1.2778% +1.6400%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 3 outliers among 100 measurements (3.00%)
+  3 (3.00%) high mild
+`
+
+func writeTestFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "bench.txt")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func assertStat(t *testing.T, s shared.Stat, expectedType string, expectedValue float64, expectedSymbol string) {
+	t.Helper()
+	if s.Type != expectedType {
+		t.Errorf("Stat type = %q, want %q", s.Type, expectedType)
+	}
+	if s.Value != expectedValue {
+		t.Errorf("Stat value = %f, want %f", s.Value, expectedValue)
+	}
+	if s.Symbol != expectedSymbol {
+		t.Errorf("Stat symbol = %q, want %q", s.Symbol, expectedSymbol)
+	}
+}
+
+func TestParseCargoBenchmark(t *testing.T) {
+	origPattern := shared.FlagState.GroupPattern
+	origFilter := shared.FlagState.FilterRegex
+	origTimeUnit := shared.FlagState.TimeUnit
+	defer func() {
+		shared.FlagState.GroupPattern = origPattern
+		shared.FlagState.FilterRegex = origFilter
+		shared.FlagState.TimeUnit = origTimeUnit
+	}()
+
+	t.Run("Real cargo criterion output", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "n/y"
+		shared.FlagState.FilterRegex = ""
+		shared.FlagState.TimeUnit = "ns"
+
+		results := ParseCargoBenchmark(writeTestFile(t, testCargoTable))
+
+		if len(results) != 6 {
+			t.Fatalf("expected 6 results, got %d", len(results))
+		}
+
+		// First: bubbleSort/n=100 → 3.0524 µs = 3052.4 ns
+		assertStat(t, results[0].Stats[0], "Latency avg (ns)", 3052.4, "")
+		assertStat(t, results[0].Stats[1], "Latency lower (ns)", 3042.4, "")
+		assertStat(t, results[0].Stats[2], "Latency upper (ns)", 3063.7, "±")
+
+		if results[0].Name != "bubbleSort" {
+			t.Errorf("Name = %q, want %q", results[0].Name, "bubbleSort")
+		}
+		if results[0].YAxis != "n=100" {
+			t.Errorf("YAxis = %q, want %q", results[0].YAxis, "n=100")
+		}
+
+		// Second: insertionSort/n=100 → 821.61 ns (already in ns)
+		assertStat(t, results[1].Stats[0], "Latency avg (ns)", 821.61, "")
+		assertStat(t, results[1].Stats[1], "Latency lower (ns)", 819.49, "")
+		assertStat(t, results[1].Stats[2], "Latency upper (ns)", 824.5, "±")
+
+		// Fifth: bubbleSort/n=2000 → 1.3827 ms = 1382700 ns
+		assertStat(t, results[4].Stats[0], "Latency avg (ns)", 1382700, "")
+
+		// Last: insertionSort/n=2000 → 300.19 µs = 300190 ns
+		assertStat(t, results[5].Stats[0], "Latency avg (ns)", 300190, "")
+		if results[5].Name != "insertionSort" {
+			t.Errorf("Name = %q, want %q", results[5].Name, "insertionSort")
+		}
+		if results[5].YAxis != "n=2000" {
+			t.Errorf("YAxis = %q, want %q", results[5].YAxis, "n=2000")
+		}
+	})
+
+	t.Run("Unit conversion to us", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "n/y"
+		shared.FlagState.FilterRegex = ""
+		shared.FlagState.TimeUnit = "us"
+
+		results := ParseCargoBenchmark(writeTestFile(t, testCargoTable))
+
+		if len(results) != 6 {
+			t.Fatalf("expected 6 results, got %d", len(results))
+		}
+
+		// 3052.4 ns → 3.05 us
+		assertStat(t, results[0].Stats[0], "Latency avg (us)", 3.05, "")
+		// 821.61 ns → 0.82 us
+		assertStat(t, results[1].Stats[0], "Latency avg (us)", 0.82, "")
+		// 1382700 ns → 1382.7 us
+		assertStat(t, results[4].Stats[0], "Latency avg (us)", 1382.7, "")
+	})
+
+	t.Run("Filter regex", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "n/y"
+		shared.FlagState.FilterRegex = "bubbleSort"
+		shared.FlagState.TimeUnit = "ns"
+
+		results := ParseCargoBenchmark(writeTestFile(t, testCargoTable))
+
+		if len(results) != 3 {
+			t.Fatalf("expected 3 bubbleSort results, got %d", len(results))
+		}
+		for _, r := range results {
+			if r.Name != "bubbleSort" {
+				t.Errorf("unexpected Name = %q", r.Name)
+			}
+		}
+	})
+
+	t.Run("Empty file", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "y"
+		shared.FlagState.FilterRegex = ""
+		shared.FlagState.TimeUnit = "ns"
+
+		results := ParseCargoBenchmark(writeTestFile(t, ""))
+		if len(results) != 0 {
+			t.Errorf("expected 0 results for empty file, got %d", len(results))
+		}
+	})
+}

--- a/pkg/parser/rust/common.go
+++ b/pkg/parser/rust/common.go
@@ -1,0 +1,29 @@
+package rust
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func toNsMultiplier(unit string) float64 {
+	switch unit {
+	case "ns":
+		return 1
+	case "µs", "μs":
+		return 1e3
+	case "ms":
+		return 1e6
+	case "s":
+		return 1e9
+	}
+	return 1
+}
+
+func parseNum(s string) float64 {
+	s = strings.ReplaceAll(s, ",", "")
+	n, _ := strconv.ParseFloat(s, 64)
+	return n
+}

--- a/pkg/parser/rust/criterion.go
+++ b/pkg/parser/rust/criterion.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"os"
 	"regexp"
-	"strconv"
 	"strings"
 	"unicode"
 
@@ -14,34 +13,12 @@ import (
 )
 
 func init() {
-	parser.Parsers["rs:cargo"] = ParseCargoBenchmark
+	parser.Parsers["rs:criterion"] = ParseCriterionBenchmark
 }
-
-var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 var criterionRe = regexp.MustCompile(`^(\S+)\s+time:\s+\[([\d.]+)\s*(ns|µs|μs|ms|s)\s+([\d.]+)\s*(ns|µs|μs|ms|s)\s+([\d.]+)\s*(ns|µs|μs|ms|s)\]`)
 
-func toNsMultiplier(unit string) float64 {
-	switch unit {
-	case "ns":
-		return 1
-	case "µs", "μs":
-		return 1e3
-	case "ms":
-		return 1e6
-	case "s":
-		return 1e9
-	}
-	return 1
-}
-
-func parseNum(s string) float64 {
-	s = strings.ReplaceAll(s, ",", "")
-	n, _ := strconv.ParseFloat(s, 64)
-	return n
-}
-
-func ParseCargoBenchmark(filename string) []shared.BenchmarkData {
+func ParseCriterionBenchmark(filename string) []shared.BenchmarkData {
 	f, err := os.Open(filename)
 	if err != nil {
 		shared.ExitWithError("Error opening file", err)

--- a/pkg/parser/rust/criterion_test.go
+++ b/pkg/parser/rust/criterion_test.go
@@ -70,7 +70,7 @@ func assertStat(t *testing.T, s shared.Stat, expectedType string, expectedValue 
 	assert.Equal(t, expectedSymbol, s.Symbol, "stat symbol mismatch")
 }
 
-func TestParseCargoBenchmark(t *testing.T) {
+func TestParseCriterionBenchmark(t *testing.T) {
 	origPattern := shared.FlagState.GroupPattern
 	origFilter := shared.FlagState.FilterRegex
 	origTimeUnit := shared.FlagState.TimeUnit
@@ -85,7 +85,7 @@ func TestParseCargoBenchmark(t *testing.T) {
 		shared.FlagState.FilterRegex = ""
 		shared.FlagState.TimeUnit = "ns"
 
-		results := ParseCargoBenchmark(writeTestFile(t, testCargoTable))
+		results := ParseCriterionBenchmark(writeTestFile(t, testCargoTable))
 		assert.Len(t, results, 6)
 
 		// First: bubbleSort/n=100 → 3.0524 µs = 3052.4 ns
@@ -115,7 +115,7 @@ func TestParseCargoBenchmark(t *testing.T) {
 		shared.FlagState.FilterRegex = ""
 		shared.FlagState.TimeUnit = "us"
 
-		results := ParseCargoBenchmark(writeTestFile(t, testCargoTable))
+		results := ParseCriterionBenchmark(writeTestFile(t, testCargoTable))
 		assert.Len(t, results, 6)
 
 		assertStat(t, results[0].Stats[0], "Latency avg (us)", 3.05, "")
@@ -128,7 +128,7 @@ func TestParseCargoBenchmark(t *testing.T) {
 		shared.FlagState.FilterRegex = "bubbleSort"
 		shared.FlagState.TimeUnit = "ns"
 
-		results := ParseCargoBenchmark(writeTestFile(t, testCargoTable))
+		results := ParseCriterionBenchmark(writeTestFile(t, testCargoTable))
 		assert.Len(t, results, 3)
 		for _, r := range results {
 			assert.Equal(t, "bubbleSort", r.Name)
@@ -140,7 +140,7 @@ func TestParseCargoBenchmark(t *testing.T) {
 		shared.FlagState.FilterRegex = ""
 		shared.FlagState.TimeUnit = "ns"
 
-		results := ParseCargoBenchmark(writeTestFile(t, ""))
+		results := ParseCriterionBenchmark(writeTestFile(t, ""))
 		assert.Empty(t, results)
 	})
 }

--- a/pkg/parser/rust/divan.go
+++ b/pkg/parser/rust/divan.go
@@ -1,0 +1,98 @@
+package rust
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/goptics/vizb/pkg/parser"
+	"github.com/goptics/vizb/shared"
+	"github.com/goptics/vizb/shared/utils"
+)
+
+func init() {
+	parser.Parsers["rs:divan"] = ParseDivanBenchmark
+}
+
+var divanRowRe = regexp.MustCompile(`^[├╰]─\s+(\S+)\s+(.+)$`)
+
+var divanValRe = regexp.MustCompile(`([\d.]+)\s*(ns|µs|μs|ms|s)`)
+
+func ParseDivanBenchmark(filename string) []shared.BenchmarkData {
+	f, err := os.Open(filename)
+	if err != nil {
+		shared.ExitWithError("Error opening file", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	var results []shared.BenchmarkData
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		line = ansiRe.ReplaceAllString(line, "")
+		line = strings.TrimLeftFunc(line, unicode.IsSpace)
+
+		match := divanRowRe.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+
+		name := match[1]
+		if !parser.ShouldIncludeBenchmark(name) {
+			continue
+		}
+
+		rest := match[2]
+		parts := strings.Split(rest, "│")
+
+		var values []float64
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			v := divanValRe.FindStringSubmatch(p)
+			if v != nil {
+				values = append(values, parseNum(v[1])*toNsMultiplier(v[2]))
+			} else {
+				values = append(values, parseNum(p))
+			}
+		}
+
+		if len(values) < 5 {
+			continue
+		}
+
+		fastestNs := values[0]
+		slowestNs := values[1]
+		medianNs := values[2]
+		meanNs := values[3]
+		samples := values[4]
+
+		group, groupErr := parser.GroupBenchmarkName(name)
+		if groupErr != nil {
+			shared.ExitWithError("Error parsing divan benchmark name", groupErr)
+		}
+
+		benchName, xAxis, yAxis := group["name"], group["xAxis"], group["yAxis"]
+
+		results = append(results, shared.BenchmarkData{
+			Name:  benchName,
+			XAxis: xAxis,
+			YAxis: yAxis,
+			Stats: []shared.Stat{
+				{Type: utils.CreateStatType("Latency fastest", shared.FlagState.TimeUnit, ""), Value: utils.ConvertTime(fastestNs, "ns", shared.FlagState.TimeUnit)},
+				{Type: utils.CreateStatType("Latency slowest", shared.FlagState.TimeUnit, ""), Value: utils.ConvertTime(slowestNs, "ns", shared.FlagState.TimeUnit), Symbol: "±"},
+				{Type: utils.CreateStatType("Latency median", shared.FlagState.TimeUnit, ""), Value: utils.ConvertTime(medianNs, "ns", shared.FlagState.TimeUnit)},
+				{Type: utils.CreateStatType("Latency mean", shared.FlagState.TimeUnit, ""), Value: utils.ConvertTime(meanNs, "ns", shared.FlagState.TimeUnit)},
+				{Type: "Samples", Value: samples},
+			},
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		shared.ExitWithError("failed to read file", err)
+	}
+
+	return results
+}

--- a/pkg/parser/rust/divan_test.go
+++ b/pkg/parser/rust/divan_test.go
@@ -1,0 +1,96 @@
+package rust
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goptics/vizb/shared"
+	"github.com/stretchr/testify/assert"
+)
+
+var testDivanTable = `sort_divan              fastest       │ slowest       │ median        │ mean          │ samples │ iters
+├─ bubble_sort_100      4.36 µs       │ 9.68 µs       │ 4.646 µs      │ 4.733 µs      │ 100     │ 100
+├─ bubble_sort_500      103.7 µs      │ 174.6 µs      │ 108 µs        │ 119.1 µs      │ 100     │ 100
+├─ bubble_sort_2000     1.36 ms       │ 2.005 ms      │ 1.391 ms      │ 1.458 ms      │ 100     │ 100
+├─ insertion_sort_100   1.131 µs      │ 1.423 µs      │ 1.139 µs      │ 1.149 µs      │ 100     │ 200
+├─ insertion_sort_500   20.86 µs      │ 23.8 µs       │ 21.42 µs      │ 21.39 µs      │ 100     │ 100
+╰─ insertion_sort_2000  289 µs        │ 299.9 µs      │ 292.8 µs      │ 292.4 µs      │ 100     │ 100
+`
+
+func writeDivanTestFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "bench.txt")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestParseDivanBenchmark(t *testing.T) {
+	origPattern := shared.FlagState.GroupPattern
+	origFilter := shared.FlagState.FilterRegex
+	origTimeUnit := shared.FlagState.TimeUnit
+	defer func() {
+		shared.FlagState.GroupPattern = origPattern
+		shared.FlagState.FilterRegex = origFilter
+		shared.FlagState.TimeUnit = origTimeUnit
+	}()
+
+	t.Run("Real divan output", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "y"
+		shared.FlagState.FilterRegex = ""
+		shared.FlagState.TimeUnit = "ns"
+
+		results := ParseDivanBenchmark(writeDivanTestFile(t, testDivanTable))
+		assert.Len(t, results, 6)
+
+		assertStat(t, results[0].Stats[0], "Latency fastest (ns)", 4360, "")
+		assertStat(t, results[0].Stats[1], "Latency slowest (ns)", 9680, "±")
+		assertStat(t, results[0].Stats[2], "Latency median (ns)", 4646, "")
+		assertStat(t, results[0].Stats[3], "Latency mean (ns)", 4733, "")
+		assertStat(t, results[0].Stats[4], "Samples", 100, "")
+
+		assert.Equal(t, "bubble_sort_100", results[0].YAxis)
+
+		assertStat(t, results[2].Stats[0], "Latency fastest (ns)", 1360000, "")
+		assertStat(t, results[2].Stats[1], "Latency slowest (ns)", 2005000, "±")
+
+		assertStat(t, results[5].Stats[3], "Latency mean (ns)", 292400, "")
+		assert.Equal(t, "insertion_sort_2000", results[5].YAxis)
+	})
+
+	t.Run("Unit conversion to us", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "y"
+		shared.FlagState.FilterRegex = ""
+		shared.FlagState.TimeUnit = "us"
+
+		results := ParseDivanBenchmark(writeDivanTestFile(t, testDivanTable))
+		assert.Len(t, results, 6)
+
+		assertStat(t, results[0].Stats[0], "Latency fastest (us)", 4.36, "")
+		assertStat(t, results[0].Stats[3], "Latency mean (us)", 4.73, "")
+		assertStat(t, results[2].Stats[0], "Latency fastest (us)", 1360, "")
+	})
+
+	t.Run("Filter regex", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "y"
+		shared.FlagState.FilterRegex = "insertion"
+		shared.FlagState.TimeUnit = "ns"
+
+		results := ParseDivanBenchmark(writeDivanTestFile(t, testDivanTable))
+		assert.Len(t, results, 3)
+		for _, r := range results {
+			assert.Contains(t, r.YAxis, "insertion")
+		}
+	})
+
+	t.Run("Empty file", func(t *testing.T) {
+		shared.FlagState.GroupPattern = "y"
+		shared.FlagState.FilterRegex = ""
+		shared.FlagState.TimeUnit = "ns"
+
+		results := ParseDivanBenchmark(writeDivanTestFile(t, ""))
+		assert.Empty(t, results)
+	})
+}

--- a/pkg/template/generate_ui_test.go
+++ b/pkg/template/generate_ui_test.go
@@ -1,19 +1,19 @@
 package template
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/goptics/vizb/shared"
 	"github.com/goptics/vizb/version"
 )
 
 func TestGenerateHTMLBenchmarkUI(t *testing.T) {
-	// Save original OsExit and restore after test
 	originalOsExit := shared.OsExit
 	defer func() { shared.OsExit = originalOsExit }()
 
-	// Simple test template
 	testTemplate := `<!DOCTYPE html><html><head><title>Test</title></head><body><script>window.VIZB_VERSION = {{ .Version }}; window.VIZB_DATA = {{ .Data }};</script></body></html>`
 
 	t.Run("Happy Path - Valid JSON", func(t *testing.T) {
@@ -26,44 +26,14 @@ func TestGenerateHTMLBenchmarkUI(t *testing.T) {
 
 		result := GenerateHTMLBenchmarkUI(benchmarkJSON, testTemplate)
 
-		// Verify OsExit was not called
-		if exitCalled {
-			t.Error("Expected OsExit not to be called for valid input")
-		}
-
-		// Verify result is not empty
-		if result == "" {
-			t.Error("Expected non-empty HTML output")
-		}
-
-		// Verify window.VIZB_DATA is injected
-		if !strings.Contains(result, "window.VIZB_DATA") {
-			t.Error("Expected HTML to contain window.VIZB_DATA")
-		}
-
-		// Verify window.VIZB_VERSION is injected
-		if !strings.Contains(result, "window.VIZB_VERSION") {
-			t.Error("Expected HTML to contain window.VIZB_VERSION")
-		}
-
-		// Verify version value is present
-		if !strings.Contains(result, version.Version) {
-			t.Errorf("Expected HTML to contain version %s", version.Version)
-		}
-
-		// Verify the JSON data is present
-		if !strings.Contains(result, string(benchmarkJSON)) {
-			t.Error("Expected HTML to contain the benchmark JSON data")
-		}
-
-		// Verify basic HTML structure
-		if !strings.Contains(result, "<!DOCTYPE html>") {
-			t.Error("Expected HTML to contain DOCTYPE declaration")
-		}
-
-		if !strings.Contains(result, "<html") {
-			t.Error("Expected HTML to contain html tag")
-		}
+		assert.False(t, exitCalled, "Expected OsExit not to be called for valid input")
+		require.NotEmpty(t, result, "Expected non-empty HTML output")
+		assert.Contains(t, result, "window.VIZB_DATA")
+		assert.Contains(t, result, "window.VIZB_VERSION")
+		assert.Contains(t, result, version.Version)
+		assert.Contains(t, result, string(benchmarkJSON))
+		assert.Contains(t, result, "<!DOCTYPE html>")
+		assert.Contains(t, result, "<html")
 	})
 
 	t.Run("Empty JSON Array", func(t *testing.T) {
@@ -76,64 +46,44 @@ func TestGenerateHTMLBenchmarkUI(t *testing.T) {
 
 		result := GenerateHTMLBenchmarkUI(benchmarkJSON, testTemplate)
 
-		if exitCalled {
-			t.Error("Expected OsExit not to be called for empty JSON array")
-		}
-
-		if result == "" {
-			t.Error("Expected non-empty HTML output")
-		}
-
-		if !strings.Contains(result, "window.VIZB_DATA") {
-			t.Error("Expected HTML to contain window.VIZB_DATA")
-		}
+		assert.False(t, exitCalled, "Expected OsExit not to be called for empty JSON array")
+		require.NotEmpty(t, result, "Expected non-empty HTML output")
+		assert.Contains(t, result, "window.VIZB_DATA")
 	})
 
 	t.Run("Invalid Template Execution", func(t *testing.T) {
 		exitCalled := false
 		shared.OsExit = func(code int) {
 			exitCalled = true
-			panic("exit called") // Panic to stop execution
+			panic("exit called")
 		}
 
 		benchmarkJSON := []byte(`[{"name":"test","data":[]}]`)
 		invalidTemplate := `<!DOCTYPE html><html><body>{{ .InvalidField }}</body></html>`
 
-		// Use WithSafe to handle the panic from our mocked OsExit
 		err := shared.WithSafe("GenerateHTMLBenchmarkUI", func() {
 			_ = GenerateHTMLBenchmarkUI(benchmarkJSON, invalidTemplate)
 		})
 
-		if !exitCalled {
-			t.Error("Expected OsExit to be called for invalid template execution")
-		}
-
-		if err == nil {
-			t.Error("Expected error from WithSafe when OsExit is called")
-		}
+		assert.True(t, exitCalled, "Expected OsExit to be called for invalid template execution")
+		assert.NotNil(t, err, "Expected error from WithSafe when OsExit is called")
 	})
 
 	t.Run("Malformed Template Syntax", func(t *testing.T) {
 		exitCalled := false
 		shared.OsExit = func(code int) {
 			exitCalled = true
-			panic("exit called") // Panic to stop execution
+			panic("exit called")
 		}
 
 		benchmarkJSON := []byte(`[{"name":"test","data":[]}]`)
 		malformedTemplate := `<!DOCTYPE html><html><body>{{ .Version</body></html>`
 
-		// Use WithSafe to handle the panic from our mocked OsExit
 		err := shared.WithSafe("GenerateHTMLBenchmarkUI", func() {
 			_ = GenerateHTMLBenchmarkUI(benchmarkJSON, malformedTemplate)
 		})
 
-		if !exitCalled {
-			t.Error("Expected OsExit to be called for malformed template syntax")
-		}
-
-		if err == nil {
-			t.Error("Expected error from WithSafe when OsExit is called")
-		}
+		assert.True(t, exitCalled, "Expected OsExit to be called for malformed template syntax")
+		assert.NotNil(t, err, "Expected error from WithSafe when OsExit is called")
 	})
 }

--- a/shared/bench.go
+++ b/shared/bench.go
@@ -1,8 +1,9 @@
 package shared
 
 type Stat struct {
-	Type  string  `json:"type"`
-	Value float64 `json:"value,omitempty"`
+	Type   string  `json:"type"`
+	Value  float64 `json:"value,omitempty"`
+	Symbol string  `json:"symbol,omitempty"`
 }
 
 type BenchmarkData struct {

--- a/shared/flag_state.go
+++ b/shared/flag_state.go
@@ -16,6 +16,7 @@ type flagState struct {
 	FilterRegex     string
 	Scale           string
 	TagAxis string
+	Parser          string
 }
 
 var FlagState flagState = flagState{}

--- a/shared/safe_test.go
+++ b/shared/safe_test.go
@@ -2,6 +2,9 @@ package shared
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWithSafe(t *testing.T) {
@@ -11,13 +14,8 @@ func TestWithSafe(t *testing.T) {
 			executed = true
 		})
 
-		if !executed {
-			t.Error("Expected function to be executed")
-		}
-
-		if err != nil {
-			t.Errorf("Expected no error, got: %v", err)
-		}
+		assert.True(t, executed, "Expected function to be executed")
+		assert.NoError(t, err)
 	})
 
 	t.Run("Panic Recovery", func(t *testing.T) {
@@ -25,31 +23,21 @@ func TestWithSafe(t *testing.T) {
 			panic("test panic message")
 		})
 
-		if err == nil {
-			t.Error("Expected error from panic recovery")
-		}
+		require.Error(t, err, "Expected error from panic recovery")
 
 		expectedMsg := "panic recovered inside test panic: test panic message"
-		if err.Error() != expectedMsg {
-			t.Errorf("Expected error message %q, got %q", expectedMsg, err.Error())
-		}
+		assert.EqualError(t, err, expectedMsg)
 	})
 
 	t.Run("Panic with Different Types", func(t *testing.T) {
-		// Test with string panic
 		err := WithSafe("string panic", func() {
 			panic("string error")
 		})
-		if err == nil {
-			t.Error("Expected error from string panic")
-		}
+		assert.Error(t, err, "Expected error from string panic")
 
-		// Test with int panic
 		err = WithSafe("int panic", func() {
 			panic(42)
 		})
-		if err == nil {
-			t.Error("Expected error from int panic")
-		}
+		assert.Error(t, err, "Expected error from int panic")
 	})
 }

--- a/shared/tmp_files_manager_test.go
+++ b/shared/tmp_files_manager_test.go
@@ -4,182 +4,124 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewTmpFileManager(t *testing.T) {
 	manager := NewTmpFileManager()
-
-	if len(manager.files) != 0 {
-		t.Errorf("NewTmpFileManager() should create empty files slice, got %d files", len(manager.files))
-	}
+	assert.Empty(t, manager.files)
 }
 
 func TestTmpFilesManager_Store(t *testing.T) {
 	manager := NewTmpFileManager()
 
-	// Test storing single file
 	manager.Store("file1.txt")
-	if len(manager.files) != 1 {
-		t.Errorf("Expected 1 file after Store, got %d", len(manager.files))
-	}
-	if manager.files[0] != "file1.txt" {
-		t.Errorf("Expected file1.txt, got %s", manager.files[0])
-	}
+	assert.Len(t, manager.files, 1)
+	assert.Equal(t, "file1.txt", manager.files[0])
 
-	// Test storing multiple files at once
 	manager.Store("file2.txt", "file3.txt")
-	if len(manager.files) != 3 {
-		t.Errorf("Expected 3 files after storing multiple, got %d", len(manager.files))
-	}
-
-	expected := []string{"file1.txt", "file2.txt", "file3.txt"}
-	for i, expected := range expected {
-		if manager.files[i] != expected {
-			t.Errorf("Expected %s at index %d, got %s", expected, i, manager.files[i])
-		}
-	}
+	assert.Len(t, manager.files, 3)
+	assert.Equal(t, []string{"file1.txt", "file2.txt", "file3.txt"}, manager.files)
 }
 
 func TestTmpFilesManager_RemoveAll(t *testing.T) {
-	// Create temporary directory for test
 	tempDir := t.TempDir()
 
-	// Create test files
 	file1 := filepath.Join(tempDir, "test1.txt")
 	file2 := filepath.Join(tempDir, "test2.txt")
 	file3 := filepath.Join(tempDir, "test3.txt")
 
-	// Create actual files
 	for _, file := range []string{file1, file2, file3} {
 		f, err := os.Create(file)
-		if err != nil {
-			t.Fatalf("Failed to create test file %s: %v", file, err)
-		}
+		require.NoError(t, err, "Failed to create test file")
 		f.Close()
 	}
 
-	// Verify files exist
 	for _, file := range []string{file1, file2, file3} {
-		if _, err := os.Stat(file); os.IsNotExist(err) {
-			t.Fatalf("Test file %s should exist", file)
-		}
+		_, err := os.Stat(file)
+		require.False(t, os.IsNotExist(err), "Test file should exist")
 	}
 
-	// Store files in manager
 	manager := NewTmpFileManager()
 	manager.Store(file1, file2, file3)
 
-	// Remove all files
 	manager.RemoveAll()
 
-	// Verify files are deleted
 	for _, file := range []string{file1, file2, file3} {
-		if _, err := os.Stat(file); !os.IsNotExist(err) {
-			t.Errorf("File %s should have been deleted", file)
-		}
+		_, err := os.Stat(file)
+		assert.True(t, os.IsNotExist(err), "File should have been deleted")
 	}
 
-	// Verify manager files slice is reset
-	if len(manager.files) != 0 {
-		t.Errorf("Manager files slice should be empty after RemoveAll, got %d files", len(manager.files))
-	}
+	assert.Empty(t, manager.files)
 }
 
 func TestTmpFilesManager_RemoveAll_NonExistentFiles(t *testing.T) {
 	manager := NewTmpFileManager()
 	manager.Store("nonexistent1.txt", "nonexistent2.txt")
 
-	// Should not panic when removing non-existent files
 	manager.RemoveAll()
 
-	// Verify manager files slice is reset
-	if len(manager.files) != 0 {
-		t.Errorf("Manager files slice should be empty after RemoveAll, got %d files", len(manager.files))
-	}
+	assert.Empty(t, manager.files)
 }
 
 func TestGlobalTempFiles(t *testing.T) {
-	// Save original state
 	originalFiles := make([]string, len(TempFiles.files))
 	copy(originalFiles, TempFiles.files)
 
-	// Clean up after test
 	defer func() {
 		TempFiles.files = originalFiles
 	}()
 
-	// Test global TempFiles variable
 	initialLen := len(TempFiles.files)
 	TempFiles.Store("global_test.txt")
 
-	if len(TempFiles.files) != initialLen+1 {
-		t.Errorf("Global TempFiles should have %d files, got %d", initialLen+1, len(TempFiles.files))
-	}
+	assert.Len(t, TempFiles.files, initialLen+1)
 
 	TempFiles.RemoveAll()
 
-	if len(TempFiles.files) != 0 {
-		t.Errorf("Global TempFiles should be empty after RemoveAll, got %d files", len(TempFiles.files))
-	}
+	assert.Empty(t, TempFiles.files)
 }
 
 func TestTmpFilesManager_EmptyStore(t *testing.T) {
 	manager := NewTmpFileManager()
 
-	// Test storing no files
 	manager.Store()
 
-	if len(manager.files) != 0 {
-		t.Errorf("Expected 0 files after Store(), got %d", len(manager.files))
-	}
+	assert.Empty(t, manager.files)
 }
 
 func TestTmpFilesManager_Integration(t *testing.T) {
-	// Create temporary directory
 	tempDir := t.TempDir()
 
-	// Create manager and test full workflow
 	manager := NewTmpFileManager()
 
-	// Create and store multiple files
 	files := make([]string, 3)
 	for i := 0; i < 3; i++ {
 		file := filepath.Join(tempDir, "integration_test_"+string(rune('1'+i))+".txt")
 		f, err := os.Create(file)
-		if err != nil {
-			t.Fatalf("Failed to create test file: %v", err)
-		}
+		require.NoError(t, err, "Failed to create test file")
 		f.Close()
 		files[i] = file
 	}
 
-	// Store files one by one and in batch
 	manager.Store(files[0])
 	manager.Store(files[1], files[2])
 
-	if len(manager.files) != 3 {
-		t.Errorf("Expected 3 files stored, got %d", len(manager.files))
-	}
+	assert.Len(t, manager.files, 3)
 
-	// Verify all files exist
 	for _, file := range files {
-		if _, err := os.Stat(file); os.IsNotExist(err) {
-			t.Errorf("File %s should exist before RemoveAll", file)
-		}
+		_, err := os.Stat(file)
+		assert.False(t, os.IsNotExist(err), "File should exist before RemoveAll")
 	}
 
-	// Remove all
 	manager.RemoveAll()
 
-	// Verify all files are deleted
 	for _, file := range files {
-		if _, err := os.Stat(file); !os.IsNotExist(err) {
-			t.Errorf("File %s should be deleted after RemoveAll", file)
-		}
+		_, err := os.Stat(file)
+		assert.True(t, os.IsNotExist(err), "File should be deleted after RemoveAll")
 	}
 
-	// Verify manager is reset
-	if len(manager.files) != 0 {
-		t.Errorf("Manager should be empty after RemoveAll, got %d files", len(manager.files))
-	}
+	assert.Empty(t, manager.files)
 }

--- a/shared/utils/formatter.go
+++ b/shared/utils/formatter.go
@@ -57,6 +57,32 @@ func FormatMem(n float64, unit string) (mem float64) {
 	return RoundToTwo(mem)
 }
 
+// ConvertTime converts a time value from one unit to another.
+// Supported units: "ns", "us", "ms", "s".
+func ConvertTime(n float64, from, to string) float64 {
+	if n == 0 {
+		return 0
+	}
+
+	if from == to {
+		return n
+	}
+
+	var ns float64
+	switch from {
+	case "s":
+		ns = n * 1e9
+	case "ms":
+		ns = n * 1e6
+	case "us":
+		ns = n * 1e3
+	default:
+		ns = n
+	}
+
+	return FormatTime(ns, to)
+}
+
 // FormatNumber converts an allocation count to the specified unit.
 // Supported units: "K" (thousands), "M" (millions), "B" (billions), "T" (trillions).
 // Empty unit string returns the value unchanged.

--- a/shared/utils/formatter_test.go
+++ b/shared/utils/formatter_test.go
@@ -275,6 +275,40 @@ func TestFormatterConcurrency(t *testing.T) {
 	})
 }
 
+func TestConvertTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    float64
+		from     string
+		to       string
+		expected float64
+	}{
+		{"Zero", 0, "ms", "ns", 0},
+		{"Identity ns", 1000, "ns", "ns", 1000},
+		{"Identity ms", 5.5, "ms", "ms", 5.5},
+		{"ms to ns", 1, "ms", "ns", 1000000},
+		{"ms to us", 1, "ms", "us", 1000},
+		{"ms to s", 1000, "ms", "s", 1},
+		{"ns to ms", 1000000, "ns", "ms", 1},
+		{"ns to us", 1000, "ns", "us", 1},
+		{"ns to s", 1e9, "ns", "s", 1},
+		{"us to ms", 1000, "us", "ms", 1},
+		{"us to ns", 1, "us", "ns", 1000},
+		{"s to ms", 1, "s", "ms", 1000},
+		{"s to us", 1, "s", "us", 1000000},
+		{"s to ns", 1, "s", "ns", 1e9},
+		{"Small ms to ns", 0.0038, "ms", "ns", 3800},
+		{"Small ms to us", 0.0038, "ms", "us", 3.8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ConvertTime(tt.input, tt.from, tt.to)
+			assert.Equal(t, tt.expected, result, "ConvertTime(%f, %s, %s) should equal %f", tt.input, tt.from, tt.to, tt.expected)
+		})
+	}
+}
+
 // Test comprehensive input validation
 func TestInputValidation(t *testing.T) {
 	t.Run("All Units Coverage", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Refactors Go-only parser into a multi-language registry pattern (`pkg/parser/registry.go`) dispatching via `--parser` CLI flag. Adds parsers for Rust (criterion + divan), JavaScript (vitest + tinybench), and migrates all tests to testify.

## Parsers added

| Key | Framework | Stats |
|-----|-----------|-------|
| `go` | Go testing (benchfmt) | Execution time, memory, allocs, throughput, iterations |
| `js:tinybench` | Tinybench console.table() | Latency avg/med, throughput, RME, MAD, samples |
| `js:vitest` | Vitest benchmark | Throughput, latency min/max/avg/p75/p99/p995/p999, RME, samples |
| `rs:criterion` | Rust Criterion (cargo bench) | Latency avg/lower/upper |
| `rs:divan` | Rust Divan (cargo bench) | Latency fastest/slowest/median/mean, samples |

## Changes

| File | Action |
|------|--------|
| `pkg/parser/registry.go` | New — `ParseFunc` type, `Parsers` map, `GetParser`, `AvailableParsers`, `ShouldIncludeBenchmark` |
| `pkg/parser/golang/golang.go` | Moved from `pkg/parser/bench_data.go`, renamed `ParseBenchmarkData` → `ParseGoBenchmark`, registers `"go"` key |
| `pkg/parser/javascript/tinybench.go` | New — parses tinybench `console.table()` output |
| `pkg/parser/javascript/vitest.go` | New — parses vitest benchmark output |
| `pkg/parser/rust/common.go` | New — shared helpers (`ansiRe`, `toNsMultiplier`, `parseNum`) for Rust parsers |
| `pkg/parser/rust/criterion.go` | New — parses criterion `time: [...]` output, registers `"rs:criterion"` |
| `pkg/parser/rust/divan.go` | New — parses divan table output, registers `"rs:divan"` |
| `pkg/parser/parse_pattern.go` | Added `GroupBenchmarkName()` helper consolidating group/regex dispatch |
| `cmd/root.go` | Added `--parser/-P` flag with dynamic help text, registry dispatch, conditional JSON→TXT conversion |
| `cmd/flag_validation_rules.go` | Added parser validation rule |
| `shared/bench.go` | Added `Symbol` field to `Stat` struct |
| `shared/flag_state.go` | Added `Parser` field |
| `shared/utils/formatter.go` | Added `ConvertTime` helper |

## Test migration

All 24 test files migrated from raw `t.Errorf`/`t.Fatalf` to testify (`assert` + `require`). Removed hand-rolled helpers (`almostEqual`, `contains`, `indexOfSubstring`).

## Test plan

- [x] `go test -count=1 ./...` — 10/10 packages pass
- [x] `go build ./...` — binary compiles with all parser registrations
- [ ] `./bin/vizb existing_go_bench.txt` — backward compatible (default `--parser go`)
- [ ] `./bin/vizb --parser rs:criterion cargo_bench.txt` — parses criterion output
- [ ] `./bin/vizb --parser rs:divan divan_bench.txt` — parses divan output
- [ ] `./bin/vizb --parser js:tinybench tinybench_output.txt` — parses tinybench output
- [ ] `./bin/vizb --parser js:vitest vitest_output.txt` — parses vitest output
- [ ] `./bin/vizb --parser invalid` — exits with "unknown parser" error