### PR TITLE
ci: parallelize gates and centralize action tests in CLI

### DIFF
--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Go
         if: env.ACT != 'true'
@@ -36,7 +36,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Go
         if: env.ACT != 'true'

--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Build vizb
         if: env.ACT != 'true'
@@ -42,6 +43,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Build vizb
         if: env.ACT != 'true'

--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -1,4 +1,4 @@
-name: test-action
+name: action
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -7,6 +7,8 @@ on:
       - '**.go'
       - go.mod
       - go.sum
+      - action.yml
+      - .github/workflows/action-ci.yml
       - .github/workflows/cli.yml
   pull_request:
     branches: [main]
@@ -14,6 +16,8 @@ on:
       - '**.go'
       - go.mod
       - go.sum
+      - action.yml
+      - .github/workflows/action-ci.yml
       - .github/workflows/cli.yml
 
 jobs:
@@ -32,7 +36,6 @@ jobs:
           version: v1.64
 
   format:
-    needs: lint
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
@@ -50,7 +53,6 @@ jobs:
           fi
 
   test:
-    needs: format
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
@@ -70,15 +72,6 @@ jobs:
         with:
           files: ./coverage.txt
 
-  build:
-    needs: test
-    runs-on: ubuntu-slim
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - run: go build -ldflags="-s -w" -o ./bin/vizb .
+  action:
+    needs: [lint, format, test]
+    uses: ./.github/workflows/action-ci.yml

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.64
+          version: v2.12
 
   format:
     runs-on: ubuntu-slim

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -24,21 +24,21 @@ jobs:
   lint:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: v1.64
 
   format:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-go@v6
         with:
@@ -55,7 +55,7 @@ jobs:
   test:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-go@v6
         with:
@@ -66,7 +66,7 @@ jobs:
 
       - run: go test -coverprofile=coverage.txt -covermode=atomic ./...
 
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,11 +15,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/deploy-examples-csv.yml
+++ b/.github/workflows/deploy-examples-csv.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - examples/csv/**
       - action.yml
-      - .github/workflows/test-action.yml
       - .github/workflows/deploy-examples-csv.yml
   workflow_run:
     workflows: [Release]
@@ -13,12 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    uses: ./.github/workflows/test-action.yml
-
   convert:
     name: Convert CSV Data
-    needs: test
     strategy:
       matrix:
         include:

--- a/.github/workflows/deploy-examples-csv.yml
+++ b/.github/workflows/deploy-examples-csv.yml
@@ -69,7 +69,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: ${{ matrix.name }}
         uses: ./
@@ -84,7 +84,7 @@ jobs:
           output-json: ${{ matrix.output }}.json
 
       - name: Uploading json artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: json-${{ matrix.output }}
           path: ${{ matrix.output }}.json

--- a/.github/workflows/deploy-examples-go.yml
+++ b/.github/workflows/deploy-examples-go.yml
@@ -69,7 +69,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: ${{ matrix.name }}
         uses: ./
@@ -87,7 +87,7 @@ jobs:
           output-json: ${{ matrix.output }}.json
 
       - name: Uploading json artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: json-${{ matrix.output }}
           path: ${{ matrix.output }}.json

--- a/.github/workflows/deploy-examples-go.yml
+++ b/.github/workflows/deploy-examples-go.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - examples/go/**
       - action.yml
-      - .github/workflows/test-action.yml
       - .github/workflows/deploy-examples-go.yml
   workflow_run:
     workflows: [Release]
@@ -13,12 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    uses: ./.github/workflows/test-action.yml
-
   convert:
     name: Convert Go Benchmarks
-    needs: test
     strategy:
       matrix:
         include:

--- a/.github/workflows/deploy-examples-javascript.yml
+++ b/.github/workflows/deploy-examples-javascript.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - examples/javascript/**
       - action.yml
-      - .github/workflows/test-action.yml
       - .github/workflows/deploy-examples-javascript.yml
   workflow_run:
     workflows: [Release]
@@ -13,12 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    uses: ./.github/workflows/test-action.yml
-
   convert:
     name: Convert Javascript Benchmarks
-    needs: test
     strategy:
       matrix:
         include:

--- a/.github/workflows/deploy-examples-javascript.yml
+++ b/.github/workflows/deploy-examples-javascript.yml
@@ -31,7 +31,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: ${{ matrix.name }}
         uses: ./
@@ -48,7 +48,7 @@ jobs:
           output-json: ${{ matrix.output }}.json
 
       - name: Uploading json artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: json-${{ matrix.output }}
           path: ${{ matrix.output }}.json

--- a/.github/workflows/deploy-examples-json.yml
+++ b/.github/workflows/deploy-examples-json.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - examples/json/**
       - action.yml
-      - .github/workflows/test-action.yml
       - .github/workflows/deploy-examples-json.yml
   workflow_run:
     workflows: [Release]
@@ -13,12 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    uses: ./.github/workflows/test-action.yml
-
   convert:
     name: Convert JSON Data
-    needs: test
     strategy:
       matrix:
         include:

--- a/.github/workflows/deploy-examples-json.yml
+++ b/.github/workflows/deploy-examples-json.yml
@@ -27,7 +27,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: ${{ matrix.name }}
         uses: ./
@@ -45,7 +45,7 @@ jobs:
           output-json: ${{ matrix.output }}.json
 
       - name: Uploading json artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: json-${{ matrix.output }}
           path: ${{ matrix.output }}.json

--- a/.github/workflows/deploy-examples-rust.yml
+++ b/.github/workflows/deploy-examples-rust.yml
@@ -31,7 +31,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: ${{ matrix.name }}
         uses: ./
@@ -48,7 +48,7 @@ jobs:
           output-json: ${{ matrix.output }}.json
 
       - name: Uploading json artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: json-${{ matrix.output }}
           path: ${{ matrix.output }}.json

--- a/.github/workflows/deploy-examples-rust.yml
+++ b/.github/workflows/deploy-examples-rust.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - examples/rust/**
       - action.yml
-      - .github/workflows/test-action.yml
       - .github/workflows/deploy-examples-rust.yml
   workflow_run:
     workflows: [Release]
@@ -13,12 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    uses: ./.github/workflows/test-action.yml
-
   convert:
     name: Convert Rust Benchmarks
-    needs: test
     strategy:
       matrix:
         include:

--- a/.github/workflows/merge-deploy-examples.yml
+++ b/.github/workflows/merge-deploy-examples.yml
@@ -14,10 +14,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Downloading json artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: json-*
           path: /tmp/jsons

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -52,7 +52,7 @@ jobs:
         run: go test -v ./...
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -20,13 +20,13 @@ jobs:
       run:
         working-directory: ui
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -42,13 +42,13 @@ jobs:
       run:
         working-directory: ui
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -64,13 +64,13 @@ jobs:
       run:
         working-directory: ui
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -84,13 +84,13 @@ jobs:
     needs: [lint, format, test]
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -37,7 +37,6 @@ jobs:
       - run: pnpm typecheck
 
   format:
-    needs: lint
     runs-on: ubuntu-slim
     defaults:
       run:
@@ -60,7 +59,6 @@ jobs:
       - run: pnpm format:check
 
   test:
-    needs: format
     runs-on: ubuntu-slim
     defaults:
       run:
@@ -83,7 +81,7 @@ jobs:
       - run: pnpm test
 
   build:
-    needs: test
+    needs: [lint, format, test]
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+version: "2"
+
+linters:
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -118,14 +118,14 @@ tasks:
     deps: [build:cli]
     cmds:
       - task: act:check
-      - act --bind --container-options "--user $(id -u):$(id -g)" workflow_dispatch -W .github/workflows/test-action.yml --job stateless --matrix os:ubuntu-latest
+      - act --bind --container-options "--user $(id -u):$(id -g)" workflow_dispatch -W .github/workflows/action-ci.yml --job stateless --matrix os:ubuntu-latest
 
   act:test:stateful:
     desc: Test action in stateful mode (merge + HTML + JSON)
     deps: [build:cli]
     cmds:
       - task: act:check
-      - act --bind --container-options "--user $(id -u):$(id -g)" workflow_dispatch -W .github/workflows/test-action.yml --job stateful --matrix os:ubuntu-latest
+      - act --bind --container-options "--user $(id -u):$(id -g)" workflow_dispatch -W .github/workflows/action-ci.yml --job stateful --matrix os:ubuntu-latest
 
   act:clean:
     desc: Clean up act test artifacts

--- a/action.yml
+++ b/action.yml
@@ -181,23 +181,26 @@ runs:
       id: resolve
       shell: bash
       run: |
-        printf '%s\n' \
-          'append_chart_stat_flags() {' \
-          '  local -n _args=$1' \
-          '  local _charts="$2" _chart_input="$3" _stat_val="$4"' \
-          '  [ -n "$_charts" ] && _args+=(-c "$_charts")' \
-          '  while IFS= read -r line; do' \
-          '    line="${line#"${line%%[![:space:]]*}"}"' \
-          '    [ -z "$line" ] && continue' \
-          '    case "$line" in \#*) continue ;; esac' \
-          '    _args+=(--chart "$line")' \
-          '  done <<< "$_chart_input"' \
-          '  if [ "$_stat_val" = "all" ] || [ "$_stat_val" = "true" ]; then' \
-          '    _args+=(--stat)' \
-          '  elif [ -n "$_stat_val" ]; then' \
-          '    _args+=("--stat=$_stat_val")' \
-          '  fi' \
-          '}' > "$RUNNER_TEMP/vizb-chart-flags.sh"
+        cat > "$RUNNER_TEMP/vizb-chart-flags.sh" <<'EOF'
+        append_chart_stat_flags() {
+          local _args_name=$1
+          local _charts="$2" _chart_input="$3" _stat_val="$4"
+          if [ -n "$_charts" ]; then
+            eval "${_args_name}+=( -c $(printf '%q' "$_charts") )"
+          fi
+          while IFS= read -r line; do
+            line="${line#"${line%%[![:space:]]*}"}"
+            [ -z "$line" ] && continue
+            case "$line" in \#*) continue ;; esac
+            eval "${_args_name}+=( --chart $(printf '%q' "$line") )"
+          done <<< "$_chart_input"
+          if [ "$_stat_val" = "all" ] || [ "$_stat_val" = "true" ]; then
+            eval "${_args_name}+=( --stat )"
+          elif [ -n "$_stat_val" ]; then
+            eval "${_args_name}+=( $(printf '%q' "--stat=${_stat_val}") )"
+          fi
+        }
+        EOF
 
         # New generic inputs take priority; fall back to deprecated bench-* aliases.
         FILE="${{ inputs.file }}"

--- a/action.yml
+++ b/action.yml
@@ -131,7 +131,7 @@ runs:
     - name: Cache vizb binary
       if: steps.version.outputs.is-major != 'true' && inputs.vizb-binary == ''
       id: cache-vizb
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ~/.local/bin/vizb
         key: vizb-${{ steps.version.outputs.tag }}-${{ runner.os }}-${{ runner.arch }}

--- a/cmd/charts/bar/bar.go
+++ b/cmd/charts/bar/bar.go
@@ -42,7 +42,7 @@ func NewCommand() *cobra.Command {
 		Long:  "Generate an interactive bar chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.",
 		Args:  cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			o.LinearOptions.Validate()
+			o.Validate()
 			cli.ValidateScale(&o.Scale)
 
 			var threeDVisualMap *bool
@@ -62,7 +62,7 @@ func NewCommand() *cobra.Command {
 				Stat:            o.Stat,
 			}, nil)
 
-			axes := parser.GroupAxes(o.CommonOptions.ParseConfig())
+			axes := parser.GroupAxes(o.ParseConfig())
 			if err := shared.ValidateSwap(cfg.Swap, axes); err != nil {
 				shared.ExitWithError(err.Error(), nil)
 			}

--- a/cmd/charts/heatmap/heatmap.go
+++ b/cmd/charts/heatmap/heatmap.go
@@ -28,7 +28,7 @@ func NewCommand() *cobra.Command {
 		Long:  "Generate an interactive heatmap chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.",
 		Args:  cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			o.LinearOptions.Validate()
+			o.Validate()
 
 			cfg := heatmapchart.Materialise(heatmapchart.Flags{
 				Swap:       o.Swap,
@@ -37,7 +37,7 @@ func NewCommand() *cobra.Command {
 				Stat:       o.Stat,
 			}, nil)
 
-			axes := parser.GroupAxes(o.CommonOptions.ParseConfig())
+			axes := parser.GroupAxes(o.ParseConfig())
 			if err := shared.ValidateSwap(cfg.Swap, axes); err != nil {
 				shared.ExitWithError(err.Error(), nil)
 			}
@@ -45,6 +45,6 @@ func NewCommand() *cobra.Command {
 			cli.RunSingleChart(cmd, args, o.CommonOptions, []config_charts.ChartConfig{cfg})
 		},
 	}
-	o.ChartOptions.Bind(cmd.Flags())
+	o.Bind(cmd.Flags())
 	return cmd
 }

--- a/cmd/charts/line/line.go
+++ b/cmd/charts/line/line.go
@@ -42,7 +42,7 @@ func NewCommand() *cobra.Command {
 		Long:  "Generate an interactive line chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.",
 		Args:  cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			o.LinearOptions.Validate()
+			o.Validate()
 			cli.ValidateScale(&o.Scale)
 
 			var threeDVisualMap *bool
@@ -62,7 +62,7 @@ func NewCommand() *cobra.Command {
 				Stat:            o.Stat,
 			}, nil)
 
-			axes := parser.GroupAxes(o.CommonOptions.ParseConfig())
+			axes := parser.GroupAxes(o.ParseConfig())
 			if err := shared.ValidateSwap(cfg.Swap, axes); err != nil {
 				shared.ExitWithError(err.Error(), nil)
 			}

--- a/cmd/charts/pie/pie.go
+++ b/cmd/charts/pie/pie.go
@@ -28,7 +28,7 @@ func NewCommand() *cobra.Command {
 		Long:  "Generate an interactive pie chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.",
 		Args:  cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			o.LinearOptions.Validate()
+			o.Validate()
 
 			cfg := piechart.Materialise(piechart.Flags{
 				Swap:       o.Swap,
@@ -37,7 +37,7 @@ func NewCommand() *cobra.Command {
 				Stat:       o.Stat,
 			}, nil)
 
-			axes := parser.GroupAxes(o.CommonOptions.ParseConfig())
+			axes := parser.GroupAxes(o.ParseConfig())
 			if err := shared.ValidateSwap(cfg.Swap, axes); err != nil {
 				shared.ExitWithError(err.Error(), nil)
 			}
@@ -45,6 +45,6 @@ func NewCommand() *cobra.Command {
 			cli.RunSingleChart(cmd, args, o.CommonOptions, []config_charts.ChartConfig{cfg})
 		},
 	}
-	o.ChartOptions.Bind(cmd.Flags())
+	o.Bind(cmd.Flags())
 	return cmd
 }

--- a/cmd/charts/radar/radar.go
+++ b/cmd/charts/radar/radar.go
@@ -27,7 +27,7 @@ func NewCommand() *cobra.Command {
 		Long:  "Generate an interactive radar chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.",
 		Args:  cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			o.LinearOptions.Validate()
+			o.Validate()
 
 			cfg := radarchart.Materialise(radarchart.Flags{
 				Swap:       o.Swap,
@@ -36,7 +36,7 @@ func NewCommand() *cobra.Command {
 				Stat:       o.Stat,
 			}, nil)
 
-			axes := parser.GroupAxes(o.CommonOptions.ParseConfig())
+			axes := parser.GroupAxes(o.ParseConfig())
 			if err := shared.ValidateSwap(cfg.Swap, axes); err != nil {
 				shared.ExitWithError(err.Error(), nil)
 			}
@@ -44,6 +44,6 @@ func NewCommand() *cobra.Command {
 			cli.RunSingleChart(cmd, args, o.CommonOptions, []config_charts.ChartConfig{cfg})
 		},
 	}
-	o.ChartOptions.Bind(cmd.Flags())
+	o.Bind(cmd.Flags())
 	return cmd
 }

--- a/cmd/charts/scatter/scatter.go
+++ b/cmd/charts/scatter/scatter.go
@@ -40,7 +40,7 @@ func NewCommand() *cobra.Command {
 		Long:  "Generate an interactive scatter chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.",
 		Args:  cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			o.LinearOptions.Validate()
+			o.Validate()
 			cli.ValidateScale(&o.Scale)
 
 			var threeDVisualMap *bool

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,7 +77,7 @@ func Execute() {
 }
 
 func init() {
-	rootOpts.LinearOptions.Bind(rootCmd.Flags())
+	rootOpts.Bind(rootCmd.Flags())
 	rootCmd.Flags().StringSliceVarP(&rootOpts.Charts, "charts", "c", defaultChartTypes, "Chart types to generate (bar, line, scatter, pie, heatmap, radar)")
 	rootCmd.Flags().StringArrayVar(&rootOpts.ChartSpecs, "chart", nil,
 		"Per-chart settings override: <type>:<key>=<val>(,<key>=<val>)* or bare flags (labels, 3d-rotate, 3d). "+
@@ -186,7 +186,7 @@ func runBenchmark(cmd *cobra.Command, args []string) {
 }
 
 func validateRootOptions() {
-	rootOpts.LinearOptions.Validate()
+	rootOpts.Validate()
 	utils.ApplyValidationRules([]utils.ValidationRule{{
 		Label:        "charts",
 		SliceValue:   &rootOpts.Charts,

--- a/pkg/parser/parse_pattern.go
+++ b/pkg/parser/parse_pattern.go
@@ -72,7 +72,7 @@ func findPatternMatches(pattern string) ([]patternMatch, error) {
 		}
 	}
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("Invalid part: %q; only name(n), xAxis(x), yAxis(y), zAxis(z) allowed", pattern)
+		return nil, fmt.Errorf("invalid part: %q; only name(n), xAxis(x), yAxis(y), zAxis(z) allowed", pattern)
 	}
 	return matches, nil
 }
@@ -84,7 +84,7 @@ func invalidPatternRemainder(s string) error {
 	}
 	for _, r := range s {
 		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			return fmt.Errorf("Invalid part: %q; only name(n), xAxis(x), yAxis(y), zAxis(z) allowed", s)
+			return fmt.Errorf("invalid part: %q; only name(n), xAxis(x), yAxis(y), zAxis(z) allowed", s)
 		}
 	}
 	return nil

--- a/pkg/parser/parse_pattern_test.go
+++ b/pkg/parser/parse_pattern_test.go
@@ -173,7 +173,7 @@ func (s *ParsePatternSuite) TestValidateGroupPattern() {
 		{name: "Valid pattern: name_yAxis", pattern: "name_yAxis"},
 		{name: "Valid pattern with shorthand: n_y/x", pattern: "n_y/x"},
 		{name: "Valid pattern: yAxis only", pattern: "yAxis"},
-		{name: "Invalid pattern: unknown part", pattern: "name_invalid", expectError: true, errorContains: "Invalid part:"},
+		{name: "Invalid pattern: unknown part", pattern: "name_invalid", expectError: true, errorContains: "invalid part:"},
 		{name: "Empty pattern", pattern: "", expectError: true, errorContains: "pattern cannot be empty"},
 		{name: "Valid pattern: all parts", pattern: "name_yAxis_xAxis"},
 		{name: "Valid pattern: xAxis without yAxis", pattern: "name_xAxis"},


### PR DESCRIPTION
## Summary

Restructures CI workflows for faster feedback and less duplication.

- **Parallel gates**: `lint`, `format`, and `test` now run in parallel in `cli.yml` and `ui.yml`; downstream jobs wait for all three.
- **Centralized action testing**: `test-action.yml` is renamed to `action-ci.yml` and invoked from `cli.yml` as the `action` job (3-OS matrix, act-compatible).
- **Removed redundancy**: drops the standalone CLI `build` job (action-ci already builds) and removes the duplicate `action-ci` gate from all `deploy-examples-*` workflows.

## Pipeline shape

```
lint  ─┐
format ─┼─→ action (action-ci.yml)
test  ─┘
```

## Files changed

- `.github/workflows/cli.yml`
- `.github/workflows/ui.yml`
- `.github/workflows/action-ci.yml` (renamed from `test-action.yml`)
- `.github/workflows/deploy-examples-*.yml` (5 files)
- `Taskfile.yml` (act paths)

## Notes

Deploy workflows triggered by Release or `workflow_dispatch` no longer run `action-ci` first; CLI covers that on Go/action changes.