### PR TITLE
fix(merge): ensure tag-axis dimension is present in axes

### DIFF
--- a/shared/dimension.go
+++ b/shared/dimension.go
@@ -8,3 +8,17 @@ const (
 	DimensionYAxis Dimension = "y"
 	DimensionZAxis Dimension = "z"
 )
+
+// AxisKey returns the dataset.axes key for this inject dimension.
+func (d Dimension) AxisKey() string {
+	switch d {
+	case DimensionXAxis:
+		return "x"
+	case DimensionYAxis:
+		return "y"
+	case DimensionZAxis:
+		return "z"
+	default:
+		return "name"
+	}
+}

--- a/shared/dimension_test.go
+++ b/shared/dimension_test.go
@@ -1,0 +1,15 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDimensionAxisKey(t *testing.T) {
+	assert.Equal(t, "name", DimensionName.AxisKey())
+	assert.Equal(t, "x", DimensionXAxis.AxisKey())
+	assert.Equal(t, "y", DimensionYAxis.AxisKey())
+	assert.Equal(t, "z", DimensionZAxis.AxisKey())
+	assert.Equal(t, "name", Dimension("unknown").AxisKey())
+}

--- a/shared/merge.go
+++ b/shared/merge.go
@@ -1,10 +1,13 @@
 package shared
 
 import (
+	"slices"
 	"sort"
 
 	internal_charts "github.com/goptics/vizb/internal/charts"
 )
+
+var canonicalAxisOrder = []string{"name", "x", "y", "z"}
 
 const noTagKey = "__no_tag__"
 
@@ -84,6 +87,7 @@ func MergeDatasets(benchmarks []Dataset, dim Dimension) []Dataset {
 				base.Timestamp = latest.Timestamp
 				base.History = buildHistory(allDatasets, latest.Tag)
 				base.Data = mergeData(allDatasets, dim)
+				base.Axes = ensureInjectAxis(base.Axes, dim)
 				result = append(result, base)
 				continue
 			}
@@ -92,6 +96,7 @@ func MergeDatasets(benchmarks []Dataset, dim Dimension) []Dataset {
 			base := deepCloneDataset(latest)
 			base.History = buildHistory(tagged, latest.Tag)
 			base.Data = mergeData(tagged, dim)
+			base.Axes = ensureInjectAxis(base.Axes, dim)
 			result = append(result, base)
 		}
 	}
@@ -249,6 +254,59 @@ func dimFieldValue(item DataPoint, dim Dimension) string {
 	default:
 		return item.Name
 	}
+}
+
+// ensureInjectAxis adds the tag-axis dimension to axes when missing so injected
+// tag values remain visible to the UI identity pipeline. Non-metric axes are
+// kept in canonical name/x/y/z order; metric axes keep their trailing position.
+func ensureInjectAxis(axes []Axis, dim Dimension) []Axis {
+	key := dim.AxisKey()
+	if slices.ContainsFunc(axes, func(a Axis) bool { return a.Key == key }) {
+		return axes
+	}
+
+	newAxis := Axis{Key: key}
+	if len(axes) == 0 {
+		return []Axis{newAxis}
+	}
+
+	orderIndex := func(axisKey string) (int, bool) {
+		for i, k := range canonicalAxisOrder {
+			if k == axisKey {
+				return i, true
+			}
+		}
+		return len(canonicalAxisOrder), false
+	}
+
+	newIdx, known := orderIndex(key)
+	if !known {
+		return append(axes, newAxis)
+	}
+
+	var nonMetric []Axis
+	var metric []Axis
+	for _, a := range axes {
+		if a.Key == "metric" {
+			metric = append(metric, a)
+		} else {
+			nonMetric = append(nonMetric, a)
+		}
+	}
+
+	insertAt := len(nonMetric)
+	for i, a := range nonMetric {
+		if idx, ok := orderIndex(a.Key); ok && newIdx < idx {
+			insertAt = i
+			break
+		}
+	}
+
+	nonMetric = append(nonMetric, Axis{})
+	copy(nonMetric[insertAt+1:], nonMetric[insertAt:])
+	nonMetric[insertAt] = newAxis
+
+	return append(nonMetric, metric...)
 }
 
 func mergeData(benchmarks []Dataset, dim Dimension) []DataPoint {

--- a/shared/merge.go
+++ b/shared/merge.go
@@ -279,10 +279,7 @@ func ensureInjectAxis(axes []Axis, dim Dimension) []Axis {
 		return len(canonicalAxisOrder), false
 	}
 
-	newIdx, known := orderIndex(key)
-	if !known {
-		return append(axes, newAxis)
-	}
+	newIdx, _ := orderIndex(key)
 
 	var nonMetric []Axis
 	var metric []Axis

--- a/shared/merge_test.go
+++ b/shared/merge_test.go
@@ -19,6 +19,14 @@ func makeBench(tag, name, timestamp string, data []DataPoint) Dataset {
 	}
 }
 
+func axisKeys(axes []Axis) []string {
+	keys := make([]string, len(axes))
+	for i, a := range axes {
+		keys[i] = a.Key
+	}
+	return keys
+}
+
 func (s *MergeSuite) TestMergeInjectsTagIntoEmptyDimension() {
 	bench := makeBench("v2", "DS", "2026-01-01T00:00:00Z", []DataPoint{
 		{XAxis: "", YAxis: "10", Stats: []Stat{{Type: "time", Value: F64(1)}}},
@@ -144,6 +152,7 @@ func (s *MergeSuite) TestMergeDatasetsInjectDimensionX() {
 	s.Equal("1", result[0].Data[0].XAxis)
 	s.Equal("2", result[0].Data[1].XAxis)
 	s.Equal("", result[0].Data[0].Name)
+	s.Equal([]string{"x"}, axisKeys(result[0].Axes))
 }
 
 func (s *MergeSuite) TestMergeDatasetsInjectDimensionY() {
@@ -158,6 +167,7 @@ func (s *MergeSuite) TestMergeDatasetsInjectDimensionY() {
 	s.Len(result, 1)
 	s.Equal("1", result[0].Data[0].YAxis)
 	s.Equal("2", result[0].Data[1].YAxis)
+	s.Equal([]string{"y"}, axisKeys(result[0].Axes))
 }
 
 func (s *MergeSuite) TestMergeDatasetsInjectDimensionZ() {
@@ -172,6 +182,75 @@ func (s *MergeSuite) TestMergeDatasetsInjectDimensionZ() {
 	s.Len(result, 1)
 	s.Equal("1", result[0].Data[0].ZAxis)
 	s.Equal("2", result[0].Data[1].ZAxis)
+	s.Equal([]string{"z"}, axisKeys(result[0].Axes))
+}
+
+func (s *MergeSuite) TestMergeEnsuresZAxisInAxes() {
+	axes := []Axis{{Key: "x"}, {Key: "y"}}
+	bench1 := makeBench("1", "Test", "2026-05-13T10:00:00Z", []DataPoint{
+		{XAxis: "size", YAxis: "100", ZAxis: ""},
+	})
+	bench1.Axes = axes
+	bench2 := makeBench("2", "Test", "2026-05-13T10:05:00Z", []DataPoint{
+		{XAxis: "size", YAxis: "200", ZAxis: ""},
+	})
+	bench2.Axes = axes
+
+	result := MergeDatasets([]Dataset{bench1, bench2}, DimensionZAxis)
+	s.Require().Len(result, 1)
+	s.Equal([]string{"x", "y", "z"}, axisKeys(result[0].Axes))
+	s.Equal("1", result[0].Data[0].ZAxis)
+	s.Equal("2", result[0].Data[1].ZAxis)
+}
+
+func (s *MergeSuite) TestMergeEnsuresNameAxisInAxes() {
+	axes := []Axis{{Key: "x"}, {Key: "y"}}
+	bench1 := makeBench("1", "Test", "2026-05-13T10:00:00Z", []DataPoint{
+		{Name: "", XAxis: "speed", YAxis: "100"},
+	})
+	bench1.Axes = axes
+	bench2 := makeBench("2", "Test", "2026-05-13T10:05:00Z", []DataPoint{
+		{Name: "", XAxis: "speed", YAxis: "200"},
+	})
+	bench2.Axes = axes
+
+	result := MergeDatasets([]Dataset{bench1, bench2}, DimensionName)
+	s.Require().Len(result, 1)
+	s.Equal([]string{"name", "x", "y"}, axisKeys(result[0].Axes))
+	s.Equal("1", result[0].Data[0].Name)
+	s.Equal("2", result[0].Data[1].Name)
+}
+
+func (s *MergeSuite) TestMergeDoesNotDuplicateAxis() {
+	axes := []Axis{{Key: "x"}, {Key: "y"}}
+	bench1 := makeBench("1", "Test", "2026-05-13T10:00:00Z", []DataPoint{
+		{XAxis: "", YAxis: "100"},
+	})
+	bench1.Axes = axes
+	bench2 := makeBench("2", "Test", "2026-05-13T10:05:00Z", []DataPoint{
+		{XAxis: "", YAxis: "200"},
+	})
+	bench2.Axes = axes
+
+	result := MergeDatasets([]Dataset{bench1, bench2}, DimensionXAxis)
+	s.Require().Len(result, 1)
+	s.Equal([]string{"x", "y"}, axisKeys(result[0].Axes))
+}
+
+func (s *MergeSuite) TestMergePreservesMetricAxisWhenEnsuringInjectAxis() {
+	axes := []Axis{{Key: "x"}, {Key: "y"}, {Key: "metric", Label: "value"}}
+	bench1 := makeBench("1", "Test", "2026-05-13T10:00:00Z", []DataPoint{
+		{XAxis: "size", YAxis: "100", ZAxis: ""},
+	})
+	bench1.Axes = axes
+	bench2 := makeBench("2", "Test", "2026-05-13T10:05:00Z", []DataPoint{
+		{XAxis: "size", YAxis: "200", ZAxis: ""},
+	})
+	bench2.Axes = axes
+
+	result := MergeDatasets([]Dataset{bench1, bench2}, DimensionZAxis)
+	s.Require().Len(result, 1)
+	s.Equal([]string{"x", "y", "z", "metric"}, axisKeys(result[0].Axes))
 }
 
 func (s *MergeSuite) TestMergeDatasetsHistoryMerge() {

--- a/shared/merge_test.go
+++ b/shared/merge_test.go
@@ -546,6 +546,33 @@ func (s *MergeSuite) TestMergeReplaceSameTagSkipsOlderIncoming() {
 	}, result[0].History)
 }
 
+func (s *MergeSuite) TestEnsureInjectAxisEmptyAxes() {
+	s.Equal([]string{"x"}, axisKeys(ensureInjectAxis(nil, DimensionXAxis)))
+	s.Equal([]string{"y"}, axisKeys(ensureInjectAxis([]Axis{}, DimensionYAxis)))
+}
+
+func (s *MergeSuite) TestEnsureInjectAxisInsertsAmongNonCanonicalAxes() {
+	axes := []Axis{{Key: "custom"}, {Key: "y"}}
+	result := ensureInjectAxis(axes, DimensionXAxis)
+	s.Equal([]string{"custom", "x", "y"}, axisKeys(result))
+}
+
+func (s *MergeSuite) TestEnsureInjectAxisNoTagMergePath() {
+	noTag := Dataset{
+		Name: "Bench",
+		Data: []DataPoint{{Name: "legacy", XAxis: "x", YAxis: "y"}},
+		Axes: []Axis{{Key: "name"}, {Key: "y"}},
+	}
+	tagged := makeBench("v1", "Bench", "2026-05-13T10:00:00Z", []DataPoint{
+		{Name: "", XAxis: "speed", YAxis: "100"},
+	})
+	tagged.Axes = []Axis{{Key: "name"}, {Key: "y"}}
+
+	result := MergeDatasets([]Dataset{noTag, tagged}, DimensionXAxis)
+	s.Require().Len(result, 1)
+	s.Equal([]string{"name", "x", "y"}, axisKeys(result[0].Axes))
+}
+
 func TestMergeSuite(t *testing.T) {
 	suite.Run(t, new(MergeSuite))
 }


### PR DESCRIPTION
## Summary

When merging with `--tag-axis`, tag values were injected into `DataPoint` fields without ensuring the corresponding axis exists in `dataset.axes`. The UI derives chart identity from `axes[]`, so injected tags on missing dimensions were invisible.

## Changes

- Add `Dimension.AxisKey()` mapping inject dimension to axis key (`n` → `name`, `x`/`y`/`z` → axis keys)
- Add `ensureInjectAxis()` to insert the inject dimension into `axes` in canonical `name/x/y/z` order
- Keep `metric` axes trailing when inserting
- Call `ensureInjectAxis` after tagged deep-merge in `MergeDatasets`
- Add tests for x/y/z/name inject axes, dedup, and metric axis preservation

## Test plan

- [x] `go test ./shared/... -run Merge`
- [x] `go test ./cmd/... -run Merge`