### PR TITLE
fix(ci): use GITHUB_TOKEN for release approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,9 @@ jobs:
     steps:
       - uses: trstringer/manual-approval@v1
         with:
-          secret: ${{ secrets.GORELEASER_TOKEN }}
+          # Issue creation uses workflow permissions (issues: write). GORELEASER_TOKEN
+          # is a release PAT and often lacks Issues scope — that causes 403 on POST /issues.
+          secret: ${{ secrets.GITHUB_TOKEN }}
           approvers: fahimfaisaal
           minimum-approvals: 1
           issue-title: 'Release Approval: ${{ github.ref_name }}'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -101,6 +101,19 @@ tasks:
       - git push origin {{.VERSION}}
       - echo "Tag {{.VERSION}} pushed. GitHub Actions will create the release."
 
+  release:remove:
+    desc: Remove a botched release (GitHub release + local and remote tag)
+    prompt: Delete release/tag {{.VERSION}} on GitHub and locally?
+    vars:
+      VERSION: "{{.CLI_ARGS}}"
+    cmds:
+      - |
+        test -n "{{.VERSION}}" || { echo "Usage: task release:remove -- v1.2.3"; exit 1; }
+      - gh release delete "{{.VERSION}}" --yes --cleanup-tag 2>/dev/null || true
+      - git push origin --delete "{{.VERSION}}" 2>/dev/null || true
+      - git tag -d "{{.VERSION}}" 2>/dev/null || true
+      - echo "Removed {{.VERSION}} (GitHub release and tags, where present)"
+
   # ── Act: Local GitHub Actions Testing ──────────────────────
 
   act:install:


### PR DESCRIPTION
## Summary

Fixes release CI failing at `manual-approval` with:

```
403 Resource not accessible by personal access token
```

The approval step now uses `GITHUB_TOKEN` (workflow already grants `issues: write`). `GORELEASER_TOKEN` stays on the GoReleaser job only.

Also adds `task release:remove` to unwind a failed tag/release before retrying.

## Usage

```bash
# After merging, re-tag for v0.13.0:
task release:remove -- v0.13.0   # optional — clean up failed attempt
task release -- v0.13.0          # push tag again once fix is on main
```

## Test plan

- [x] Workflow YAML validates (approval uses `secrets.GITHUB_TOKEN`)
- [ ] Merge to main, then re-push `v0.13.0` or cut a new patch tag