### PR TITLE
feat(ci): replace artifact storage with R2 in stateful CI example

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -4,15 +4,15 @@ on:
   push:
     branches: [main]
     paths:
-      - 'ui/**'
-      - 'pkg/template/vizb-ui.gen.go'
-      - '.github/workflows/ui.yml'
+      - "ui/**"
+      - "pkg/template/vizb-ui.gen.go"
+      - ".github/workflows/ui.yml"
   pull_request:
     branches: [main]
     paths:
-      - 'ui/**'
-      - 'pkg/template/vizb-ui.gen.go'
-      - '.github/workflows/ui.yml'
+      - "ui/**"
+      - "pkg/template/vizb-ui.gen.go"
+      - ".github/workflows/ui.yml"
 
 jobs:
   lint:
@@ -100,6 +100,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: true
 
       - run: pnpm install --frozen-lockfile
         working-directory: ui

--- a/docs/src/content/docs/ci-cd/stateful.mdx
+++ b/docs/src/content/docs/ci-cd/stateful.mdx
@@ -5,12 +5,12 @@ description: Track benchmark performance across releases with artifact persisten
 
 import { Steps, Aside } from '@astrojs/starlight/components';
 
-Stateful CI tracks benchmark performance over time. Each run merges with historical data, creating a progressive visualization that shows how performance changes across releases.
+Stateful CI tracks benchmark performance over time. Each run merges with historical data, creating a progressive visualization that shows how performance changes across releases. Vizb is language-agnostic — its parser strategy auto-detects the format, supporting Go, Rust, JavaScript, CSV, JSON, and more.
 
 ## How It Works
 
 1. Each release run tags benchmarks with the version
-2. Previous benchmark data is downloaded from artifacts
+2. Previous benchmark data is downloaded from artifacts or S3 compatible storage
 3. Vizb merges old and new data with tag-based deep merge
 4. The merged result is uploaded as an artifact for the next run
 5. HTML report shows all versions in a single chart
@@ -36,31 +36,33 @@ Stateful CI tracks benchmark performance over time. Each run merges with histori
        steps:
          - uses: actions/checkout@v4
 
-         - uses: actions/setup-go@v6
+         - uses: actions/setup-go@v5
            with:
              go-version-file: go.mod
 
-         - name: Download previous benchmark data
-           uses: dawidd6/action-download-artifact@v21
+         - name: Fetch existing merged.json from R2
+           uses: cloudflare/wrangler-action@v4
            continue-on-error: true
            with:
-             workflow: bench.yml
-             name: merged.json
-             path: prev
+             apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+             accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+             command: r2 object get my-bench-data/merged.json --file=prev-merged.json --remote
 
          - uses: goptics/vizb@v0
            with:
              cmd: "go test -bench=."
              tag: ${{ github.ref_name }}
-             merge-dir: prev
+             merge-dir: prev-merged.json
              tag-axis: x
              output-json: merged.json
              output-html: pages/index.html
 
-         - uses: actions/upload-artifact@v4
+         - name: Upload merged.json to R2
+           uses: cloudflare/wrangler-action@v4
            with:
-             name: merged.json
-             path: merged.json
+             apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+             accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+             command: r2 object put my-bench-data/merged.json --file=merged.json --content-type=application/json --remote
 
          - uses: peaceiris/actions-gh-pages@v4
            with:


### PR DESCRIPTION
Replaces GitHub Artifact download/upload with Cloudflare R2 for persistent benchmark storage in the stateful CI example.

**Changes:**
- Swap `dawidd6/action-download-artifact` + `actions/upload-artifact` for `cloudflare/wrangler-action` with R2 object get/put
- Update `merge-dir` to `prev-merged.json` to match R2 filename
- Add `cache: true` to setup-go in UI workflow
- Note language-agnostic parser strategy in stateful CI doc