### PR TITLE
docs/ci: enrich examples page and fix deploy-docs trigger

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,11 +1,8 @@
 name: Deploy Docs
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'docs/**'
-      - '.github/workflows/docs.yml'
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/deploy-examples-go.yml
+++ b/.github/workflows/deploy-examples-go.yml
@@ -37,6 +37,7 @@ jobs:
             group-regex: "/text=(?<n>.*)/level=(?<x>.*)/size=(?<y>.*)"
             filter: "Encode"
             scale: "log"
+
           - output: 02-hash
             bench-file: 01-hash
             name: "Hashing"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,10 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}
+
+  deploy-docs:
+    needs: goreleaser
+    uses: ./.github/workflows/deploy-docs.yml
+    secrets: inherit
+    permissions:
+      contents: write

--- a/docs/src/content/docs/examples.mdx
+++ b/docs/src/content/docs/examples.mdx
@@ -17,39 +17,40 @@ Benchmark files are organized by language under [`examples/`](https://github.com
 
 ## Go Benchmarks Inputs
 
-| Benchmark | Input File | Dashboard |
-|-----------|-----------|-----------|
-| Decode | [decode-encode.txt](https://github.com/goptics/vizb/blob/main/examples/go/00-decode-encode.txt) | [vizb.goptics.org/examples/go/](https://vizb.goptics.org/examples/go/) |
-| Encode | [decode-encode.txt](https://github.com/goptics/vizb/blob/main/examples/go/00-decode-encode.txt) | [vizb.goptics.org/examples/go/](https://vizb.goptics.org/examples/go/?b=1) |
-| Hashing | [hash.txt](https://github.com/goptics/vizb/blob/main/examples/go/01-hash.txt) | [vizb.goptics.org/examples/go/](https://vizb.goptics.org/examples/go/?b=2) |
-| HTTP Routing | [http-routing.txt](https://github.com/goptics/vizb/blob/main/examples/go/02-http-routing.txt) | [vizb.goptics.org/examples/go/](https://vizb.goptics.org/examples/go/?b=3) |
-| Serialization | [serialization.txt](https://github.com/goptics/vizb/blob/main/examples/go/03-serialization.txt) | [vizb.goptics.org/examples/go/](https://vizb.goptics.org/examples/go/?b=4) |
-| Validator | [validator.txt](https://github.com/goptics/vizb/blob/main/examples/go/04-validator.txt) | [vizb.goptics.org/examples/go/](https://vizb.goptics.org/examples/go/?b=5) |
-| Varmq | [varmq.txt](https://github.com/goptics/vizb/blob/main/examples/go/05-varmq.txt) | [vizb.goptics.org/examples/go/](https://vizb.goptics.org/examples/go/?b=6) |
-| Worker Pools | [worker-pools.txt](https://github.com/goptics/vizb/blob/main/examples/go/06-worker-pools.txt) | [vizb.goptics.org/examples/go/](https://vizb.goptics.org/examples/go/?b=7) |
+| Benchmark | Input File | Pattern | Regex | Dashboard |
+|-----------|-----------|---------|-------|-----------|
+| Decode | [decode-encode.txt](https://github.com/goptics/vizb/blob/main/examples/go/00-decode-encode.txt) | — | `/text=(?<n>.*)/level=(?<x>.*)/size=(?<y>.*)` | [Live](https://vizb.goptics.org/examples/go/) |
+| Encode | [decode-encode.txt](https://github.com/goptics/vizb/blob/main/examples/go/00-decode-encode.txt) | — | `/text=(?<n>.*)/level=(?<x>.*)/size=(?<y>.*)` | [Live](https://vizb.goptics.org/examples/go/?b=1) |
+| Hashing | [hash.txt](https://github.com/goptics/vizb/blob/main/examples/go/01-hash.txt) | — | `Hashing64(?<x>.*)` | [Live](https://vizb.goptics.org/examples/go/?b=2) |
+| HTTP Routing | [http-routing.txt](https://github.com/goptics/vizb/blob/main/examples/go/02-http-routing.txt) | `x_n` | — | [Live](https://vizb.goptics.org/examples/go/?b=3) |
+| Serialization | [serialization.txt](https://github.com/goptics/vizb/blob/main/examples/go/03-serialization.txt) | — | `(?<x>.*)By(?<y>.*)` | [Live](https://vizb.goptics.org/examples/go/?b=4) |
+| Validator | [validator.txt](https://github.com/goptics/vizb/blob/main/examples/go/04-validator.txt) | — | `(?<y>.*?)(?:(?<x>Success\|Failure)(?<n>.*)\|$)` | [Live](https://vizb.goptics.org/examples/go/?b=5) |
+| Varmq | [varmq.txt](https://github.com/goptics/vizb/blob/main/examples/go/05-varmq.txt) | `x/y` | — | [Live](https://vizb.goptics.org/examples/go/?b=6) |
+| Worker Pools | [worker-pools.txt](https://github.com/goptics/vizb/blob/main/examples/go/06-worker-pools.txt) | `n/y/x` | — | [Live](https://vizb.goptics.org/examples/go/?b=7) |
 
 
 ## JavaScript Benchmarks Inputs
 
-| Benchmark | Input File | Dashboard |
-|-----------|-----------|-----------|
-| Tinybench | [tinybench.txt](https://github.com/goptics/vizb/blob/main/examples/javascript/00-tinybench.txt) | [vizb.goptics.org/examples/javascript/](https://vizb.goptics.org/examples/javascript/) |
-| Vitest | [vitest.txt](https://github.com/goptics/vizb/blob/main/examples/javascript/01-vitest.txt) | [vizb.goptics.org/examples/javascript/](https://vizb.goptics.org/examples/javascript/?b=1) |
+| Benchmark | Input File | Pattern | Regex | Dashboard |
+|-----------|-----------|---------|-------|-----------|
+| Tinybench | [tinybench.txt](https://github.com/goptics/vizb/blob/main/examples/javascript/00-tinybench.txt) | `x/y` | — | [Live](https://vizb.goptics.org/examples/javascript/) |
+| Vitest | [vitest.txt](https://github.com/goptics/vizb/blob/main/examples/javascript/01-vitest.txt) | — | `n=(?<y>.*)/(?<x>.*)` | [Live](https://vizb.goptics.org/examples/javascript/?b=1) |
 
 ## Rust Benchmarks Inputs
 
-| Benchmark | Input File | Dashboard |
-|-----------|-----------|-----------|
-| Criterion | [criterion.txt](https://github.com/goptics/vizb/blob/main/examples/rust/00-criterion.txt) | [vizb.goptics.org/examples/rust/](https://vizb.goptics.org/examples/rust/) |
-| Divan | [divan.txt](https://github.com/goptics/vizb/blob/main/examples/rust/01-divan.txt) | [vizb.goptics.org/examples/rust/](https://vizb.goptics.org/examples/rust/?b=1) |
+| Benchmark | Input File | Pattern | Regex | Dashboard |
+|-----------|-----------|---------|-------|-----------|
+| Criterion | [criterion.txt](https://github.com/goptics/vizb/blob/main/examples/rust/00-criterion.txt) | — | `(?<x>.*)/n=(?<y>.*)` | [Live](https://vizb.goptics.org/examples/rust/) |
+| Divan | [divan.txt](https://github.com/goptics/vizb/blob/main/examples/rust/01-divan.txt) | `x__y` | — | [Live](https://vizb.goptics.org/examples/rust/?b=1) |
 
 ## How People Are Using Vizb
 
-| Repository | Short Description | Workflow | Live Link |
+| Repository | Short Description | Workflow | Dashboard |
 |------------|-------------------|----------|-----------|
-| [goptics/vizb](https://github.com/goptics/vizb) | Vizb's own benchmark dashboards for Go, JavaScript, and Rust manges CI/CD pipeline by vizb action | [deploy-examples-*.yml](https://github.com/goptics/vizb/tree/main/.github/workflows) | [vizb.goptics.org/examples/](https://vizb.goptics.org/examples/) |
-| [goptics/varmq-benchmarks](https://github.com/goptics/varmq-benchmarks) | Worker pool benchmarks comparing VarMQ vs PondV2 across workload patterns and CPU configs | [bench.yml](https://github.com/goptics/varmq-benchmarks/blob/main/.github/workflows/bench.yml) | [goptics.github.io/varmq-benchmarks/](https://goptics.github.io/varmq-benchmarks/) |
-| [goptics/sortbench](https://github.com/goptics/sortbench) | Sorting algorithm benchmarks across git versions using per-tag vizb merging (bubble, insertion, shell, quicksort, merge) | [bench.yml](https://github.com/goptics/sortbench/blob/main/.github/workflows/bench.yml) | [goptics.github.io/sortbench/](https://goptics.github.io/sortbench/) |
+| [goptics/vizb](https://github.com/goptics/vizb) | Vizb's own benchmark dashboards for Go, JavaScript, and Rust manges CI/CD pipeline by vizb action | [deploy-examples-*.yml](https://github.com/goptics/vizb/tree/main/.github/workflows) | [Live](https://vizb.goptics.org/examples/) |
+| [goptics/varmq-benchmarks](https://github.com/goptics/varmq-benchmarks) | Worker pool benchmarks comparing VarMQ vs PondV2 across workload patterns and CPU configs | [bench.yml](https://github.com/goptics/varmq-benchmarks/blob/main/.github/workflows/bench.yml) | [Live](https://goptics.github.io/varmq-benchmarks/) |
+| [goptics/sortbench](https://github.com/goptics/sortbench) | Sorting algorithm benchmarks across git versions using per-tag vizb merging (bubble, insertion, shell, quicksort, merge) | [bench.yml](https://github.com/goptics/sortbench/blob/main/.github/workflows/bench.yml) | [Live](https://goptics.github.io/sortbench/) |
+| [goptics/varmq](https://github.com/goptics/varmq) | Tracks benchmark evolution across VarMQ release versions, generating a cumulative bench log dashboard via vizb action on each release | [deploy-bench-log.yml](https://github.com/goptics/varmq/blob/main/.github/workflows/deploy-bench-log.yml) | [Live](https://varmq.goptics.org/bench-log/) |
 
 **Using vizb in your project?** [Open a PR](https://github.com/goptics/vizb/edit/main/docs/src/content/docs/examples.mdx) to add your entry!
 


### PR DESCRIPTION
## Summary

- Add Pattern and Regex columns to all benchmark input tables (Go, JavaScript, Rust) — values sourced from CI workflow flags
- Rename Dashboard link text to compact `Live` across all tables for consistency
- Add `goptics/varmq` entry to the "How People Are Using Vizb" section
- Replace `deploy-docs.yml` push trigger with `workflow_call` + `workflow_dispatch` — docs now deploy only after a successful release, or on manual trigger
- Add `deploy-docs` job to `release.yml` (needs: goreleaser) to wire the two workflows together

## Test plan

- [ ] Verify examples page renders all three tables with 5 columns
- [ ] Push a non-release commit — confirm deploy-docs does NOT trigger
- [ ] Cut a release tag — confirm deploy-docs fires after goreleaser succeeds
- [ ] Manually trigger deploy-docs from Actions tab — confirm it runs