### PR TITLE
fix(bar,line): decouple --3d-visualmap from --3d

### DIFF
--- a/cmd/charts/bar/bar_test.go
+++ b/cmd/charts/bar/bar_test.go
@@ -93,8 +93,7 @@ func (s *BarSuite) TestBarCommandWithThreeDFlag() {
 	s.Require().True(ok)
 	s.Require().NotNil(barCfg.ThreeD)
 	s.True(*barCfg.ThreeD)
-	s.Require().NotNil(barCfg.ThreeDVisualMap)
-	s.True(*barCfg.ThreeDVisualMap)
+	s.Nil(barCfg.ThreeDVisualMap)
 }
 
 func (s *BarSuite) TestBarCommandWithThreeDVisualMapFlag() {

--- a/config/charts/bar/bar.go
+++ b/config/charts/bar/bar.go
@@ -71,9 +71,6 @@ func Materialise(flags Flags, override *Config) Config {
 	}
 	if flags.ThreeDVisualMap != nil {
 		out.ThreeDVisualMap = flags.ThreeDVisualMap
-	} else if flags.ThreeD {
-		v := true
-		out.ThreeDVisualMap = &v
 	}
 
 	if override != nil {

--- a/config/charts/bar/bar_test.go
+++ b/config/charts/bar/bar_test.go
@@ -67,8 +67,7 @@ func (s *BarSuite) TestMaterialiseBarPrecedence() {
 	got = Materialise(Flags{ThreeD: true}, nil)
 	s.Require().NotNil(got.ThreeD)
 	s.True(*got.ThreeD)
-	s.Require().NotNil(got.ThreeDVisualMap)
-	s.True(*got.ThreeDVisualMap)
+	s.Nil(got.ThreeDVisualMap)
 
 	falseVal := false
 	got = Materialise(Flags{ThreeD: true, ThreeDVisualMap: &falseVal}, nil)

--- a/config/charts/line/line.go
+++ b/config/charts/line/line.go
@@ -57,9 +57,6 @@ func Materialise(flags Flags, override *Config) Config {
 	}
 	if flags.ThreeDVisualMap != nil {
 		out.ThreeDVisualMap = flags.ThreeDVisualMap
-	} else if flags.ThreeD {
-		v := true
-		out.ThreeDVisualMap = &v
 	}
 
 	if override != nil {


### PR DESCRIPTION
## Summary

- `--3d` no longer implicitly enables `--3d-visualmap`; each flag is now independent
- Removed the `else if flags.ThreeD` auto-default in `Materialise` for both bar and line configs
- Updated tests to assert `ThreeDVisualMap` is `nil` when only `--3d` is passed

## Test plan

- [ ] `vizb bar --3d` → visualmap off by default
- [ ] `vizb bar --3d --3d-visualmap` → both on
- [ ] `vizb bar --3d-visualmap` (without `--3d`) → still works independently
- [ ] All existing tests pass (`go test ./...`)