### PR TITLE
feat: add terminal logo banner to install scripts

### DIFF
--- a/docs/public/install.ps1
+++ b/docs/public/install.ps1
@@ -5,10 +5,12 @@ $ErrorActionPreference = "Stop"
 
 function Show-Logo {
 Write-Host @'
-\    ####
- \ ++++        vizb installer
-  \**   izb    vizb.goptics.org
-   =
+
+    \    ####
+     \ ++++        vizb installer
+      \**   izb    vizb.goptics.org
+       =
+
 '@
 }
 Show-Logo

--- a/docs/public/install.ps1
+++ b/docs/public/install.ps1
@@ -2,6 +2,17 @@
 # Usage: irm https://vizb.goptics.org/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
+
+function Show-Logo {
+Write-Host @'
+\    ####
+ \ ++++        vizb installer
+  \**   izb    vizb.goptics.org
+   =
+'@
+}
+Show-Logo
+
 $InstallDir = "$env:LOCALAPPDATA\vizb"
 $Repo = "goptics/vizb"
 $Bin = "vizb.exe"

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -3,6 +3,16 @@
 
 set -euo pipefail
 
+show_logo() {
+cat <<'EOF'
+\    ####
+ \ ++++        vizb installer
+  \**   izb    vizb.goptics.org
+   =
+EOF
+}
+show_logo
+
 REPO="goptics/vizb"
 BIN="vizb"
 INSTALL_DIR="${HOME}/.local/bin"

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -5,10 +5,12 @@ set -euo pipefail
 
 show_logo() {
 cat <<'EOF'
-\    ####
- \ ++++        vizb installer
-  \**   izb    vizb.goptics.org
-   =
+
+    \    ####
+     \ ++++        vizb installer
+      \**   izb    vizb.goptics.org
+       =
+
 EOF
 }
 show_logo


### PR DESCRIPTION
Adds a monochrome ASCII banner to `install.sh` and `install.ps1` that renders at startup with spacing and indentation.

```
    \    ####
     \ ++++        vizb installer
      \**   izb    vizb.goptics.org
       =
```

- No ANSI escape codes (survives curl | bash / irm | iex)
- Quoted heredocs prevent interpolation
- Empty line above/below the logo for breathing room
- 4-space indent centers the logo visually
- Existing info:/error: log lines unchanged