### PR TITLE
feat: add terminal logo banner to install scripts

### DIFF
--- a/docs/public/install.ps1
+++ b/docs/public/install.ps1
@@ -2,6 +2,17 @@
 # Usage: irm https://vizb.goptics.org/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
+
+function Show-Logo {
+Write-Host @'
+\    ####
+ \ ++++        vizb installer
+  \**   izb    vizb.goptics.org
+   =
+'@
+}
+Show-Logo
+
 $InstallDir = "$env:LOCALAPPDATA\vizb"
 $Repo = "goptics/vizb"
 $Bin = "vizb.exe"

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -3,6 +3,16 @@
 
 set -euo pipefail
 
+show_logo() {
+cat <<'EOF'
+\    ####
+ \ ++++        vizb installer
+  \**   izb    vizb.goptics.org
+   =
+EOF
+}
+show_logo
+
 REPO="goptics/vizb"
 BIN="vizb"
 INSTALL_DIR="${HOME}/.local/bin"


### PR DESCRIPTION
Adds a monochrome ASCII banner to `install.sh` and `install.ps1` that renders at startup.

The logo echoes the vizb SVG wordmark using different characters per bar:

```
\    ####
 \ ++++        vizb installer
  \**   izb    vizb.goptics.org
   =
```

- No ANSI escape codes (survives curl | bash / irm | iex)
- Quoted heredocs prevent interpolation
- Existing info:/error: log lines unchanged