### PR TITLE
fix(action): preserve scatter settings on merge-deploy

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ inputs:
     default: ""
   charts:
     description: "Chart types to generate (-c flag): bar, line, scatter, pie, heatmap, radar"
-    default: "bar,line,pie"
+    default: ""
   parser:
     description: "Parser to use: csv, json, go, js:tinybench, js:vitest, rs:criterion, rs:divan (-P flag)"
     default: "auto"

--- a/cmd/testing.go
+++ b/cmd/testing.go
@@ -40,6 +40,8 @@ func ResetTestState() {
 	mergeOpts.TagAxis = "n"
 
 	resetChanged(rootCmd.Flags())
+	resetChanged(uiCmd.Flags())
+	resetChanged(mergeCmd.Flags())
 }
 
 // resetChanged clears the Changed flag on every flag in fs so

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -12,6 +12,7 @@ import (
 	heatmapchart "github.com/goptics/vizb/config/charts/heatmap"
 	linechart "github.com/goptics/vizb/config/charts/line"
 	radarchart "github.com/goptics/vizb/config/charts/radar"
+	scatterchart "github.com/goptics/vizb/config/charts/scatter"
 	"github.com/goptics/vizb/pkg/template"
 	"github.com/goptics/vizb/shared"
 	"github.com/goptics/vizb/testutil"
@@ -265,6 +266,52 @@ func (s *UISuite) TestRunUIFiltersChartsOnExplicitFlag() {
 	settings := ds["settings"].([]any)
 	s.Require().Len(settings, 1)
 	s.Equal("bar", settings[0].(map[string]any)["type"])
+}
+
+func (s *UISuite) TestRunUIPreservesScatterSettingsWithoutChartsFlag() {
+	dir := s.T().TempDir()
+	input := filepath.Join(dir, "scatter.json")
+	threeD := true
+	threeDVisualMap := true
+	testutil.WriteJSON(s.T(), input, shared.Dataset{
+		Name: "Noise Grid",
+		Settings: []config_charts.ChartConfig{
+			&scatterchart.Config{
+				Type:            "scatter",
+				Scale:           "linear",
+				ThreeDRotate:    &threeD,
+				ThreeDVisualMap: &threeDVisualMap,
+			},
+		},
+		Data: []shared.DataPoint{{XAxis: "0", YAxis: "0", ZAxis: "0", Stats: []shared.Stat{{Type: "value", Value: shared.F64(1)}}}},
+	})
+
+	outFiltered := filepath.Join(dir, "filtered.html")
+	rootCmd.SetArgs([]string{"ui", "-o", outFiltered, "-c", "bar,line,pie", input})
+	s.Require().NoError(rootCmd.Execute())
+
+	filtered := s.extractVIZBDataArray(s.read(outFiltered))
+	s.Require().Len(filtered, 1)
+	filteredSettings := filtered[0].(map[string]any)["settings"].([]any)
+	s.Empty(filteredSettings, "explicit -c bar,line,pie should strip scatter settings")
+
+	ResetTestState()
+
+	outPreserved := filepath.Join(dir, "preserved.html")
+	rootCmd.SetArgs([]string{"ui", "-o", outPreserved, input})
+	s.Require().NoError(rootCmd.Execute())
+
+	html := s.read(outPreserved)
+	s.Equal([]string{"scatter"}, s.extractVIZBCharts(html))
+
+	preserved := s.extractVIZBDataArray(html)
+	s.Require().Len(preserved, 1)
+	preservedSettings := preserved[0].(map[string]any)["settings"].([]any)
+	s.Require().Len(preservedSettings, 1)
+	scatter := preservedSettings[0].(map[string]any)
+	s.Equal("scatter", scatter["type"])
+	s.Equal(true, scatter["threeDRotate"])
+	s.Equal(true, scatter["threeDVisualMap"])
 }
 
 func (s *UISuite) TestRunUIAppliesOverrides() {


### PR DESCRIPTION
## Summary

Noise Grid 21³ and 41³ CSV examples lost their chart settings after deployment (`settings: []` in `VIZB_DATA`), even though the convert artifacts contained the correct scatter config.

The merge-deploy job calls the action without a `charts` input, so it fell back to the action default `bar,line,pie`. That made the HTML step run `vizb ui merged.json -c bar,line,pie`, which strips scatter settings before embedding data. Locally, running `vizb ui` without `-c` preserved settings via `unionCharts`.

## Changes

- Clear the `charts` input default in `action.yml` so merge-deploy no longer passes `-c` to `vizb ui`
- Add a regression test covering scatter settings stripped with explicit `-c` and preserved without it
- Reset `uiCmd`/`mergeCmd` flag `Changed` state in `ResetTestState` for reliable ui tests

## Test plan

- [x] `go test -count=1 ./cmd/...`
- [x] Verified merged CSV JSON: `-c bar,line,pie` → empty settings; no `-c` → scatter settings with `threeDVisualMap`