### PR TITLE
fix: show help and exit 0 when no target given

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,7 +48,7 @@ func Execute() {
 func init() {
 	rootCmd.Flags().StringVarP(&shared.FlagState.Name, "name", "n", "Benchmarks", "Name of the benchmark")
 	rootCmd.Flags().StringVarP(&shared.FlagState.Description, "description", "d", "", "Description of the benchmark")
-	rootCmd.PersistentFlags().StringVarP(&shared.FlagState.OutputFile, "output", "o", "", "Output file name (.json for JSON, .html or other for HTML)")
+	rootCmd.PersistentFlags().StringVarP(&shared.FlagState.OutputFile, "output", "o", "", "Output file path/name")
 	rootCmd.Flags().StringVarP(&shared.FlagState.MemUnit, "mem-unit", "M", "B", "Memory unit available: b, B, KB, MB, GB")
 	rootCmd.Flags().StringVarP(&shared.FlagState.TimeUnit, "time-unit", "T", "ns", "Time unit available: ns, us, ms, s")
 	rootCmd.Flags().StringVarP(&shared.FlagState.NumberUnit, "number-unit", "N", "", "Number unit available: K, M, B, T (default: as-is)")
@@ -83,9 +83,8 @@ func runBenchmark(cmd *cobra.Command, args []string) {
 
 		writeStdinPipedInputs(target)
 	} else {
-		fmt.Fprintln(os.Stderr, "Error: no target provided and no piped input detected")
 		cmd.Help()
-		shared.OsExit(1)
+		shared.OsExit(0)
 	}
 
 	generateOutputFile(target)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -139,7 +139,9 @@ func TestValidateFlags(t *testing.T) {
 
 			// Check the stderr output if expected
 			if tt.expectedOutput != "" {
-				assert.Contains(t, buf.String(), tt.expectedOutput)
+				if tt.expectedOutput != "" {
+					assert.Contains(t, buf.String(), tt.expectedOutput)
+				}
 			}
 		})
 	}
@@ -323,7 +325,7 @@ func TestRunBenchmark(t *testing.T) {
 			},
 			setupStdin:     func() func() { return func() {} },
 			expectExit:     true,
-			expectedOutput: "no target provided",
+			expectedOutput: "",
 			setupFlags:     func() {},
 		},
 	}


### PR DESCRIPTION
Running vizb with no arguments now displays help and exits cleanly instead of printing an error and exiting with code 1.

Also corrected the --output flag description.