### PR TITLE
docs(readme): add quick example with platform-specific install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ irm https://vizb.goptics.org/install.ps1 | iex
 Run one command to turn your GitHub contribution history into a 3D skyline of your activity over time. Each year stacks as a new layer; within it, every day is a column whose height is your contribution count. Replace `<your-github-username>` with your GitHub username and open the generated `index.html`.
 
 <p align="center">
-  <video src="https://github.com/user-attachments/assets/7c949be7-165a-4f9f-9c59-bf85526b1c1e" controls width="100%"></video>
+  <video src="https://github.com/user-attachments/assets/07b03de7-6ab1-46bb-a7e7-0068050f188d" controls autoplay muted loop width="100%"></video>
   <br />
   <sub>Example: <a href="https://github.com/torvalds">torvalds</a> contribution history</sub>
 </p>

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ irm https://vizb.goptics.org/install.ps1 | iex
 Run one command to turn your GitHub contribution history into a 3D skyline of your activity over time. Each year stacks as a new layer; within it, every day is a column whose height is your contribution count. Replace `<your-github-username>` with your GitHub username and open the generated `index.html`.
 
 <p align="center">
-  <video src="https://github.com/user-attachments/assets/07b03de7-6ab1-46bb-a7e7-0068050f188d" controls autoplay muted loop width="100%"></video>
+  <video src="https://github.com/user-attachments/assets/07b03de7-6ab1-46bb-a7e7-0068050f188d" controls width="100%"></video>
   <br />
   <sub>Example: <a href="https://github.com/torvalds">torvalds</a> contribution history</sub>
 </p>

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ irm https://vizb.goptics.org/install.ps1 | iex
 
 ### Quick Example
 
-Turn your GitHub contribution history into a 3D skyline of your activity over time. Each year stacks as a new layer; within it, every day is a column whose height is your contribution count. Replace `<your-github-username>` with your GitHub username.
+Run one command to turn your GitHub contribution history into a 3D skyline of your activity over time. Each year stacks as a new layer; within it, every day is a column whose height is your contribution count. Replace `<your-github-username>` with your GitHub username and open the generated `index.html`.
 
 <p align="center">
   <video src="https://github.com/user-attachments/assets/7c949be7-165a-4f9f-9c59-bf85526b1c1e" controls width="100%"></video>

--- a/README.md
+++ b/README.md
@@ -43,13 +43,62 @@
 
 ### Quick Install
 
-```bash
-# Linux / macOS
-curl -fsSL https://vizb.goptics.org/install.sh | bash
+#### Linux / macOS
 
-# Windows
+```bash
+curl -fsSL https://vizb.goptics.org/install.sh | bash
+```
+
+#### Windows
+
+```powershell
 irm https://vizb.goptics.org/install.ps1 | iex
 ```
+
+### Quick Example
+
+Turn your GitHub contribution history into a 3D skyline of your activity over time. Each year stacks as a new layer; within it, every day is a column whose height is your contribution count. Replace `<your-github-username>` with your GitHub username.
+
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/7c949be7-165a-4f9f-9c59-bf85526b1c1e" controls width="100%"></video>
+  <br />
+  <sub>Example: <a href="https://github.com/torvalds">torvalds</a> contribution history</sub>
+</p>
+
+#### Linux / macOS
+
+```bash
+curl -s "https://github-contributions-api.jogruber.de/v4/<your-github-username>" \
+  | vizb bar \
+      --group date \
+      --group-pattern '[z{Year}-y{Month}-x{Date}]' \
+      --json-path '.contributions' \
+      --select 'count{Contributions}' \
+      --stat \
+      --output index.html
+```
+
+#### Windows
+
+```powershell
+(iwr "https://github-contributions-api.jogruber.de/v4/<your-github-username>").Content `
+  | vizb bar `
+      --group date `
+      --group-pattern '[z{Year}-y{Month}-x{Date}]' `
+      --json-path '.contributions' `
+      --select 'count{Contributions}' `
+      --stat `
+      --output index.html
+```
+
+Flags used:
+
+- `--group date` — group rows by date
+- `--group-pattern '[z{Year}-y{Month}-x{Date}]'` — split each date into Year / Month / Day axes (z / y / x)
+- `--json-path '.contributions'` — pull the nested contributions array out of the API envelope
+- `--select 'count{Contributions}'` — keep only the count column and rename it to `Contributions`
+- `--stat` — add the statistics panel
+- `--output index.html` — write a self-contained HTML file
 
 ### Go Toolchain
 

--- a/docs/src/components/QuickExample.mdx
+++ b/docs/src/components/QuickExample.mdx
@@ -30,7 +30,7 @@ curl -s "https://github-contributions-api.jogruber.de/v4/<your-github-username>"
   </TabItem>
 </Tabs>
 
-Turn your GitHub contribution history into a 3D skyline of your activity over time. Each year stacks as a new layer; within it, every day is a column whose height is your contribution count. Replace `<your-github-username>` with your GitHub username.
+Run one command to turn your GitHub contribution history into a 3D skyline of your activity over time. Each year stacks as a new layer; within it, every day is a column whose height is your contribution count. Replace `<your-github-username>` with your GitHub username and open the generated `index.html`.
 
 Flags used below:
 


### PR DESCRIPTION
## Summary

- Split Quick Install into separate Linux/macOS and Windows sections
- Add a Quick Example section that turns GitHub contribution history into a 3D skyline with one command
- Embed a torvalds demo video in the README
- Align the docs homepage Quick Example copy with the README wording

## Changes

- `README.md`: platform-specific install commands, quick example commands, demo video, and flag explanations
- `docs/src/components/QuickExample.mdx`: update intro to start with "Run one command..."

## Test plan

- [ ] Preview README rendering on GitHub (video embed, platform sections)
- [ ] Verify docs homepage Quick Example section reads correctly