### PR TITLE
ci: gate releases and reuse embedded UI builds

### DIFF
--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   embed-ui:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -23,13 +24,13 @@ jobs:
         if: env.ACT != 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: action-embedded-ui-${{ github.sha }}
+          name: cli-embedded-ui-${{ github.sha }}
           path: pkg/template/vizb-ui.gen.go
           if-no-files-found: error
 
   stateless:
     needs: embed-ui
-    if: ${{ always() && needs.embed-ui.result == 'success' }}
+    if: ${{ always() && (needs.embed-ui.result == 'success' || needs.embed-ui.result == 'skipped') }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -48,7 +49,7 @@ jobs:
         if: env.ACT != 'true'
         uses: actions/download-artifact@v8
         with:
-          name: action-embedded-ui-${{ github.sha }}
+          name: cli-embedded-ui-${{ github.sha }}
           path: pkg/template
 
       - name: Build vizb
@@ -64,7 +65,7 @@ jobs:
 
   stateful:
     needs: embed-ui
-    if: ${{ always() && needs.embed-ui.result == 'success' }}
+    if: ${{ always() && (needs.embed-ui.result == 'success' || needs.embed-ui.result == 'skipped') }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -83,7 +84,7 @@ jobs:
         if: env.ACT != 'true'
         uses: actions/download-artifact@v8
         with:
-          name: action-embedded-ui-${{ github.sha }}
+          name: cli-embedded-ui-${{ github.sha }}
           path: pkg/template
 
       - name: Build vizb

--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -4,7 +4,32 @@ on:
   workflow_dispatch:
 
 jobs:
+  embed-ui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        if: env.ACT != 'true'
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Setup embed UI
+        if: env.ACT != 'true'
+        uses: ./.github/actions/setup-embed-ui
+
+      - name: Upload embedded UI
+        if: env.ACT != 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: action-embedded-ui-${{ github.sha }}
+          path: pkg/template/vizb-ui.gen.go
+          if-no-files-found: error
+
   stateless:
+    needs: embed-ui
+    if: ${{ always() && needs.embed-ui.result == 'success' }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -19,9 +44,12 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Setup embed UI
+      - name: Download embedded UI
         if: env.ACT != 'true'
-        uses: ./.github/actions/setup-embed-ui
+        uses: actions/download-artifact@v8
+        with:
+          name: action-embedded-ui-${{ github.sha }}
+          path: pkg/template
 
       - name: Build vizb
         if: env.ACT != 'true'
@@ -35,6 +63,8 @@ jobs:
           vizb-binary: ./bin/vizb
 
   stateful:
+    needs: embed-ui
+    if: ${{ always() && needs.embed-ui.result == 'success' }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -49,9 +79,12 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Setup embed UI
+      - name: Download embedded UI
         if: env.ACT != 'true'
-        uses: ./.github/actions/setup-embed-ui
+        uses: actions/download-artifact@v8
+        with:
+          name: action-embedded-ui-${{ github.sha }}
+          path: pkg/template
 
       - name: Build vizb
         if: env.ACT != 'true'

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,6 +1,7 @@
 name: CLI
 
 on:
+  workflow_call:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -24,7 +24,7 @@ on:
       - .github/actions/setup-embed-ui/**
 
 jobs:
-  lint:
+  embed-ui:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7
@@ -36,6 +36,30 @@ jobs:
 
       - name: Setup embed UI
         uses: ./.github/actions/setup-embed-ui
+
+      - name: Upload embedded UI
+        uses: actions/upload-artifact@v7
+        with:
+          name: cli-embedded-ui-${{ github.sha }}
+          path: pkg/template/vizb-ui.gen.go
+          if-no-files-found: error
+
+  lint:
+    needs: embed-ui
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download embedded UI
+        uses: actions/download-artifact@v8
+        with:
+          name: cli-embedded-ui-${{ github.sha }}
+          path: pkg/template
 
       - uses: golangci/golangci-lint-action@v9
         with:
@@ -59,6 +83,7 @@ jobs:
           fi
 
   test:
+    needs: embed-ui
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7
@@ -68,8 +93,11 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Setup embed UI
-        uses: ./.github/actions/setup-embed-ui
+      - name: Download embedded UI
+        uses: actions/download-artifact@v8
+        with:
+          name: cli-embedded-ui-${{ github.sha }}
+          path: pkg/template
 
       - run: go mod download
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,18 @@ jobs:
             - A PR is auto-submitted to microsoft/winget-pkgs
             - Examples at https://goptics.github.io/vizb/examples/ are auto-redeployed
 
-  goreleaser:
+  cli:
+    name: CLI
     needs: approve
+    uses: ./.github/workflows/cli.yml
+
+  ui:
+    name: UI
+    needs: approve
+    uses: ./.github/workflows/ui.yml
+
+  goreleaser:
+    needs: [cli, ui]
     runs-on: ubuntu-slim
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,11 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Setup embed UI
-        uses: ./.github/actions/setup-embed-ui
+      - name: Download embedded UI
+        uses: actions/download-artifact@v8
+        with:
+          name: embedded-ui-${{ github.sha }}
+          path: pkg/template
 
       - name: Download dependencies
         run: go mod download

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -107,3 +107,11 @@ jobs:
       # Smoke: prove embed generation works. gen.go is gitignored; no sync check.
       - run: EMBED_UI=True pnpm build
         working-directory: ui
+
+      - name: Upload embedded UI
+        if: github.event_name == 'workflow_call'
+        uses: actions/upload-artifact@v7
+        with:
+          name: embedded-ui-${{ github.sha }}
+          path: pkg/template/vizb-ui.gen.go
+          if-no-files-found: error

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,6 +1,7 @@
 name: UI
 
 on:
+  workflow_call:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary
- invoke CLI and UI CI workflows in parallel after release approval
- wait for both workflow calls before running GoReleaser
- reuse the UI workflow generated vizb-ui.gen.go artifact in GoReleaser
- share generated embedded UI artifacts across CLI lint/test and Action CI matrix jobs

## Why
The release workflow and CI jobs previously rebuilt the embedded UI multiple times. Artifact handoff removes duplicate Node/pnpm installs and frontend builds while preserving Action CI manual-dispatch support.

## Validation
- workflow YAML parsing
- git diff --check
- local EMBED_UI=True pnpm build generation
- pre-commit format hook