### PR TITLE
fix(ui): keep grouped 3D z-axis name with transparent text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.out
 *.test
 *.prof
+*-out
 coverage.txt
 coverage.html
 .gocache/

--- a/docs/src/content/docs/charts/3d.mdx
+++ b/docs/src/content/docs/charts/3d.mdx
@@ -27,7 +27,7 @@ A chart renders in grouped 3D when a data point has **all three** plotting axes 
 - **YAxis** — categories along the depth's base
 - **ZAxis** — grouping values for stacked layers / legend (not the vertical axis title)
 
-In grouped 3D the **vertical axis** is the **metric** (chart title). The z column name is still set on the axis for layout (name gap), but rendered **transparent** so it does not read as a categorical height label. The pattern slot `z` drives the **legend** and ChartCard badge. Value mode (`--3d`) still names the vertical axis with the metric.
+In grouped 3D the **vertical axis** is the **metric** (chart title). The z column name is still set on the axis for layout, but rendered **transparent** so it does not read as a categorical height label. The pattern slot `z` drives the **legend** and ChartCard badge. Value mode (`--3d`) still names the vertical axis with the metric.
 
 The **Name** dimension stays optional — it still groups points into separate
 charts. Without a z-axis, charts render as the usual 2D bar/line/pie.

--- a/docs/src/content/docs/charts/3d.mdx
+++ b/docs/src/content/docs/charts/3d.mdx
@@ -27,7 +27,7 @@ A chart renders in grouped 3D when a data point has **all three** plotting axes 
 - **YAxis** — categories along the depth's base
 - **ZAxis** — grouping values for stacked layers / legend (not the vertical axis title)
 
-In grouped 3D the **vertical axis** is the **metric** (chart title); its axis title is left blank. The pattern slot `z` drives the **legend** and ChartCard badge, not the height-axis label. Value mode (`--3d`) still names the vertical axis with the metric.
+In grouped 3D the **vertical axis** is the **metric** (chart title). The z column name is still set on the axis for layout (name gap), but rendered **transparent** so it does not read as a categorical height label. The pattern slot `z` drives the **legend** and ChartCard badge. Value mode (`--3d`) still names the vertical axis with the metric.
 
 The **Name** dimension stays optional — it still groups points into separate
 charts. Without a z-axis, charts render as the usual 2D bar/line/pie.

--- a/ui/src/composables/charts/shared/3d.ts
+++ b/ui/src/composables/charts/shared/3d.ts
@@ -356,6 +356,25 @@ export function axis3DName(label: string | undefined, styling: ChartStyling) {
 }
 
 /**
+ * Grouped 3D vertical axis: keep name + nameGap for echarts-gl framing so the
+ * metric scale is not crushed, but paint the title transparent (z column name
+ * is already in the legend/badge; showing it on a numeric height axis misleads).
+ * Always sets `name` so Chart3D notMerge:false clears sticky titles.
+ */
+export function axis3DNameInvisible(label: string | undefined) {
+  if (!label) return { name: '' as const }
+  return {
+    name: label,
+    nameGap: 25,
+    nameTextStyle: {
+      color: 'transparent',
+      fontSize: 14,
+      fontWeight: 'bold' as const,
+    },
+  }
+}
+
+/**
  * Pure factory for the complex per-cell 3D tooltip.
  * Shared by bar3D and line3D so the aggregation, Σz, marginals, spread, and donut
  * logic never diverges.

--- a/ui/src/composables/charts/shared/3d.ts
+++ b/ui/src/composables/charts/shared/3d.ts
@@ -356,21 +356,15 @@ export function axis3DName(label: string | undefined, styling: ChartStyling) {
 }
 
 /**
- * Grouped 3D vertical axis: keep name + nameGap for echarts-gl framing so the
- * metric scale is not crushed, but paint the title transparent (z column name
- * is already in the legend/badge; showing it on a numeric height axis misleads).
- * Always sets `name` so Chart3D notMerge:false clears sticky titles.
+ * Grouped 3D vertical axis: keep a real `name` so echarts-gl still reserves
+ * title space (empty name crushed framing), but hide the text. Always sets
+ * `name` so Chart3D notMerge:false clears sticky titles.
  */
 export function axis3DNameInvisible(label: string | undefined) {
   if (!label) return { name: '' as const }
   return {
     name: label,
-    nameGap: 25,
-    nameTextStyle: {
-      color: 'transparent',
-      fontSize: 14,
-      fontWeight: 'bold' as const,
-    },
+    nameTextStyle: { color: 'transparent' },
   }
 }
 

--- a/ui/src/composables/charts/useBar3DChartOptions.ts
+++ b/ui/src/composables/charts/useBar3DChartOptions.ts
@@ -7,6 +7,7 @@ import {
   EMPTY_RENDER,
   makeAxis3DCommon,
   axis3DName,
+  axis3DNameInvisible,
   create3DTooltipFormatter,
   createZLegendConfig,
   create3DGridConfig,
@@ -201,10 +202,10 @@ export function useBar3DChartOptions(config: BaseChartConfig) {
         ...axisCommon,
         ...axis3DName(chartData.value.axisLabels?.y, styling),
       },
-      // name:'' clears sticky labels under Chart3D notMerge:false (omit does not)
+      // Invisible name keeps nameGap framing; explicit name clears sticky merges.
       zAxis3D: {
         ...zAxis3DBase,
-        name: '',
+        ...axis3DNameInvisible(chartData.value.axisLabels?.z),
       },
       grid3D,
       series,

--- a/ui/src/composables/charts/useGrouped3DZAxisLabel.test.ts
+++ b/ui/src/composables/charts/useGrouped3DZAxisLabel.test.ts
@@ -84,13 +84,11 @@ describe('grouped 3D z axis labels', () => {
       const { options } = useOptions(makeConfig(groupedRender))
       const zAxis = options.value.zAxis3D as {
         name?: string
-        nameGap?: number
         nameTextStyle?: { color?: string }
       }
 
-      // Non-empty name + nameGap preserve framing; transparent text hides the label.
+      // Non-empty name preserves framing; transparent text hides the label.
       expect(zAxis.name).toBe('category')
-      expect(zAxis.nameGap).toBe(25)
       expect(zAxis.nameTextStyle?.color).toBe('transparent')
     }
   )

--- a/ui/src/composables/charts/useGrouped3DZAxisLabel.test.ts
+++ b/ui/src/composables/charts/useGrouped3DZAxisLabel.test.ts
@@ -79,18 +79,30 @@ const chartFactories = [
 
 describe('grouped 3D z axis labels', () => {
   it.each(chartFactories)(
-    'clears the grouped z-axis name for %s charts (merge-safe)',
+    'keeps the grouped z-axis name invisible for %s charts (merge-safe)',
     (_name, useOptions) => {
       const { options } = useOptions(makeConfig(groupedRender))
+      const zAxis = options.value.zAxis3D as {
+        name?: string
+        nameGap?: number
+        nameTextStyle?: { color?: string }
+      }
 
-      // Empty string, not omit: Chart3D uses notMerge:false so sticky names clear.
-      expect((options.value.zAxis3D as { name?: string }).name).toBe('')
+      // Non-empty name + nameGap preserve framing; transparent text hides the label.
+      expect(zAxis.name).toBe('category')
+      expect(zAxis.nameGap).toBe(25)
+      expect(zAxis.nameTextStyle?.color).toBe('transparent')
     }
   )
 
   it.each(chartFactories)('keeps the value-mode z-axis name for %s charts', (_name, useOptions) => {
     const { options } = useOptions(makeConfig(valueRender))
+    const zAxis = options.value.zAxis3D as {
+      name?: string
+      nameTextStyle?: { color?: string }
+    }
 
-    expect((options.value.zAxis3D as { name?: string }).name).toBe('sales')
+    expect(zAxis.name).toBe('sales')
+    expect(zAxis.nameTextStyle?.color).not.toBe('transparent')
   })
 })

--- a/ui/src/composables/charts/useLine3DChartOptions.ts
+++ b/ui/src/composables/charts/useLine3DChartOptions.ts
@@ -7,6 +7,7 @@ import {
   EMPTY_RENDER,
   makeAxis3DCommon,
   axis3DName,
+  axis3DNameInvisible,
   create3DTooltipFormatter,
   createZLegendConfig,
   create3DGridConfig,
@@ -243,10 +244,10 @@ export function useLine3DChartOptions(config: BaseChartConfig) {
         ...axisCommon,
         ...axis3DName(chartData.value.axisLabels?.y, styling),
       },
-      // name:'' clears sticky labels under Chart3D notMerge:false (omit does not)
+      // Invisible name keeps nameGap framing; explicit name clears sticky merges.
       zAxis3D: {
         ...zAxis3DBase,
-        name: '',
+        ...axis3DNameInvisible(chartData.value.axisLabels?.z),
       },
       grid3D,
       series: [...series, ...labelSeries],

--- a/ui/src/composables/charts/useScatter3DChartOptions.ts
+++ b/ui/src/composables/charts/useScatter3DChartOptions.ts
@@ -6,6 +6,7 @@ import {
   EMPTY_RENDER,
   makeAxis3DCommon,
   axis3DName,
+  axis3DNameInvisible,
   create3DTooltipFormatter,
   createZLegendConfig,
   create3DGridConfig,
@@ -197,10 +198,10 @@ export function useScatter3DChartOptions(config: BaseChartConfig) {
         ...axisCommon,
         ...axis3DName(axisLabels?.y, styling),
       },
-      // name:'' clears sticky labels under Chart3D notMerge:false (omit does not)
+      // Invisible name keeps nameGap framing; explicit name clears sticky merges.
       zAxis3D: {
         ...zAxis3DBase,
-        name: '',
+        ...axis3DNameInvisible(axisLabels?.z),
       },
       grid3D,
       series: seriesData.map((s: Series3DData) => {


### PR DESCRIPTION
## Related Issues

Follow-up to #192 / #188 — empty `zAxis3D.name` fixed the misleading label but dropped title framing so the metric scale looked crushed on first view.

## Summary

- Grouped 3D charts keep the z-axis **name** for echarts-gl layout, but paint the title with transparent text so the grouping column is not shown as a height label.
- Value-mode charts still show the metric name on the vertical axis as before.
- Docs updated to describe transparent-name behavior for grouped 3D.

## Changes

- Added `axis3DNameInvisible()` in `ui/src/composables/charts/shared/3d.ts` (`name` + `nameTextStyle.color: 'transparent'` only).
- Wired it into grouped mode for bar / line / scatter 3D options (replaces `name: ''`).
- Updated `useGrouped3DZAxisLabel.test.ts` to assert name + transparent color.
- Updated grouped 3D docs in `docs/src/content/docs/charts/3d.mdx`.

## Test Result

```bash
cd ui
pnpm vitest run \
  src/composables/charts/useGrouped3DZAxisLabel.test.ts \
  src/composables/charts/useScatter3DChartOptions.test.ts \
  src/composables/charts/shared/3d.test.ts
```

All tests passed.

Manual check (recommended):

```bash
vizb bar examples/csv/sales.csv -g product,region,category -p n,x,y --3d -o /tmp/grouped-3d.html
```

- Vertical axis title should not be visible
- Height scale should not look crushed on first load
- Legend still shows z group values
- Switching bar/line/scatter 3D and light/dark should not leave a sticky visible z title