### PR TITLE
refactor(cli): rename html command to ui, keep html alias

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -239,8 +239,8 @@ runs:
       shell: bash
       run: |
         if [ -n "${{ inputs.data-url }}" ]; then
-          vizb html -U "${{ inputs.data-url }}" -o "${{ inputs.output-html }}"
+          vizb ui -U "${{ inputs.data-url }}" -o "${{ inputs.output-html }}"
         else
-          vizb html "${{ steps.resolve.outputs.json_file }}" -o "${{ inputs.output-html }}"
+          vizb ui "${{ steps.resolve.outputs.json_file }}" -o "${{ inputs.output-html }}"
         fi
         echo "html=${{ inputs.output-html }}" >> "$GITHUB_OUTPUT"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -342,12 +342,17 @@ func TestRunBenchmark(t *testing.T) {
 			restore := tt.setupStdin()
 			defer restore()
 
-			// Capture stdout and stderr
+			// Capture stdout and stderr. Restore via defer so a panic
+			// (recovered by WithSafe) can't leak the pipe into later tests.
 			oldStdout := os.Stdout
 			oldStderr := os.Stderr
 			r, w, _ := os.Pipe()
 			os.Stdout = w
 			os.Stderr = w
+			defer func() {
+				os.Stdout = oldStdout
+				os.Stderr = oldStderr
+			}()
 
 			// Create a cobra command for testing
 			cmd := &cobra.Command{}
@@ -355,13 +360,6 @@ func TestRunBenchmark(t *testing.T) {
 
 			// Run the function and catch any os.Exit calls
 			if tt.expectExit {
-				// Capture both stdout and stderr
-				oldStdout := os.Stdout
-				oldStderr := os.Stderr
-				r, w, _ := os.Pipe()
-				os.Stdout = w
-				os.Stderr = w
-
 				// Use WithSafe to handle panic
 				err := shared.WithSafe("runBenchmark", func() {
 					runBenchmark(cmd, args)
@@ -371,10 +369,6 @@ func TestRunBenchmark(t *testing.T) {
 				w.Close()
 				var buf bytes.Buffer
 				io.Copy(&buf, r)
-
-				// Restore stdout and stderr
-				os.Stdout = oldStdout
-				os.Stderr = oldStderr
 
 				// Verify assertions
 				if err == nil {
@@ -391,10 +385,6 @@ func TestRunBenchmark(t *testing.T) {
 				// Read output
 				var buf bytes.Buffer
 				io.Copy(&buf, r)
-
-				// Restore stdout and stderr
-				os.Stdout = oldStdout
-				os.Stderr = oldStderr
 
 				// Validate assertions
 				assert.Contains(t, buf.String(), tt.expectedOutput)

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -10,9 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var htmlCmd = &cobra.Command{
-	Use:   "html [file]",
-	Short: "Generate HTML visualization from a benchmark JSON file",
+var uiCmd = &cobra.Command{
+	Use:     "ui [file]",
+	Aliases: []string{"html"},
+	Short:   "Generate the interactive HTML UI from a benchmark JSON file",
 	Long: `Generate an interactive HTML chart from a benchmark JSON file.
 The input file must be a valid vizb benchmark JSON (single object or array).
 
@@ -20,15 +21,15 @@ When --data-url is set, no input file is needed. The generated HTML will fetch
 benchmark JSON from the provided URL at runtime instead of embedding it.
 Note: the JSON host must serve Access-Control-Allow-Origin: * for file:// access.`,
 	Args: cobra.MaximumNArgs(1),
-	Run:  runHTML,
+	Run:  runUI,
 }
 
 func init() {
-	rootCmd.AddCommand(htmlCmd)
-	htmlCmd.Flags().StringVarP(&shared.FlagState.DataURL, "data-url", "U", "", "URL to fetch benchmark JSON from at runtime (no input file needed)")
+	rootCmd.AddCommand(uiCmd)
+	uiCmd.Flags().StringVarP(&shared.FlagState.DataURL, "data-url", "U", "", "URL to fetch benchmark JSON from at runtime (no input file needed)")
 }
 
-func runHTML(cmd *cobra.Command, args []string) {
+func runUI(cmd *cobra.Command, args []string) {
 	outFile := shared.FlagState.OutputFile
 	if outFile == "" {
 		outFile = resolveOutputFileName(outFile)

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHtmlCmd_SingleObject(t *testing.T) {
+func TestUICmd_SingleObject(t *testing.T) {
 	oldOsExit := shared.OsExit
 	defer func() { shared.OsExit = oldOsExit }()
 
@@ -34,7 +34,7 @@ func TestHtmlCmd_SingleObject(t *testing.T) {
 	outFile := filepath.Join(tmpDir, "output.html")
 	shared.FlagState.OutputFile = outFile
 
-	rootCmd.SetArgs([]string{"html", inputFile})
+	rootCmd.SetArgs([]string{"ui", inputFile})
 	err = rootCmd.Execute()
 	assert.NoError(t, err)
 	assert.Equal(t, 0, exitCode)
@@ -49,7 +49,7 @@ func TestHtmlCmd_SingleObject(t *testing.T) {
 	assert.Contains(t, htmlStr, "</html>")
 }
 
-func TestHtmlCmd_ArrayInput(t *testing.T) {
+func TestUICmd_ArrayInput(t *testing.T) {
 	oldOsExit := shared.OsExit
 	defer func() { shared.OsExit = oldOsExit }()
 
@@ -72,7 +72,7 @@ func TestHtmlCmd_ArrayInput(t *testing.T) {
 	outFile := filepath.Join(tmpDir, "output.html")
 	shared.FlagState.OutputFile = outFile
 
-	rootCmd.SetArgs([]string{"html", inputFile})
+	rootCmd.SetArgs([]string{"ui", inputFile})
 	err = rootCmd.Execute()
 	assert.NoError(t, err)
 	assert.Equal(t, 0, exitCode)
@@ -87,19 +87,19 @@ func TestHtmlCmd_ArrayInput(t *testing.T) {
 	assert.Contains(t, htmlStr, "Test2")
 }
 
-func TestHtmlCmd_MissingFile(t *testing.T) {
+func TestUICmd_MissingFile(t *testing.T) {
 	oldOsExit := shared.OsExit
 	defer func() { shared.OsExit = oldOsExit }()
 
 	exitCode := 0
 	shared.OsExit = func(code int) { exitCode = code }
 
-	rootCmd.SetArgs([]string{"html", "/nonexistent/path.json"})
+	rootCmd.SetArgs([]string{"ui", "/nonexistent/path.json"})
 	rootCmd.Execute()
 	assert.Equal(t, 1, exitCode)
 }
 
-func TestHtmlCmd_NoArgs(t *testing.T) {
+func TestUICmd_NoArgs(t *testing.T) {
 	oldOsExit := shared.OsExit
 	defer func() { shared.OsExit = oldOsExit }()
 
@@ -107,12 +107,12 @@ func TestHtmlCmd_NoArgs(t *testing.T) {
 	shared.OsExit = func(code int) { exitCode = code }
 
 	shared.FlagState.DataURL = ""
-	rootCmd.SetArgs([]string{"html"})
+	rootCmd.SetArgs([]string{"ui"})
 	rootCmd.Execute()
 	assert.Equal(t, 1, exitCode)
 }
 
-func TestHtmlCmd_APIFlag(t *testing.T) {
+func TestUICmd_APIFlag(t *testing.T) {
 	oldOsExit := shared.OsExit
 	defer func() { shared.OsExit = oldOsExit }()
 
@@ -130,7 +130,7 @@ func TestHtmlCmd_APIFlag(t *testing.T) {
 	shared.FlagState.DataURL = "https://example.com/bench.json"
 	defer func() { shared.FlagState.DataURL = "" }()
 
-	rootCmd.SetArgs([]string{"html", "--data-url", "https://example.com/bench.json"})
+	rootCmd.SetArgs([]string{"ui", "--data-url", "https://example.com/bench.json"})
 	err = rootCmd.Execute()
 	assert.NoError(t, err)
 	assert.Equal(t, 0, exitCode)
@@ -144,7 +144,7 @@ func TestHtmlCmd_APIFlag(t *testing.T) {
 	assert.NotContains(t, htmlStr, `"name":"Bench`)
 }
 
-func TestHtmlCmd_APIFlag_InvalidURL(t *testing.T) {
+func TestUICmd_APIFlag_InvalidURL(t *testing.T) {
 	oldOsExit := shared.OsExit
 	defer func() { shared.OsExit = oldOsExit }()
 
@@ -154,12 +154,12 @@ func TestHtmlCmd_APIFlag_InvalidURL(t *testing.T) {
 	shared.FlagState.DataURL = "not-a-url"
 	defer func() { shared.FlagState.DataURL = "" }()
 
-	rootCmd.SetArgs([]string{"html", "--data-url", "not-a-url"})
+	rootCmd.SetArgs([]string{"ui", "--data-url", "not-a-url"})
 	rootCmd.Execute()
 	assert.Equal(t, 1, exitCode)
 }
 
-func TestHtmlCmd_InvalidJSON(t *testing.T) {
+func TestUICmd_InvalidJSON(t *testing.T) {
 	oldOsExit := shared.OsExit
 	defer func() { shared.OsExit = oldOsExit }()
 
@@ -175,12 +175,12 @@ func TestHtmlCmd_InvalidJSON(t *testing.T) {
 	inputFile := filepath.Join(tmpDir, "invalid.json")
 	os.WriteFile(inputFile, []byte("not json"), 0644)
 
-	rootCmd.SetArgs([]string{"html", inputFile})
+	rootCmd.SetArgs([]string{"ui", inputFile})
 	rootCmd.Execute()
 	assert.Equal(t, 1, exitCode)
 }
 
-func TestHtmlCmd_StdoutFallback(t *testing.T) {
+func TestUICmd_StdoutFallback(t *testing.T) {
 	oldOsExit := shared.OsExit
 	defer func() { shared.OsExit = oldOsExit }()
 
@@ -204,13 +204,13 @@ func TestHtmlCmd_StdoutFallback(t *testing.T) {
 
 	shared.FlagState.OutputFile = ""
 
-	rootCmd.SetArgs([]string{"html", inputFile})
+	rootCmd.SetArgs([]string{"ui", inputFile})
 	err = rootCmd.Execute()
 	assert.NoError(t, err)
 	assert.Equal(t, 0, exitCode)
 }
 
-func TestHtmlCmd_EmptyFile(t *testing.T) {
+func TestUICmd_EmptyFile(t *testing.T) {
 	oldOsExit := shared.OsExit
 	defer func() { shared.OsExit = oldOsExit }()
 
@@ -226,12 +226,12 @@ func TestHtmlCmd_EmptyFile(t *testing.T) {
 	inputFile := filepath.Join(tmpDir, "empty.json")
 	os.WriteFile(inputFile, []byte(""), 0644)
 
-	rootCmd.SetArgs([]string{"html", inputFile})
+	rootCmd.SetArgs([]string{"ui", inputFile})
 	rootCmd.Execute()
 	assert.Equal(t, 1, exitCode)
 }
 
-func TestHtmlCmd_MergedOutput(t *testing.T) {
+func TestUICmd_MergedOutput(t *testing.T) {
 	oldOsExit := shared.OsExit
 	defer func() { shared.OsExit = oldOsExit }()
 
@@ -263,7 +263,7 @@ func TestHtmlCmd_MergedOutput(t *testing.T) {
 	outFile := filepath.Join(tmpDir, "chart.html")
 	shared.FlagState.OutputFile = outFile
 
-	rootCmd.SetArgs([]string{"html", inputFile})
+	rootCmd.SetArgs([]string{"ui", inputFile})
 	err = rootCmd.Execute()
 	assert.NoError(t, err)
 	assert.Equal(t, 0, exitCode)
@@ -275,4 +275,40 @@ func TestHtmlCmd_MergedOutput(t *testing.T) {
 	assert.Contains(t, htmlStr, "v1.0.0")
 	assert.Contains(t, htmlStr, "v0.9.0")
 	assert.Contains(t, htmlStr, "Sort Benchmarks")
+}
+
+// TestUICmd_HtmlAlias verifies the legacy `html` alias still resolves to the ui command.
+func TestUICmd_HtmlAlias(t *testing.T) {
+	oldOsExit := shared.OsExit
+	defer func() { shared.OsExit = oldOsExit }()
+
+	var exitCode int
+	shared.OsExit = func(code int) { exitCode = code }
+
+	tmpDir, err := os.MkdirTemp("", "vizb-html-alias-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	bench := shared.Benchmark{
+		Name: "Bench1",
+		Data: []shared.BenchmarkData{
+			{Name: "Test1", XAxis: "1", YAxis: "100"},
+		},
+	}
+	inputFile := filepath.Join(tmpDir, "bench.json")
+	writeJSON(t, inputFile, bench)
+
+	outFile := filepath.Join(tmpDir, "output.html")
+	shared.FlagState.OutputFile = outFile
+
+	rootCmd.SetArgs([]string{"html", inputFile})
+	err = rootCmd.Execute()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+
+	content, err := os.ReadFile(outFile)
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), "Bench1")
 }

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -25,7 +25,7 @@ export default defineConfig({
 				items: [
 					{ label: 'vizb', slug: 'commands/root' },
 					{ label: 'vizb merge', slug: 'commands/merge' },
-					{ label: 'vizb html', slug: 'commands/html' },
+					{ label: 'vizb ui', slug: 'commands/ui' },
 				],
 			},
 			{

--- a/docs/src/content/docs/commands/ui.mdx
+++ b/docs/src/content/docs/commands/ui.mdx
@@ -1,6 +1,6 @@
 ---
-title: vizb html
-description: Generate HTML visualization from a benchmark JSON file.
+title: vizb ui
+description: Generate the interactive HTML UI from a benchmark JSON file.
 ---
 
 import { Aside } from '@astrojs/starlight/components';
@@ -10,10 +10,14 @@ Generate an interactive HTML chart from a vizb benchmark JSON file. This is the 
 ## Usage
 
 ```bash
-vizb html [file] [flags]
+vizb ui [file] [flags]
 ```
 
 `[file]` is optional when `--data-url` is set.
+
+<Aside type="note">
+  `vizb html` remains as a backward-compatible alias for `vizb ui`.
+</Aside>
 
 ## Input
 
@@ -35,7 +39,7 @@ A single JSON file containing a vizb benchmark object or array. This must be JSO
 vizb bench.txt -o data.json
 
 # Step 2: Generate HTML from JSON
-vizb html data.json -o report.html
+vizb ui data.json -o report.html
 ```
 
 ### After merging
@@ -45,7 +49,7 @@ vizb html data.json -o report.html
 vizb merge v1.json v2.json -o merged.json
 
 # Render the merged result as HTML
-vizb html merged.json -o report.html
+vizb ui merged.json -o report.html
 ```
 
 ### Remote data via `--data-url`
@@ -58,7 +62,7 @@ Instead of embedding the JSON inside the HTML, point the dashboard at a hosted U
 The generated HTML is a lean ~786 KB viewer; benchmark data is fetched at load time.
 
 ```bash
-vizb html --data-url https://example.com/bench.json -o report.html
+vizb ui --data-url https://example.com/bench.json -o report.html
 ```
 
 Upload `bench.json` to the URL separately (GitHub raw, S3, GitHub Pages, etc.), then open `report.html` in any browser.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -51,7 +51,7 @@ import LogoAnimation from '../../components/LogoAnimation.astro';
 ## Explore
 
 <CardGrid cols={2}>
-  <LinkCard title="Commands" description="All CLI flags and options for root, merge, and html commands." href="/commands/root" />
+  <LinkCard title="Commands" description="All CLI flags and options for root, merge, and ui commands." href="/commands/root" />
   <LinkCard title="CI/CD Integration" description="GitHub Action reference and step-by-step CI tutorials." href="/ci-cd/github-action" />
   <LinkCard title="Grouping Guide" description="Pattern and regex grouping for multi-dimensional data." href="/guides/grouping" />
   <LinkCard title="Merging Guide" description="Combine benchmarks with tag-based inner and outer merging." href="/guides/merging" />

--- a/docs/src/content/docs/internals/how-it-works.mdx
+++ b/docs/src/content/docs/internals/how-it-works.mdx
@@ -22,7 +22,7 @@ go test -bench .  →  raw text  →  parser  →  Benchmark struct  →  JSON /
 - cmd/
   - root.go          CLI entry point, flag definitions, parser discovery
   - merge.go         Merge command
-  - html.go          HTML generation command
+  - ui.go            HTML UI generation command
 - pkg/
   - parser/
     - registry.go        Parser registration (ParseFunc, Parsers map)


### PR DESCRIPTION
## What

Rename the `vizb html` subcommand to `vizb ui`. The old name described the output *format*, not the command's purpose — generating the interactive UI dashboard.

`html` is kept as a cobra **alias**, so existing users, CI pipelines, and the GitHub Action continue to work unchanged.

## Changes

- `cmd/html.go` → `cmd/ui.go`: `uiCmd` / `runUI`, `Aliases: ["html"]`
- `cmd/html_test.go` → `cmd/ui_test.go`: tests use `"ui"`, added `TestUICmd_HtmlAlias` for alias coverage
- `action.yml`: invokes `vizb ui`
- docs: renamed command page (`commands/html.mdx` → `ui.mdx`) with alias note, updated sidebar / index / internals refs

## Out of scope

`.html` output extension default and temp-file format string in `cmd/root.go` — those describe the file format, not the command name.

## Verification

- `go test ./...` — pass (incl. alias test)
- `vizb ui --help` shows `Aliases: ui, html`
- Both `vizb ui` and `vizb html` emit valid HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)