### PR TITLE
fix(merge): replace only colliding tag data on same-tag merge

### DIFF
--- a/shared/merge.go
+++ b/shared/merge.go
@@ -31,7 +31,23 @@ func MergeDatasets(benchmarks []Dataset, dim Dimension) []Dataset {
 			tag = noTagKey
 		}
 
-		if existing, exists := tags[tag]; exists && existing.Timestamp >= ds.Timestamp {
+		if existing, exists := tags[tag]; exists {
+			if tag == noTagKey {
+				if existing.Timestamp >= ds.Timestamp {
+					continue
+				}
+				tags[tag] = &ds
+				continue
+			}
+
+			var newer, older Dataset
+			if existing.Timestamp >= ds.Timestamp {
+				newer, older = *existing, ds
+			} else {
+				newer, older = ds, *existing
+			}
+			replaced := replaceTagData(pickAccumulatedBase(older, newer), newer, dim)
+			tags[tag] = &replaced
 			continue
 		}
 
@@ -175,6 +191,66 @@ func buildHistory(benchmarks []Dataset, latestTag string) []HistoryEntry {
 	return entries
 }
 
+func pickAccumulatedBase(a, b Dataset) Dataset {
+	if len(a.History) != len(b.History) {
+		if len(a.History) > len(b.History) {
+			return a
+		}
+		return b
+	}
+	if len(a.Data) >= len(b.Data) {
+		return a
+	}
+	return b
+}
+
+// replaceTagData swaps only data points belonging to incoming.Tag on the inject
+// dimension, preserving accumulated versions from an already-merged dataset.
+func replaceTagData(existing, incoming Dataset, dim Dimension) Dataset {
+	tag := incoming.Tag
+	kept := make([]DataPoint, 0, len(existing.Data))
+	for _, item := range existing.Data {
+		if !dataPointBelongsToTag(item, tag, dim) {
+			kept = append(kept, deepCloneData(item))
+		}
+	}
+
+	result := deepCloneDataset(existing)
+	result.Data = append(kept, mergeDataForTag(incoming, dim)...)
+	result.Tag = incoming.Tag
+	result.Timestamp = incoming.Timestamp
+	if incoming.Meta != nil {
+		m := *incoming.Meta
+		if incoming.Meta.CPU != nil {
+			cpu := *incoming.Meta.CPU
+			m.CPU = &cpu
+		}
+		result.Meta = &m
+	}
+	return result
+}
+
+func dataPointBelongsToTag(item DataPoint, tag string, dim Dimension) bool {
+	val := dimFieldValue(item, dim)
+	if val == "" {
+		return true
+	}
+	return val == tag
+}
+
+func dimFieldValue(item DataPoint, dim Dimension) string {
+	switch dim {
+	case DimensionXAxis:
+		return item.XAxis
+	case DimensionYAxis:
+		return item.YAxis
+	case DimensionZAxis:
+		return item.ZAxis
+	default:
+		return item.Name
+	}
+}
+
 func mergeData(benchmarks []Dataset, dim Dimension) []DataPoint {
 	var result []DataPoint
 	for _, ds := range benchmarks {
@@ -184,6 +260,21 @@ func mergeData(benchmarks []Dataset, dim Dimension) []DataPoint {
 			} else {
 				result = append(result, deepCloneData(item))
 			}
+		}
+	}
+	return result
+}
+
+func mergeDataForTag(ds Dataset, dim Dimension) []DataPoint {
+	var result []DataPoint
+	for _, item := range ds.Data {
+		if !dataPointBelongsToTag(item, ds.Tag, dim) {
+			continue
+		}
+		if dimFieldEmpty(item, dim) {
+			result = append(result, injectTag(item, ds.Tag, dim))
+		} else {
+			result = append(result, deepCloneData(item))
 		}
 	}
 	return result

--- a/shared/merge_test.go
+++ b/shared/merge_test.go
@@ -301,6 +301,62 @@ func (s *MergeSuite) TestMergeDatasetsTagOrderChronological() {
 	}, result[0].History)
 }
 
+func (s *MergeSuite) TestMergeReplaceSameTagPreservesOlderVersions() {
+	accumulated := makeBench("v1.8.0", "Bench", "2026-07-04T05:09:39Z", []DataPoint{
+		{Name: "Add", XAxis: "v1.3.0", YAxis: "Queue"},
+		{Name: "Add", XAxis: "v1.7.1", YAxis: "Queue"},
+		{Name: "Add", XAxis: "v1.8.0", YAxis: "Queue", Stats: []Stat{{Type: "time", Value: F64(99)}}},
+	})
+	accumulated.History = []HistoryEntry{
+		{Tag: "v1.3.0", Timestamp: "2026-05-25T08:44:05Z"},
+		{Tag: "v1.7.1", Timestamp: "2026-05-25T09:21:58Z"},
+	}
+
+	incoming := makeBench("v1.8.0", "Bench", "2026-07-04T05:33:48Z", []DataPoint{
+		{Name: "Add", XAxis: "", YAxis: "Queue", Stats: []Stat{{Type: "time", Value: F64(2141)}}},
+		{Name: "AddAll", XAxis: "", YAxis: "Queue", Stats: []Stat{{Type: "time", Value: F64(1489434)}}},
+	})
+
+	result := MergeDatasets([]Dataset{incoming, accumulated}, DimensionXAxis)
+	s.Require().Len(result, 1)
+	s.Equal("v1.8.0", result[0].Tag)
+	s.Equal("2026-07-04T05:33:48Z", result[0].Timestamp)
+	s.Equal([]HistoryEntry{
+		{Tag: "v1.3.0", Timestamp: "2026-05-25T08:44:05Z"},
+		{Tag: "v1.7.1", Timestamp: "2026-05-25T09:21:58Z"},
+	}, result[0].History)
+
+	s.Require().Len(result[0].Data, 4)
+	s.Equal("v1.3.0", result[0].Data[0].XAxis)
+	s.Equal("v1.7.1", result[0].Data[1].XAxis)
+	s.Equal("v1.8.0", result[0].Data[2].XAxis)
+	s.Equal(2141.0, *result[0].Data[2].Stats[0].Value)
+	s.Equal("v1.8.0", result[0].Data[3].XAxis)
+	s.Equal("AddAll", result[0].Data[3].Name)
+}
+
+func (s *MergeSuite) TestMergeReplaceSameTagSkipsOlderIncoming() {
+	accumulated := makeBench("v1.8.0", "Bench", "2026-07-04T05:33:48Z", []DataPoint{
+		{Name: "Add", XAxis: "v1.3.0", YAxis: "Queue"},
+		{Name: "Add", XAxis: "v1.8.0", YAxis: "Queue", Stats: []Stat{{Type: "time", Value: F64(2141)}}},
+	})
+	accumulated.History = []HistoryEntry{{Tag: "v1.3.0", Timestamp: "2026-05-25T08:44:05Z"}}
+
+	older := makeBench("v1.8.0", "Bench", "2026-07-04T05:09:39Z", []DataPoint{
+		{Name: "Add", XAxis: "", YAxis: "Queue", Stats: []Stat{{Type: "time", Value: F64(99)}}},
+	})
+
+	result := MergeDatasets([]Dataset{older, accumulated}, DimensionXAxis)
+	s.Require().Len(result, 1)
+	s.Equal("2026-07-04T05:33:48Z", result[0].Timestamp)
+	s.Require().Len(result[0].Data, 2)
+	s.Equal("v1.3.0", result[0].Data[0].XAxis)
+	s.Equal(2141.0, *result[0].Data[1].Stats[0].Value)
+	s.Equal([]HistoryEntry{
+		{Tag: "v1.3.0", Timestamp: "2026-05-25T08:44:05Z"},
+	}, result[0].History)
+}
+
 func TestMergeSuite(t *testing.T) {
 	suite.Run(t, new(MergeSuite))
 }

--- a/shared/merge_test.go
+++ b/shared/merge_test.go
@@ -335,6 +335,116 @@ func (s *MergeSuite) TestMergeReplaceSameTagPreservesOlderVersions() {
 	s.Equal("AddAll", result[0].Data[3].Name)
 }
 
+func (s *MergeSuite) TestMergeNoTagNewerReplacesOlder() {
+	bench1 := Dataset{
+		Name:      "Bench",
+		Timestamp: "2026-01-01T00:00:00Z",
+		Data:      []DataPoint{{Name: "first"}},
+	}
+	bench2 := Dataset{
+		Name:      "Bench",
+		Timestamp: "2026-02-01T00:00:00Z",
+		Data:      []DataPoint{{Name: "second"}},
+	}
+
+	result := MergeDatasets([]Dataset{bench1, bench2}, DimensionName)
+	s.Require().Len(result, 1)
+	s.Equal("second", result[0].Data[0].Name)
+}
+
+func (s *MergeSuite) TestPickAccumulatedBasePrefersMoreHistory() {
+	withHistory := Dataset{History: []HistoryEntry{{Tag: "v1", Timestamp: "t1"}}}
+	withoutHistory := Dataset{Data: []DataPoint{{Name: "a"}, {Name: "b"}}}
+
+	s.Equal(withHistory, pickAccumulatedBase(withoutHistory, withHistory))
+	s.Equal(withHistory, pickAccumulatedBase(withHistory, withoutHistory))
+}
+
+func (s *MergeSuite) TestPickAccumulatedBasePrefersMoreDataWhenHistoryEqual() {
+	smaller := Dataset{Data: []DataPoint{{Name: "one"}}}
+	larger := Dataset{Data: []DataPoint{{Name: "one"}, {Name: "two"}}}
+
+	s.Equal(larger, pickAccumulatedBase(smaller, larger))
+	s.Equal(larger, pickAccumulatedBase(larger, smaller))
+}
+
+func (s *MergeSuite) TestReplaceTagDataUpdatesMeta() {
+	existing := makeBench("v1", "Bench", "2026-01-01T00:00:00Z", []DataPoint{
+		{Name: "Add", XAxis: "v1", YAxis: "Queue"},
+	})
+	incoming := makeBench("v1", "Bench", "2026-02-01T00:00:00Z", []DataPoint{
+		{Name: "Add", XAxis: "", YAxis: "Queue"},
+	})
+	incoming.Meta = &Meta{
+		CPU:  &CPUInfo{Name: "Apple M2", Cores: 10},
+		OS:   "darwin",
+		Arch: "arm64",
+		Pkg:  "github.com/example/pkg",
+	}
+
+	result := replaceTagData(existing, incoming, DimensionXAxis)
+	s.Equal("2026-02-01T00:00:00Z", result.Timestamp)
+	s.Require().NotNil(result.Meta)
+	s.Require().NotNil(result.Meta.CPU)
+	s.Equal("Apple M2", result.Meta.CPU.Name)
+	s.Equal("darwin", result.Meta.OS)
+	s.NotSame(incoming.Meta.CPU, result.Meta.CPU)
+}
+
+func (s *MergeSuite) TestMergeReplaceSameTagOnYAxis() {
+	accumulated := makeBench("v2", "Bench", "2026-07-04T05:09:39Z", []DataPoint{
+		{Name: "Add", XAxis: "Queue", YAxis: "v1"},
+		{Name: "Add", XAxis: "Queue", YAxis: "v2", Stats: []Stat{{Type: "time", Value: F64(99)}}},
+	})
+	incoming := makeBench("v2", "Bench", "2026-07-04T05:33:48Z", []DataPoint{
+		{Name: "Add", XAxis: "Queue", YAxis: "", Stats: []Stat{{Type: "time", Value: F64(200)}}},
+	})
+
+	result := MergeDatasets([]Dataset{incoming, accumulated}, DimensionYAxis)
+	s.Require().Len(result, 1)
+	s.Require().Len(result[0].Data, 2)
+	s.Equal("v1", result[0].Data[0].YAxis)
+	s.Equal("v2", result[0].Data[1].YAxis)
+	s.Equal(200.0, *result[0].Data[1].Stats[0].Value)
+}
+
+func (s *MergeSuite) TestMergeReplaceSameTagOnZAxis() {
+	accumulated := makeBench("v2", "Bench", "2026-07-04T05:09:39Z", []DataPoint{
+		{Name: "Add", XAxis: "x", YAxis: "y", ZAxis: "v1"},
+		{Name: "Add", XAxis: "x", YAxis: "y", ZAxis: "v2"},
+	})
+	incoming := makeBench("v2", "Bench", "2026-07-04T05:33:48Z", []DataPoint{
+		{Name: "Add", XAxis: "x", YAxis: "y", ZAxis: ""},
+	})
+
+	result := MergeDatasets([]Dataset{incoming, accumulated}, DimensionZAxis)
+	s.Require().Len(result, 1)
+	s.Require().Len(result[0].Data, 2)
+	s.Equal("v1", result[0].Data[0].ZAxis)
+	s.Equal("v2", result[0].Data[1].ZAxis)
+}
+
+func (s *MergeSuite) TestMergeDataForTagKeepsPreInjectedPoints() {
+	ds := makeBench("v1.8.0", "Bench", "2026-07-04T05:33:48Z", []DataPoint{
+		{Name: "Add", XAxis: "v1.8.0", YAxis: "Queue", Stats: []Stat{{Type: "time", Value: F64(42)}}},
+		{Name: "Add", XAxis: "v1.3.0", YAxis: "Queue"},
+	})
+
+	points := mergeDataForTag(ds, DimensionXAxis)
+	s.Require().Len(points, 1)
+	s.Equal("v1.8.0", points[0].XAxis)
+	s.Equal(42.0, *points[0].Stats[0].Value)
+}
+
+func (s *MergeSuite) TestDataPointBelongsToTag() {
+	s.True(dataPointBelongsToTag(DataPoint{XAxis: ""}, "v1", DimensionXAxis))
+	s.True(dataPointBelongsToTag(DataPoint{XAxis: "v1"}, "v1", DimensionXAxis))
+	s.False(dataPointBelongsToTag(DataPoint{XAxis: "v2"}, "v1", DimensionXAxis))
+	s.True(dataPointBelongsToTag(DataPoint{YAxis: "v1"}, "v1", DimensionYAxis))
+	s.True(dataPointBelongsToTag(DataPoint{ZAxis: "v1"}, "v1", DimensionZAxis))
+	s.True(dataPointBelongsToTag(DataPoint{Name: "v1"}, "v1", DimensionName))
+}
+
 func (s *MergeSuite) TestMergeReplaceSameTagSkipsOlderIncoming() {
 	accumulated := makeBench("v1.8.0", "Bench", "2026-07-04T05:33:48Z", []DataPoint{
 		{Name: "Add", XAxis: "v1.3.0", YAxis: "Queue"},


### PR DESCRIPTION
## Summary

Re-merging an already-accumulated JSON with a new run that shares the same tag dropped all historical versions. Whole-dataset dedup replaced the entire accumulated entry with the fresh benchmark.

Example: `vizb merge bench.json merged.json -A x` went from 108 data points (9 versions) down to 12 (1 version) when both files had tag `v1.8.0`.

## Changes

- On same `(name, tag)` collision, use tag-level replacement instead of whole-dataset replacement
- Pick the accumulated dataset as base (more `history` / `data`)
- Remove only data points belonging to the colliding tag on the inject dimension
- Append incoming points for that tag with normal injection
- Preserve other versions, `history[]`, `axes[]`, and `settings[]`
- Update top-level `tag`, `timestamp`, and `meta` from the newer run
- Leave untagged dedup unchanged (first-seen wins)

## Test plan

- [x] `go test ./shared/... -run Merge`
- [x] Manual: `vizb merge bench.json merged.json -A x` preserves 108 points, 8 history entries, 9 xAxis versions