### PR TITLE
chore(charts): increase default marker size and 3D fill ratio

### DIFF
--- a/ui/src/composables/charts/shared/3d.test.ts
+++ b/ui/src/composables/charts/shared/3d.test.ts
@@ -46,16 +46,16 @@ describe('boxSizeForAxisCount', () => {
 
 describe('bandFillRatioForCount', () => {
   it('clamps sparse grids to low fill and dense grids to high fill', () => {
-    expect(bandFillRatioForCount(1)).toBe(0.45)
-    expect(bandFillRatioForCount(2)).toBe(0.45)
-    expect(bandFillRatioForCount(40)).toBe(0.92)
-    expect(bandFillRatioForCount(100)).toBe(0.92)
+    expect(bandFillRatioForCount(1)).toBe(0.52)
+    expect(bandFillRatioForCount(2)).toBe(0.52)
+    expect(bandFillRatioForCount(40)).toBe(0.96)
+    expect(bandFillRatioForCount(100)).toBe(0.96)
   })
 
   it('ramps monotonically between sparse and dense', () => {
     const mid = bandFillRatioForCount(20)
-    expect(mid).toBeGreaterThan(0.45)
-    expect(mid).toBeLessThan(0.92)
+    expect(mid).toBeGreaterThan(0.52)
+    expect(mid).toBeLessThan(0.96)
     expect(bandFillRatioForCount(10)).toBeLessThan(bandFillRatioForCount(30))
   })
 })

--- a/ui/src/composables/charts/shared/3d.ts
+++ b/ui/src/composables/charts/shared/3d.ts
@@ -178,8 +178,8 @@ export function orthographicSizeFor3DBox(
   return boxExtent3D(boxWidth, boxDepth, boxHeight) * 1.5
 }
 
-const BAND_FILL_MIN = 0.45
-const BAND_FILL_MAX = 0.92
+const BAND_FILL_MIN = 0.52
+const BAND_FILL_MAX = 0.96
 const BAND_FILL_LO = 2
 const BAND_FILL_HI = 40
 

--- a/ui/src/composables/charts/shared/valueMode.ts
+++ b/ui/src/composables/charts/shared/valueMode.ts
@@ -13,9 +13,9 @@ import {
 } from './chartConfig'
 import { adjustForLogScaleLine, getEffectiveScale } from './common'
 
-const defaultScatterSymbol = { symbol: 'circle' as const, symbolSize: 8 }
-const largeScatterSymbol = { symbol: 'circle' as const, symbolSize: 5 }
-const defaultLineSymbol = { symbol: 'circle' as const, symbolSize: 7 }
+const defaultScatterSymbol = { symbol: 'circle' as const, symbolSize: 10 }
+const largeScatterSymbol = { symbol: 'circle' as const, symbolSize: 6 }
+const defaultLineSymbol = { symbol: 'circle' as const, symbolSize: 9 }
 const largeLineSymbol = { symbol: 'none', sampling: 'lttb' as const }
 
 export function sortValueTuples(

--- a/ui/src/composables/charts/useCategorySeriesChartOptions.ts
+++ b/ui/src/composables/charts/useCategorySeriesChartOptions.ts
@@ -33,13 +33,13 @@ const SERIES_STYLE: Record<
   }
 > = {
   line: {
-    defaultSymbol: { symbol: 'circle', symbolSize: 7 },
+    defaultSymbol: { symbol: 'circle', symbolSize: 9 },
     largeSymbol: { symbol: 'none', sampling: 'lttb' },
     connectNulls: true,
   },
   scatter: {
-    defaultSymbol: { symbol: 'circle', symbolSize: 8 },
-    largeSymbol: { symbol: 'circle', symbolSize: 5 },
+    defaultSymbol: { symbol: 'circle', symbolSize: 10 },
+    largeSymbol: { symbol: 'circle', symbolSize: 6 },
   },
 }
 


### PR DESCRIPTION
## Summary
Slightly larger default markers for 2D line/scatter and 3D scatter grids.

- 2D defaults: scatter 8→10, line 7→9 (large-dataset scatter 5→6)
- 3D band fill ratio: sparse 0.45→0.52, dense 0.92→0.96

No CLI changes. Complements #166 (`--symbol` / `--symbol-size` overrides).

## Test plan
- [x] `cd ui && npm test -- src/composables/charts/shared/3d.test.ts`