### PR TITLE
fix: inject version via ldflags in goreleaser build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,8 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w  # Strip debug info
+      - -s -w
+      - -X github.com/goptics/vizb/version.Version={{.Version}}
     main: .
 
 archives:


### PR DESCRIPTION
## Summary

- Adds `-X github.com/goptics/vizb/version.Version={{.Version}}` to GoReleaser `ldflags`
- Release binaries now have the git tag stamped at build time instead of falling through to `debug.ReadBuildInfo()` (which returns empty for direct `go build` invocations, leaving `Version = "devel"`)
- `go install` path unaffected — `debug.ReadBuildInfo()` fallback in `version/version.go` still handles that case via the existing `if Version != "devel" { return }` guard

## Test plan

- [x] Run `goreleaser build --snapshot --clean` and verify `./dist/vizb_*/vizb --version` prints the snapshot tag, not `devel`