### PR TITLE
feat(json): add --json-path to chart a nested array from a JSON envelope

### DIFF
--- a/cmd/cli/options.go
+++ b/cmd/cli/options.go
@@ -28,6 +28,7 @@ type CommonOptions struct {
 	TimeUnit     string
 	NumberUnit   string
 	Select       string
+	JSONPath     string
 }
 
 // Bind registers the common flags onto fs.
@@ -45,6 +46,7 @@ func (o *CommonOptions) Bind(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.Tag, "tag", "t", "", "Tag/identifier for the comparison")
 	fs.StringVarP(&o.Parser, "parser", "P", "auto", "Benchmark parser to use; 'auto' detects from input content (one of: auto, "+strings.Join(parser.AvailableParsers(), ", ")+")")
 	fs.StringVar(&o.Select, "select", "", "csv/json only: select value columns; optional rename with {label} (e.g. --select=price{Unit price},count)")
+	fs.StringVar(&o.JSONPath, "json-path", "", "json only: select a nested array to chart via a jq-like dot path (e.g. --json-path '.data.results')")
 }
 
 // validationRules returns the warn-and-default rules for the common fields,
@@ -111,6 +113,7 @@ func (o *CommonOptions) ParseConfig() parser.Config {
 	if err != nil {
 		shared.ExitWithError(err.Error(), nil)
 	}
+	cfg.JSONPath = o.JSONPath
 	if strings.TrimSpace(o.Select) != "" {
 		selected, err := parser.ParseSelectFlag(o.Select)
 		if err != nil {

--- a/cmd/cli/pipeline.go
+++ b/cmd/cli/pipeline.go
@@ -238,7 +238,7 @@ func prepareData(filePath, parserKey string, cfg parser.Config) []shared.DataPoi
 		shared.ExitWithError("--axes is only supported for csv/json parsers", nil)
 	}
 
-	fmt.Println(style.Info.Render("⚙️ Parsing data..."))
+	fmt.Println(style.Info.Render("🧲 Parsing data..."))
 	data := parseFn(filePath, cfg)
 
 	// CSV/JSON emit one DataPoint per row; when grouping is active, multiple rows

--- a/cmd/cli/pipeline.go
+++ b/cmd/cli/pipeline.go
@@ -12,6 +12,7 @@ import (
 	config_charts "github.com/goptics/vizb/config/charts"
 	"github.com/goptics/vizb/pkg/parser"
 	goparser "github.com/goptics/vizb/pkg/parser/golang"
+	jsonparser "github.com/goptics/vizb/pkg/parser/json"
 	"github.com/goptics/vizb/pkg/style"
 	"github.com/goptics/vizb/pkg/template"
 	"github.com/goptics/vizb/shared"
@@ -42,17 +43,31 @@ func RunLinearWithConfig(cmd *cobra.Command, args []string, common CommonOptions
 	// auto-selected parser so the choice is never silent.
 	if common.Parser == "auto" {
 		detected := parser.DetectParser(target)
+		// --json-path only makes sense for JSON; an envelope file starts with '{'
+		// which auto-detect reads as the "go" fallback, so nudge it to json.
+		if cfg.JSONPath != "" && detected != "json" {
+			detected = "json"
+		}
 		common.Parser = detected
 		fmt.Println(style.Info.Render("✨ Auto-detected parser: " + detected))
 	}
 	WarnThreeDIfIneligible(cfg, configs)
 	outFile := ResolveOutputFileName(common.OutputFile)
 
-	// First try to read the input as an existing vizb Dataset JSON.
-	dataSet := convertToDataset(target)
+	// First try to read the input as an existing vizb Dataset JSON. --json-path
+	// explicitly marks the input as raw enveloped data, not a vizb Dataset, so
+	// skip the passthrough (an envelope object would otherwise unmarshal into an
+	// empty Dataset and silently produce no output).
+	var dataSet *shared.Dataset
+	if cfg.JSONPath == "" {
+		dataSet = convertToDataset(target)
+	}
 	if dataSet == nil {
 		// Not Dataset JSON: parse raw/bench input into data points.
 		target = preprocessInputFile(target, common.Parser)
+		if common.Parser == "json" && cfg.JSONPath != "" {
+			target = applyJSONPath(target, cfg.JSONPath)
+		}
 		results := prepareData(target, common.Parser, cfg)
 		dataSet = assembleDataset(results, common, configs, cfg)
 	} else if applyOnPassthrough {
@@ -154,18 +169,23 @@ func writeStdinPipedInputs(tempfilePath string) {
 
 	for {
 		line, err := reader.ReadString('\n')
+
+		// ReadString returns the final chunk alongside io.EOF when the input has
+		// no trailing newline, so write it before handling the error — else a
+		// single-line, newline-less payload (e.g. a curl'd JSON envelope) is lost.
+		if len(line) > 0 {
+			if _, werr := writer.WriteString(line); werr != nil {
+				shared.ExitWithError("Error writing to file", werr)
+			}
+			dataSetProgressManager.ProcessLine(line)
+		}
+
 		if err != nil {
 			if err == io.EOF {
 				break
 			}
 			shared.ExitWithError("Error reading from stdin", err)
 		}
-
-		if _, err := writer.WriteString(line); err != nil {
-			shared.ExitWithError("Error writing to file", err)
-		}
-
-		dataSetProgressManager.ProcessLine(line)
 	}
 
 	dataSetProgressManager.Finish()
@@ -183,11 +203,31 @@ func preprocessInputFile(filePath, parserKey string) string {
 	return filePath
 }
 
+// applyJSONPath extracts the array named by cfg.JSONPath from the input file and
+// writes it to a temp file, which is returned for the JSON parser to consume.
+func applyJSONPath(filePath, path string) string {
+	bytes, err := jsonparser.SelectPath(filePath, path)
+	if err != nil {
+		shared.ExitWithError(err.Error(), nil)
+	}
+
+	out := shared.MustCreateTempFile(shared.TempBenchFilePrefix, "json")
+	shared.TempFiles.Store(out)
+	if err := os.WriteFile(out, bytes, 0o600); err != nil {
+		shared.ExitWithError("Error writing json-path result", err)
+	}
+	return out
+}
+
 // prepareData parses input into data points, aggregating grouped csv/json rows.
 func prepareData(filePath, parserKey string, cfg parser.Config) []shared.DataPoint {
 	parseFn, err := parser.GetParser(parserKey)
 	if err != nil {
 		shared.ExitWithError(err.Error(), nil)
+	}
+
+	if cfg.JSONPath != "" && parserKey != "json" {
+		fmt.Fprintln(os.Stderr, "warning: --json-path is only supported for the json parser; ignoring")
 	}
 
 	if len(cfg.Select) > 0 && parserKey != "csv" && parserKey != "json" {

--- a/cmd/cli/pipeline_test.go
+++ b/cmd/cli/pipeline_test.go
@@ -56,6 +56,29 @@ func (s *PipelineSuite) TestPreprocessInputFile() {
 	})
 }
 
+func (s *PipelineSuite) TestApplyJSONPathEnvelope() {
+	envelope := s.writeFile("env.json", `{"data":[{"impl":"a","ops":120},{"impl":"b","ops":80}]}`)
+
+	extracted := applyJSONPath(envelope, ".data")
+	s.FileExists(extracted)
+
+	cfg := parser.Config{GroupPattern: "x", Group: []string{"impl"}, JSONPath: ".data"}
+	results := prepareData(extracted, "json", cfg)
+	s.Len(results, 2)
+	s.ElementsMatch([]string{"a", "b"}, []string{results[0].XAxis, results[1].XAxis})
+}
+
+func (s *PipelineSuite) TestPrepareDataWarnsJSONPathIgnoredForNonJSONParser() {
+	benchFile := s.writeFile("valid.txt", `BenchmarkExample-8    1000000    1234 ns/op`)
+	cfg := parser.Config{GroupPattern: "y", TimeUnit: "ns", MemUnit: "B", JSONPath: ".data"}
+
+	errOut := testutil.CaptureStderr(func() {
+		results := prepareData(benchFile, "go", cfg)
+		s.NotEmpty(results)
+	})
+	s.Contains(errOut, "--json-path is only supported for the json parser")
+}
+
 func (s *PipelineSuite) TestPrepareDataWarnsSelectIgnoredForGoParser() {
 	benchFile := s.writeFile("valid.txt", `BenchmarkExample-8    1000000    1234 ns/op    1000 B/op    10 allocs/op`)
 	cfg := parser.Config{

--- a/docs/src/components/QuickExample.mdx
+++ b/docs/src/components/QuickExample.mdx
@@ -1,0 +1,36 @@
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+<Tabs syncKey="os">
+  <TabItem label="Linux / macOS" icon="seti:shell">
+
+```bash
+# Fetch GitHub contribution history from a public API and chart it in 3D
+curl -s "https://github-contributions-api.jogruber.de/v4/<your-github-username>" \
+  | vizb bar \
+      --group date \
+      --group-pattern '[z{Year}-y{Month}-x{Date}]' \
+      --json-path '.contributions' \
+      --select 'count{Contributions}' \
+      --stat \
+      --output index.html
+```
+
+  </TabItem>
+  <TabItem label="Windows" icon="seti:powershell">
+
+```ps1
+# Fetch GitHub contribution history from a public API and chart it in 3D
+(iwr "https://github-contributions-api.jogruber.de/v4/<your-github-username>").Content `
+  | vizb bar `
+      --group date `
+      --group-pattern '[z{Year}-y{Month}-x{Date}]' `
+      --json-path '.contributions' `
+      --select 'count{Contributions}' `
+      --stat `
+      --output index.html
+```
+
+  </TabItem>
+</Tabs>
+
+Each flag, top to bottom: **`--group date`** charts by the `date` field; **`--group-pattern '[z{Year}-y{Month}-x{Date}]'`** splits each `YYYY-MM-DD` cell into **z = Year, y = Month, x = Day** for a 3D scene; **`--json-path '.contributions'`** pulls the nested array out of the API envelope (and forces the `json` parser); **`--select 'count{Contributions}'`** plots the daily count as bar height; **`--stat`** adds the statistics panel. Swap in your own username and open `index.html`.

--- a/docs/src/components/QuickExample.mdx
+++ b/docs/src/components/QuickExample.mdx
@@ -4,33 +4,30 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   <TabItem label="Linux / macOS" icon="seti:shell">
 
 ```bash
-# Fetch GitHub contribution history from a public API and chart it in 3D
+# Fetch GitHub contribution history from a public API
 curl -s "https://github-contributions-api.jogruber.de/v4/<your-github-username>" \
   | vizb bar \
-      --group date \
-      --group-pattern '[z{Year}-y{Month}-x{Date}]' \
-      --json-path '.contributions' \
-      --select 'count{Contributions}' \
-      --stat \
-      --output index.html
+      --group date \                                  # group rows by date
+      --group-pattern '[z{Year}-y{Month}-x{Date}]' \  # YYYY-MM-DD → Year / Month / Day axes
+      --json-path '.contributions' \                  # pull nested array from API envelope
+      --select 'count{Contributions}' \               # keep only count; rename to Contributions
+      --stat \                                        # add statistics panel
+      --output index.html                             # self-contained HTML output
 ```
 
   </TabItem>
   <TabItem label="Windows" icon="seti:powershell">
 
 ```ps1
-# Fetch GitHub contribution history from a public API and chart it in 3D
+# Fetch GitHub contribution history from a public API
 (iwr "https://github-contributions-api.jogruber.de/v4/<your-github-username>").Content `
   | vizb bar `
-      --group date `
-      --group-pattern '[z{Year}-y{Month}-x{Date}]' `
-      --json-path '.contributions' `
-      --select 'count{Contributions}' `
-      --stat `
-      --output index.html
+      --group date `                                  # group rows by date
+      --group-pattern '[z{Year}-y{Month}-x{Date}]' `  # YYYY-MM-DD → Year / Month / Day axes
+      --json-path '.contributions' `                  # pull nested array from API envelope
+      --select 'count{Contributions}' `               # keep only count; rename to Contributions
+      --stat `                                        # add statistics panel
+      --output index.html                             # self-contained HTML output
 ```
-
   </TabItem>
 </Tabs>
-
-Each flag, top to bottom: **`--group date`** charts by the `date` field; **`--group-pattern '[z{Year}-y{Month}-x{Date}]'`** splits each `YYYY-MM-DD` cell into **z = Year, y = Month, x = Day** for a 3D scene; **`--json-path '.contributions'`** pulls the nested array out of the API envelope (and forces the `json` parser); **`--select 'count{Contributions}'`** plots the daily count as bar height; **`--stat`** adds the statistics panel. Swap in your own username and open `index.html`.

--- a/docs/src/content/docs/commands/root.mdx
+++ b/docs/src/content/docs/commands/root.mdx
@@ -82,6 +82,7 @@ for how the format is chosen.
 | `--group-regex` | `-r` | `""` | Regex-based grouping (named captures) |
 | `--group` | `-g` | `""` | Names dimensions in `--group-pattern` order. csv/json: column/field names (separators must match `-p`); benchmark parsers: human-readable axis labels |
 | `--select` | | `""` | csv/json only: select value columns; optional rename with `{label}` (e.g. `--select=price{Unit price},count`) |
+| `--json-path` | | `""` | json only: select a nested array to chart via a jq-like dot path (e.g. `--json-path '.data.results'`) |
 | `--scale` | `-S` | `linear` | Scale type: `linear` or `log` |
 | `--sort` | `-s` | `""` | Sort order: `asc` or `desc` (default: as-is) |
 | `--charts` | `-c` | `bar,line,pie` | Chart types to generate (`bar`, `line`, `scatter`, `pie`, `heatmap`, `radar`) |

--- a/docs/src/content/docs/guides/data.mdx
+++ b/docs/src/content/docs/guides/data.mdx
@@ -66,7 +66,7 @@ Produces series `sells`, `stocks`, and `mem.alloc`. `date` (string) is ignored.
 
 | Topic | Behaviour |
 |-------|-----------|
-| Shape | Top-level **array of objects**. A single top-level object is not supported (it is consumed by vizb's own dataset-JSON path). |
+| Shape | Top-level **array of objects**. A single top-level object is consumed by vizb's own dataset-JSON path; reach a nested array inside an envelope with [`--json-path`](#selecting-a-nested-array-with---json-path). |
 | Numeric value | A finite JSON **number** *or* a **numeric string** (`"10"` → 10). `bool`/`null` are ignored. |
 | Nested objects | Flattened to dotted keys: `{"mem":{"alloc":5}}` → `mem.alloc`. |
 | Arrays as values | Skipped. |
@@ -112,6 +112,29 @@ vizb sales.csv --select="price{USD}",count   # quote names with , { or }
 | Overlap | A column cannot be in both `--select` and `--group` |
 | Omitted | Auto-detect numeric columns (unchanged default) |
 
+## Selecting a nested array with `--json-path`
+
+The `json` parser expects a **top-level array**. When your rows are wrapped in an
+envelope — `{"data":{"results":[...]}}`, `{"runs":[{"samples":[...]}]}` — point
+`--json-path` at the nested array with a jq-like dot path:
+
+```bash
+vizb api.json --json-path '.data.results'              # auto-detected as json
+vizb api.json -P json --json-path '.runs[0].samples'   # array index then key
+vizb api.json --json-path '.items[]'                   # trailing [] = the array itself
+```
+
+| Topic | Behaviour |
+|-------|-----------|
+| Scope | `json` parser only; ignored (with warning) for other parsers |
+| Auto-detect | Supplying `--json-path` forces the `json` parser, so envelope files (which start with `{`) still resolve correctly |
+| Path grammar | Object keys (`.a.b`), array indices (`[n]`), optional leading `.`, trailing `[]` sugar. A **subset of jq**, no expressions or filters |
+| Result | An array is used as-is; a single object is wrapped into a one-element array; a scalar is a hard error |
+| Errors | A missing key, out-of-range index, or wrong-type step names the failing segment |
+
+The selected array is then parsed exactly like a normal top-level JSON array — all
+`--group`, `--select`, and aggregation rules above still apply.
+
 ## Aggregation
 
 CSV and JSON emit **one data point per row**. Raw tables routinely have many rows that
@@ -138,5 +161,5 @@ keeps the chart (and the [statistics panel](/ui/stats)) fast.
 ## Limitations
 
 - **CSV:** no thousands separators / currency / `%` parsing; comma delimiter only; no headerless files.
-- **JSON:** a single top-level object is unsupported; arrays-of-scalars are not exploded into series.
+- **JSON:** a single top-level object is treated as a vizb Dataset, not a row — use [`--json-path`](#selecting-a-nested-array-with---json-path) to chart a nested array inside an envelope; arrays-of-scalars are not exploded into series.
 - `--number-unit`/`-N` scales every numeric column/field uniformly.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -19,11 +19,18 @@ hero:
 
 import { CardGrid, Card, LinkCard } from '@astrojs/starlight/components';
 import QuickInstall from '../../components/QuickInstall.mdx';
+import QuickExample from '../../components/QuickExample.mdx';
 import LogoAnimation from '../../components/LogoAnimation.astro';
 
 ## Quick Install
 
 <QuickInstall />
+
+## Quick Example
+
+Pipe a public JSON API into vizb — no file, no build step. Open `index.html` and rotate your GitHub contributions in 3D.
+
+<QuickExample />
 
 ## Features
 

--- a/pkg/parser/json/jsonpath.go
+++ b/pkg/parser/json/jsonpath.go
@@ -1,0 +1,134 @@
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// SelectPath reads the JSON file, navigates to the node named by a jq-like dot
+// path, and returns it re-marshalled as a JSON array ready for ParseJSON.
+//
+// Path grammar (a deliberate subset of jq): an optional leading '.', then
+// segments separated by '.'. A segment is an object key, optionally followed by
+// one or more '[n]' array indices; a bare trailing '[]' is identity sugar for
+// "the array itself". Examples: ".data.results", ".runs[0].samples", "results[]".
+//
+// The resolved node is coerced to an array: an array is used as-is; a single
+// object is wrapped into a one-element array (so a path to one object still
+// charts); anything else is an error.
+//
+// ponytail: whole-file load is opt-in (--json-path only); the default JSON path
+// stays streaming. Upgrade to a streaming seek only if huge enveloped files
+// become a real case.
+func SelectPath(filename, path string) ([]byte, error) {
+	raw, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("error reading JSON: %w", err)
+	}
+
+	var root any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return nil, fmt.Errorf("error parsing JSON: %w", err)
+	}
+
+	node, err := navigate(root, path)
+	if err != nil {
+		return nil, err
+	}
+
+	switch v := node.(type) {
+	case []any:
+		return json.Marshal(v)
+	case map[string]any:
+		return json.Marshal([]any{v})
+	default:
+		return nil, fmt.Errorf("--json-path '%s' resolves to a scalar, not an array or object", path)
+	}
+}
+
+// navigate walks node following the path segments.
+func navigate(node any, path string) (any, error) {
+	for _, seg := range tokenize(path) {
+		var err error
+		if node, err = step(node, seg); err != nil {
+			return nil, err
+		}
+	}
+	return node, nil
+}
+
+// pathSeg is one key plus any array indices that follow it. A leading index
+// (key == "" with indices) handles a path that starts at an array, and the
+// "[]" identity sugar yields a key-less, index-less no-op.
+type pathSeg struct {
+	key     string
+	indices []int
+}
+
+// tokenize splits a dot path into segments. It is lenient: a leading '.' and a
+// trailing "[]" are stripped, and empty pieces are skipped.
+func tokenize(path string) []pathSeg {
+	path = strings.TrimSpace(path)
+	path = strings.TrimPrefix(path, ".")
+
+	var segs []pathSeg
+	for _, piece := range strings.Split(path, ".") {
+		if piece == "" {
+			continue
+		}
+
+		key := piece
+		var indices []int
+		if i := strings.IndexByte(piece, '['); i >= 0 {
+			key = piece[:i]
+			rest := piece[i:]
+			for rest != "" {
+				end := strings.IndexByte(rest, ']')
+				if end <= 1 { // "[]" identity or malformed → skip
+					rest = rest[min(end+1, len(rest)):]
+					continue
+				}
+				if n, err := strconv.Atoi(rest[1:end]); err == nil {
+					indices = append(indices, n)
+				}
+				rest = rest[end+1:]
+			}
+		}
+
+		if key == "" && len(indices) == 0 {
+			continue
+		}
+		segs = append(segs, pathSeg{key: key, indices: indices})
+	}
+	return segs
+}
+
+// step applies a single segment (key lookup then any array indices).
+func step(node any, seg pathSeg) (any, error) {
+	if seg.key != "" {
+		obj, ok := node.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("--json-path: cannot read key '%s' from a non-object", seg.key)
+		}
+		v, ok := obj[seg.key]
+		if !ok {
+			return nil, fmt.Errorf("--json-path: key '%s' not found", seg.key)
+		}
+		node = v
+	}
+
+	for _, idx := range seg.indices {
+		arr, ok := node.([]any)
+		if !ok {
+			return nil, fmt.Errorf("--json-path: cannot index [%d] into a non-array", idx)
+		}
+		if idx < 0 || idx >= len(arr) {
+			return nil, fmt.Errorf("--json-path: index [%d] out of range (len %d)", idx, len(arr))
+		}
+		node = arr[idx]
+	}
+	return node, nil
+}

--- a/pkg/parser/json/jsonpath_test.go
+++ b/pkg/parser/json/jsonpath_test.go
@@ -1,0 +1,96 @@
+package json
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectPath(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		path    string
+		want    string // expected marshalled array; "" when wantErr
+		wantErr string // substring expected in the error
+	}{
+		{
+			name:  "nested keys",
+			input: `{"data":{"results":[{"a":1},{"a":2}]}}`,
+			path:  ".data.results",
+			want:  `[{"a":1},{"a":2}]`,
+		},
+		{
+			name:  "array index then key",
+			input: `{"runs":[{"samples":[{"n":1}]}]}`,
+			path:  ".runs[0].samples",
+			want:  `[{"n":1}]`,
+		},
+		{
+			name:  "trailing [] identity sugar",
+			input: `{"items":[{"x":1}]}`,
+			path:  ".items[]",
+			want:  `[{"x":1}]`,
+		},
+		{
+			name:  "leading dot optional",
+			input: `{"rows":[{"x":1}]}`,
+			path:  "rows",
+			want:  `[{"x":1}]`,
+		},
+		{
+			name:  "single object wraps into array",
+			input: `{"only":{"x":3,"y":7}}`,
+			path:  ".only",
+			want:  `[{"x":3,"y":7}]`,
+		},
+		{
+			name:    "missing key",
+			input:   `{"data":[]}`,
+			path:    ".nope",
+			wantErr: "key 'nope' not found",
+		},
+		{
+			name:    "index out of range",
+			input:   `{"runs":[]}`,
+			path:    ".runs[0]",
+			wantErr: "out of range",
+		},
+		{
+			name:    "key into non-object",
+			input:   `{"n":5}`,
+			path:    ".n.deeper",
+			wantErr: "non-object",
+		},
+		{
+			name:    "index into non-array",
+			input:   `{"n":5}`,
+			path:    ".n[0]",
+			wantErr: "non-array",
+		},
+		{
+			name:    "path resolves to scalar",
+			input:   `{"n":5}`,
+			path:    ".n",
+			wantErr: "scalar",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := filepath.Join(t.TempDir(), "in.json")
+			require.NoError(t, os.WriteFile(f, []byte(tc.input), 0o644))
+
+			got, err := SelectPath(f, tc.path)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.JSONEq(t, tc.want, string(got))
+		})
+	}
+}

--- a/pkg/parser/registry.go
+++ b/pkg/parser/registry.go
@@ -25,6 +25,7 @@ type Config struct {
 	NumberUnit      string
 	Select          []ColumnSpec
 	Axes            []ColumnSpec // --axes value mode: numeric cols placed on x,y[,z]
+	JSONPath        string       // json only: jq-like dot path to the nested array to chart
 }
 
 type ParseFunc func(filename string, cfg Config) []shared.DataPoint


### PR DESCRIPTION
## What

Adds `--json-path`, a jq-like dot-path selector for the `json` parser. It pulls a
nested array out of a JSON envelope before parsing, so API payloads like
`{"data":{"results":[...]}}` or `{"runs":[{"samples":[...]}]}` chart directly —
no `jq` pre-processing step.

```bash
vizb api.json --json-path '.data.results'              # auto-detected as json
vizb api.json -P json --json-path '.runs[0].samples'   # array index then key
vizb api.json --json-path '.items[]'                   # trailing [] = the array itself
```

## Why

The `json` parser only accepted a **top-level array of objects**. Real-world JSON
(especially public APIs) wraps rows in an envelope, forcing users to shell out to
`jq` first. This makes vizb consume that data in one pipe.

## How

- **`parser.Config.JSONPath`** — new optional field (zero value = current behavior).
- **`pkg/parser/json/SelectPath`** — dot-path navigator: object keys (`.a.b`),
  array indices (`[n]`), optional leading `.`, trailing `[]` sugar. Stdlib only,
  **no new dependency**. Array → as-is; single object → 1-element array; scalar → error.
- **CLI wiring** — `--json-path` flag; auto-detect nudges to the `json` parser when
  a path is supplied (envelope files start with `{`); passthrough guard so an
  envelope object isn't mistaken for a vizb Dataset and silently emptied.
- **stdin fix** — the piped-input reader dropped the final chunk when input had no
  trailing newline, truncating a single-line `curl`'d JSON body. Now written before
  the EOF break.
- **Docs** — `--json-path` guide section + flag row, and a landing-page **Quick
  Example** (bash + PowerShell) rendering a GitHub contribution history in 3D.

## Tests

- `pkg/parser/json/jsonpath_test.go` — 10-case table: nested keys, index, `[]`,
  single-object wrap, and error paths (missing key, OOB, scalar, wrong-type step).
- `cmd/cli/pipeline_test.go` — envelope extraction → parse, and the non-json
  warn-and-ignore guard.
- Full `go test ./...` + UI suite green via pre-commit hook.