### PR TITLE
chore(ui): upgrade TypeScript to 6.0.3

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -38,7 +38,7 @@
     "prettier-plugin-tailwindcss": "^0.7.1",
     "tailwindcss": "^3.4.16",
     "terser": "^5.44.0",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "vite": "^8.1.0",
     "vite-plugin-html": "^3.2.2",
     "vitest": "^4.1.9",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -19,29 +19,29 @@ importers:
         version: 2.1.0(echarts@5.6.0)
       lucide-vue-next:
         specifier: ^0.461.0
-        version: 0.461.0(vue@3.5.22(typescript@5.9.3))
+        version: 0.461.0(vue@3.5.22(typescript@6.0.3))
       radix-vue:
         specifier: ^1.9.0
-        version: 1.9.17(vue@3.5.22(typescript@5.9.3))
+        version: 1.9.17(vue@3.5.22(typescript@6.0.3))
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.6.0
       vue:
         specifier: ^3.5.22
-        version: 3.5.22(typescript@5.9.3)
+        version: 3.5.22(typescript@6.0.3)
       vue-echarts:
         specifier: ^7.0.3
-        version: 7.0.3(@vue/runtime-core@3.5.22)(echarts@5.6.0)(vue@3.5.22(typescript@5.9.3))
+        version: 7.0.3(@vue/runtime-core@3.5.22)(echarts@5.6.0)(vue@3.5.22(typescript@6.0.3))
     devDependencies:
       '@types/node':
         specifier: ^24.6.0
         version: 24.7.2
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
-        version: 6.0.7(vite@8.1.0(@types/node@24.7.2)(jiti@1.21.7)(terser@5.44.0))(vue@3.5.22(typescript@5.9.3))
+        version: 6.0.7(vite@8.1.0(@types/node@24.7.2)(jiti@1.21.7)(terser@5.44.0))(vue@3.5.22(typescript@6.0.3))
       '@vue/tsconfig':
         specifier: ^0.8.1
-        version: 0.8.1(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))
+        version: 0.8.1(typescript@6.0.3)(vue@3.5.22(typescript@6.0.3))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.6)
@@ -67,8 +67,8 @@ importers:
         specifier: ^5.44.0
         version: 5.44.0
       typescript:
-        specifier: ~5.9.3
-        version: 5.9.3
+        specifier: ~6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.1.0
         version: 8.1.0(@types/node@24.7.2)(jiti@1.21.7)(terser@5.44.0)
@@ -80,7 +80,7 @@ importers:
         version: 4.1.9(@types/node@24.7.2)(vite@8.1.0(@types/node@24.7.2)(jiti@1.21.7)(terser@5.44.0))
       vue-tsc:
         specifier: ^3.1.0
-        version: 3.1.1(typescript@5.9.3)
+        version: 3.1.1(typescript@6.0.3)
 
 packages:
 
@@ -1285,8 +1285,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1512,11 +1512,11 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@floating-ui/vue@1.1.9(vue@3.5.22(typescript@5.9.3))':
+  '@floating-ui/vue@1.1.9(vue@3.5.22(typescript@6.0.3))':
     dependencies:
       '@floating-ui/dom': 1.7.4
       '@floating-ui/utils': 0.2.10
-      vue-demi: 0.14.10(vue@3.5.22(typescript@5.9.3))
+      vue-demi: 0.14.10(vue@3.5.22(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -1645,10 +1645,10 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.12': {}
 
-  '@tanstack/vue-virtual@3.13.12(vue@3.5.22(typescript@5.9.3))':
+  '@tanstack/vue-virtual@3.13.12(vue@3.5.22(typescript@6.0.3))':
     dependencies:
       '@tanstack/virtual-core': 3.13.12
-      vue: 3.5.22(typescript@5.9.3)
+      vue: 3.5.22(typescript@6.0.3)
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -1670,11 +1670,11 @@ snapshots:
 
   '@types/web-bluetooth@0.0.20': {}
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.1.0(@types/node@24.7.2)(jiti@1.21.7)(terser@5.44.0))(vue@3.5.22(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@8.1.0(@types/node@24.7.2)(jiti@1.21.7)(terser@5.44.0))(vue@3.5.22(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.0(@types/node@24.7.2)(jiti@1.21.7)(terser@5.44.0)
-      vue: 3.5.22(typescript@5.9.3)
+      vue: 3.5.22(typescript@6.0.3)
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -1759,7 +1759,7 @@ snapshots:
       '@vue/compiler-dom': 3.5.22
       '@vue/shared': 3.5.22
 
-  '@vue/language-core@3.1.1(typescript@5.9.3)':
+  '@vue/language-core@3.1.1(typescript@6.0.3)':
     dependencies:
       '@volar/language-core': 2.4.23
       '@vue/compiler-dom': 3.5.22
@@ -1769,7 +1769,7 @@ snapshots:
       path-browserify: 1.0.1
       picomatch: 4.0.3
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@vue/reactivity@3.5.22':
     dependencies:
@@ -1787,34 +1787,34 @@ snapshots:
       '@vue/shared': 3.5.22
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.5.22(vue@3.5.22(typescript@5.9.3))':
+  '@vue/server-renderer@3.5.22(vue@3.5.22(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.22
       '@vue/shared': 3.5.22
-      vue: 3.5.22(typescript@5.9.3)
+      vue: 3.5.22(typescript@6.0.3)
 
   '@vue/shared@3.5.22': {}
 
-  '@vue/tsconfig@0.8.1(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))':
+  '@vue/tsconfig@0.8.1(typescript@6.0.3)(vue@3.5.22(typescript@6.0.3))':
     optionalDependencies:
-      typescript: 5.9.3
-      vue: 3.5.22(typescript@5.9.3)
+      typescript: 6.0.3
+      vue: 3.5.22(typescript@6.0.3)
 
-  '@vueuse/core@10.11.1(vue@3.5.22(typescript@5.9.3))':
+  '@vueuse/core@10.11.1(vue@3.5.22(typescript@6.0.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.5.22(typescript@5.9.3))
-      vue-demi: 0.14.10(vue@3.5.22(typescript@5.9.3))
+      '@vueuse/shared': 10.11.1(vue@3.5.22(typescript@6.0.3))
+      vue-demi: 0.14.10(vue@3.5.22(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
   '@vueuse/metadata@10.11.1': {}
 
-  '@vueuse/shared@10.11.1(vue@3.5.22(typescript@5.9.3))':
+  '@vueuse/shared@10.11.1(vue@3.5.22(typescript@6.0.3))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.22(typescript@5.9.3))
+      vue-demi: 0.14.10(vue@3.5.22(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -2254,9 +2254,9 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lucide-vue-next@0.461.0(vue@3.5.22(typescript@5.9.3)):
+  lucide-vue-next@0.461.0(vue@3.5.22(typescript@6.0.3)):
     dependencies:
-      vue: 3.5.22(typescript@5.9.3)
+      vue: 3.5.22(typescript@6.0.3)
 
   magic-string@0.30.19:
     dependencies:
@@ -2413,20 +2413,20 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  radix-vue@1.9.17(vue@3.5.22(typescript@5.9.3)):
+  radix-vue@1.9.17(vue@3.5.22(typescript@6.0.3)):
     dependencies:
       '@floating-ui/dom': 1.7.4
-      '@floating-ui/vue': 1.1.9(vue@3.5.22(typescript@5.9.3))
+      '@floating-ui/vue': 1.1.9(vue@3.5.22(typescript@6.0.3))
       '@internationalized/date': 3.10.0
       '@internationalized/number': 3.6.5
-      '@tanstack/vue-virtual': 3.13.12(vue@3.5.22(typescript@5.9.3))
-      '@vueuse/core': 10.11.1(vue@3.5.22(typescript@5.9.3))
-      '@vueuse/shared': 10.11.1(vue@3.5.22(typescript@5.9.3))
+      '@tanstack/vue-virtual': 3.13.12(vue@3.5.22(typescript@6.0.3))
+      '@vueuse/core': 10.11.1(vue@3.5.22(typescript@6.0.3))
+      '@vueuse/shared': 10.11.1(vue@3.5.22(typescript@6.0.3))
       aria-hidden: 1.2.6
       defu: 6.1.4
       fast-deep-equal: 3.1.3
       nanoid: 5.1.6
-      vue: 3.5.22(typescript@5.9.3)
+      vue: 3.5.22(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
@@ -2594,7 +2594,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   uhyphen@0.2.0: {}
 
@@ -2668,39 +2668,39 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-demi@0.13.11(vue@3.5.22(typescript@5.9.3)):
+  vue-demi@0.13.11(vue@3.5.22(typescript@6.0.3)):
     dependencies:
-      vue: 3.5.22(typescript@5.9.3)
+      vue: 3.5.22(typescript@6.0.3)
 
-  vue-demi@0.14.10(vue@3.5.22(typescript@5.9.3)):
+  vue-demi@0.14.10(vue@3.5.22(typescript@6.0.3)):
     dependencies:
-      vue: 3.5.22(typescript@5.9.3)
+      vue: 3.5.22(typescript@6.0.3)
 
-  vue-echarts@7.0.3(@vue/runtime-core@3.5.22)(echarts@5.6.0)(vue@3.5.22(typescript@5.9.3)):
+  vue-echarts@7.0.3(@vue/runtime-core@3.5.22)(echarts@5.6.0)(vue@3.5.22(typescript@6.0.3)):
     dependencies:
       echarts: 5.6.0
-      vue: 3.5.22(typescript@5.9.3)
-      vue-demi: 0.13.11(vue@3.5.22(typescript@5.9.3))
+      vue: 3.5.22(typescript@6.0.3)
+      vue-demi: 0.13.11(vue@3.5.22(typescript@6.0.3))
     optionalDependencies:
       '@vue/runtime-core': 3.5.22
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  vue-tsc@3.1.1(typescript@5.9.3):
+  vue-tsc@3.1.1(typescript@6.0.3):
     dependencies:
       '@volar/typescript': 2.4.23
-      '@vue/language-core': 3.1.1(typescript@5.9.3)
-      typescript: 5.9.3
+      '@vue/language-core': 3.1.1(typescript@6.0.3)
+      typescript: 6.0.3
 
-  vue@3.5.22(typescript@5.9.3):
+  vue@3.5.22(typescript@6.0.3):
     dependencies:
       '@vue/compiler-dom': 3.5.22
       '@vue/compiler-sfc': 3.5.22
       '@vue/runtime-dom': 3.5.22
-      '@vue/server-renderer': 3.5.22(vue@3.5.22(typescript@5.9.3))
+      '@vue/server-renderer': 3.5.22(vue@3.5.22(typescript@6.0.3))
       '@vue/shared': 3.5.22
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   which@2.0.2:
     dependencies:

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -1,9 +1,8 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "types": ["vite/client"],


### PR DESCRIPTION
## Related Issues

N/A — dependency upgrade after TypeScript 7 broke `vue-tsc` / `task build:ui` when resolving the latest release.

## Summary

- Upgrade the UI package from TypeScript `~5.9.3` to `~6.0.3`.
- `6.0.3` is the latest TypeScript release that still works with `vue-tsc` / Volar.
- TypeScript 7 drops the classic JS compiler API those tools need, so builds fail on 7.x until that ecosystem catches up.
- Migrate path aliases off deprecated `baseUrl` so TS 6 typecheck succeeds without `ignoreDeprecations`.

## Changes

- `ui/package.json`: bump `typescript` from `~5.9.3` to `~6.0.3`.
- `ui/pnpm-lock.yaml`: lockfile updated for TypeScript 6.0.3 and peer resolution.
- `ui/tsconfig.app.json`:
  - remove deprecated `baseUrl`
  - use explicit path mapping `"@/*": ["./src/*"]`

## Test Result

```bash
task build:ui
```

Succeeded (`vue-tsc -b` + Vite embed build).

```bash
cd ui
pnpm test
```

All tests passed (30 files, 458 tests).

### Notes

- `@vue/tsconfig` still peers on `typescript@5.x`; this is a soft warning and does not block build.
- Stay on TypeScript 6 until `vue-tsc` / Volar support TypeScript 7.