### PR TITLE
docs(merge): document same-tag replacement and auto-axis behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Notable changes to Vizb documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [v0.14.1] - Unreleased
+
+### Fixed
+
+- **Same-tag merge no longer wipes accumulated history** — re-merging a dataset with an existing tag now replaces only that tag's data points on the inject axis (`-A`); older versions in `history[]` and data from other tags are preserved ([#181](https://github.com/goptics/vizb/pull/181)).
+- **Tag-axis injection invisible in UI** — merge now adds the inject dimension to `axes` when missing so injected tag values appear in charts ([#182](https://github.com/goptics/vizb/pull/182)).
+
+### Changed
+
+- **Merge documentation** — updated merge command docs, merging guide, and stateful CI guide to reflect same-tag replacement and auto-axis behavior.
+
 # [v0.14.0] - 2026-07-01
 
 ### Added

--- a/docs/src/content/docs/ci-cd/stateful.mdx
+++ b/docs/src/content/docs/ci-cd/stateful.mdx
@@ -99,7 +99,7 @@ Stateful CI tracks benchmark performance over time. Each run merges with histori
 | `output-json` | `merged.json` | Stores the merged result as an artifact |
 
 <Aside type="tip">
-  Use `tag-axis: x` so versions appear on the X-axis. This creates a clear timeline showing performance changes across releases.
+  Use `tag-axis: x` so versions appear on the X-axis. This creates a clear timeline showing performance changes across releases, and merge ensures the X-axis is present in `axes` so injected tags stay visible in the chart.
 </Aside>
 
 ## The Merge Cycle
@@ -117,6 +117,8 @@ Each run:
 2. Runs benchmarks with the new tag
 3. Merges old data with new data (inner merge by tag)
 4. Uploads the new merged result for the next run
+
+When re-running benchmarks for an **existing tag** (e.g. re-tagging `v1.8.0` after a fix), merge replaces only that version's data points — it does not wipe accumulated history from prior releases.
 
 <Aside type="note">
   The `continue-on-error: true` on the artifact download step ensures the first run succeeds even when no previous data exists.

--- a/docs/src/content/docs/commands/merge.mdx
+++ b/docs/src/content/docs/commands/merge.mdx
@@ -39,7 +39,7 @@ vizb merge ./old_results/ latest.json -o comparison.json
 
 ## Outer Merge (Untagged)
 
-When merging dataset without tags, vizb concatenates all entries. Same-name dataset are deduplicated — first occurrence wins.
+When merging dataset without tags, vizb concatenates all entries. Same-name datasets are deduplicated — newer timestamp wins; if timestamps are equal or absent, first occurrence wins.
 
 ```bash
 vizb bench-a.txt -o a.json -n "Sort"
@@ -63,9 +63,14 @@ vizb merge v1.json v2.json -o comparison.json
 ```
 
 The merge process:
-1. **Deduplication** — same name + tag → keep latest timestamp
+1. **Same-tag replacement** — same name + tag → replace only that tag's data points on the inject axis (`-A`); older versions and `history[]` entries for other tags are kept. Newer timestamp wins for top-level metadata.
 2. **Deep merge** — different tags → single dataset with chronological data
 3. **Legacy** — untagged entries prepended before tagged data
+
+```bash
+# Re-run v1.8.0 into an accumulated merged.json — v1.3.0/v1.7.x data is preserved
+vizb merge bench-v1.8.0.json merged.json -A x -o merged.json
+```
 
 ## Tag-Axis
 
@@ -82,6 +87,8 @@ vizb merge v1.json v2.json -A x -o comparison.json
 | `x` | X-axis — use for version comparison |
 | `y` | Y-axis |
 | `z` | Z-axis — depth layer of a [3D chart](/charts/3d) (needs existing x + y) |
+
+If the inject dimension is missing from `axes`, merge adds it automatically (in canonical `name` / `x` / `y` / `z` order) so tag values appear in the chart.
 
 <Aside type="tip">
   Use `-A x` to display version tags on the X-axis for clean progressive comparison across releases.

--- a/docs/src/content/docs/guides/merging.mdx
+++ b/docs/src/content/docs/guides/merging.mdx
@@ -32,7 +32,7 @@ The general pipeline has three steps:
 
 ## Outer Merging (Untagged)
 
-Outer merging is a simple concatenation of data. When JSON files contain benchmarks with the same name and no tags, duplicates are resolved by keeping the first-seen entry. Use outer merging when combining different benchmark suites or independent runs.
+Outer merging is a simple concatenation of data. When JSON files contain benchmarks with the same name and no tags, duplicates are resolved by keeping the newer timestamp; if timestamps are equal or absent, the first-seen entry wins. Use outer merging when combining different benchmark suites or independent runs.
 
 ```bash
 vizb merge cpu.json memory.json -o combined.json
@@ -81,9 +81,14 @@ Inner merging compares the same benchmarks across different conditions. When ben
 
 The merge process handles tagged data as follows:
 
-- **Deduplication:** If the same benchmark name appears with the same tag, only the entry with the latest timestamp is kept.
+- **Same-tag replacement:** If the same benchmark name appears with the same tag, only that tag's data points on the inject axis (`-A`) are replaced. Older versions and `history[]` entries for other tags are preserved. Newer timestamp wins for top-level metadata.
 - **Deep merge:** Benchmarks with the same name but different tags are combined into a single benchmark entry. The data points from each tag are sorted chronologically. This creates a multi-series chart.
 - **Legacy entries:** Untagged benchmarks (those without a tag) are prepended before any tagged data. They appear as the baseline in the chart.
+
+```bash
+# Re-run v1.8.0 into an accumulated merged.json — v1.3.0/v1.7.x data is preserved
+vizb merge bench-v1.8.0.json merged.json -A x -o merged.json
+```
 
 ## Tag-Axis
 
@@ -94,6 +99,8 @@ The `-A` (or `--tag-axis`) flag controls where the tag label is injected in the 
 | `n` | Name (default) | Creates separate chart groups per tag |
 | `x` | XAxis | Places tag values on the X-axis for direct comparison |
 | `y` | YAxis | Places tag values on the Y-axis as separate series |
+
+If the inject dimension is missing from `axes`, merge adds it automatically (in canonical `name` / `x` / `y` / `z` order) so tag values appear in the chart.
 
 ```bash
 vizb merge v1.json v2.json -A x -o comparison.json


### PR DESCRIPTION
## Summary

Documents the merge fixes shipped in #181 and #182, and adds a v0.14.1 changelog section for the upcoming patch release.

## Changes

- **commands/merge.mdx** — same-tag replacement behavior, incremental re-merge example, auto-add `axes` note, corrected untagged dedup wording
- **guides/merging.mdx** — mirrored updates for the longer-form guide
- **ci-cd/stateful.mdx** — re-release note and `tag-axis: x` tip expanded for axis visibility
- **CHANGELOG.md** — v0.14.1 Unreleased entries for #181, #182, and this docs update

## Related PRs

- #181 — tag-level same-tag data replacement
- #182 — ensure inject axis is present in `axes`