### PR TITLE
feat(parser): add json parser support for 2d arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adhere
 
 ### Added
 
+- **JSON 2D array parser** — top-level JSON matrices now chart like CSV: all-string first rows become headers, numeric grids get synthetic `x`, `y`, `z`, `metric` columns, and auto-value / `--group` / `--select` reuse the existing tabular path.
 - **`--smooth` for 2D line charts** — curved segments via CLI, `--chart line:smooth`, and UI toggle; unavailable for 3D and non-line charts ([#187](https://github.com/goptics/vizb/pull/187)).
 - **`--horizontal` for 2D grouped bar charts** — layout-only (categories on Y, values on X); distinct from `--swap`; CLI, `--chart bar:horizontal`, UI toggle, and `?bar.h=` deep link ([#190](https://github.com/goptics/vizb/pull/190)).
 - **Multi-select descriptive column picker** — stats panel lets viewers choose which descriptive columns drive metrics (select-all / reset) ([#191](https://github.com/goptics/vizb/pull/191)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adhere
 
 ### Added
 
-- **JSON 2D array parser** — top-level JSON matrices now chart like CSV: all-string first rows become headers, numeric grids get synthetic `x`, `y`, `z`, `metric` columns, and auto-value / `--group` / `--select` reuse the existing tabular path.
 - **`--smooth` for 2D line charts** — curved segments via CLI, `--chart line:smooth`, and UI toggle; unavailable for 3D and non-line charts ([#187](https://github.com/goptics/vizb/pull/187)).
 - **`--horizontal` for 2D grouped bar charts** — layout-only (categories on Y, values on X); distinct from `--swap`; CLI, `--chart bar:horizontal`, UI toggle, and `?bar.h=` deep link ([#190](https://github.com/goptics/vizb/pull/190)).
 - **Multi-select descriptive column picker** — stats panel lets viewers choose which descriptive columns drive metrics (select-all / reset) ([#191](https://github.com/goptics/vizb/pull/191)).

--- a/docs/src/content/docs/guides/data.mdx
+++ b/docs/src/content/docs/guides/data.mdx
@@ -41,14 +41,14 @@ gamma,150,9,2024-06
 
 ## JSON
 
-A JSON array of objects. Each object is a row. Each key is a column.
+A JSON array of objects or a 2D array. Object rows use keys as columns. Matrix rows use the first row as headers when every first-row cell is a JSON string; otherwise columns are named by position.
 
 ```bash
 vizb data.json -o data.html           # auto-detected as json
 vizb data.json -P json -o data.html   # explicit
 ```
 
-### Input
+### Object Rows
 
 ```json
 [
@@ -59,16 +59,41 @@ vizb data.json -P json -o data.html   # explicit
 
 Produces series `sells`, `stocks`, and `mem.alloc`. `date` (string) is ignored.
 
+### Matrix Rows
+
+```json
+[
+  ["region", "sales"],
+  ["West", 10],
+  ["East", 20]
+]
+```
+
+The all-string first row becomes headers, so this is equivalent to object rows with `region` and `sales` fields.
+
+For all-numeric grids, omit headers and vizb assigns `x`, `y`, `z`, `metric`, then `col5`, `col6`, ...:
+
+```json
+[
+  [1, 2, 3, 4],
+  [5, 6, 7, 8]
+]
+```
+
+That enters the same auto-value path as all-numeric CSV: `x`, `y`, and `z` become coordinate axes, and `metric` drives visualMap where supported.
+
 ### Rules
 
 | Topic | Behaviour |
 |-------|-----------|
-| Shape | Top-level **array of objects**. A single top-level object is consumed by vizb's own dataset-JSON path. Reach a nested array inside an envelope with [`--json-path`](#selecting-a-nested-array-with---json-path). |
+| Shape | Top-level **array of objects** or **array of arrays**. The first element selects the mode. A single top-level object is consumed by vizb's own dataset-JSON path. Reach a nested array inside an envelope with [`--json-path`](#selecting-a-nested-array-with---json-path). |
+| Matrix header | First row is headers only when every cell in that row is a JSON string, including `""` and numeric-looking strings like `"10"`. Header cells are trimmed; empty names are skipped; duplicates get suffixes like `sales (2)`. |
+| Matrix without header | First row is data. Columns are named `x`, `y`, `z`, `metric`, then `col5`, `col6`, ... by position. |
 | Numeric value | A finite JSON **number** *or* a **numeric string** (`"10"` → 10). `bool`/`null` are ignored. |
 | Nested objects | Flattened to dotted keys: `{"mem":{"alloc":5}}` → `mem.alloc`. |
-| Arrays as values | Skipped. |
-| Column order | **First-seen** key order across the array (preserved, not alphabetical). |
-| Heterogeneous rows | Keys are unioned. A missing key in a row is a gap. A key numeric in some rows and text in others is charted where numeric. |
+| Arrays as values | Skipped inside object rows. Nested arrays/objects inside matrix cells are skipped. |
+| Column order | **First-seen** key order for object rows; header or position order for matrix rows. |
+| Heterogeneous rows | Keys are unioned for object rows. Matrix rows may be ragged. A missing field/cell is a gap. A field numeric in some rows and text in others is charted where numeric. |
 | No numeric fields | Hard error: `no numeric fields found in JSON`. |
 
 ## Grouping with `--group` / `-g`
@@ -142,5 +167,5 @@ This turns a row-per-record dump into a handful of meaningful grouped points. It
 ## Limitations
 
 - **CSV:** no thousands separators / currency / `%` parsing. Comma delimiter only. No headerless files.
-- **JSON:** a single top-level object is treated as a vizb Dataset, not a row. Use [`--json-path`](#selecting-a-nested-array-with---json-path) to chart a nested array inside an envelope. Arrays-of-scalars are not exploded into series.
+- **JSON:** a single top-level object is treated as a vizb Dataset, not a row. Use [`--json-path`](#selecting-a-nested-array-with---json-path) to chart a nested array inside an envelope. Mixed top-level arrays are not normalized.
 - `--number-unit`/`-N` scales every numeric column/field uniformly.

--- a/docs/src/content/docs/guides/parsers.mdx
+++ b/docs/src/content/docs/guides/parsers.mdx
@@ -28,7 +28,7 @@ CSV and JSON are the simplest inputs. Hand vizb a table and it charts the numeri
   </TabItem>
 
   <TabItem label="JSON" icon="seti:json">
-  A JSON array of objects. Each object is a row. Each numeric key becomes its own chart. Nested objects flatten to dotted keys.
+  A JSON array of objects or arrays. Object keys become columns; 2D arrays use an all-string first row as headers or synthetic `x`, `y`, `z`, `metric` names for numeric grids. Each numeric field becomes its own chart. Nested objects flatten to dotted keys.
 
   ```bash
   vizb data.json -o output.html
@@ -173,7 +173,7 @@ Vizb also parses benchmark output from three languages and five frameworks.
 |-----|--------------------|----------|
 | `auto` | Detect from content (default) | — |
 | `csv` | Generic CSV table | Any |
-| `json` | Generic JSON array of objects | Any |
+| `json` | Generic JSON object rows or 2D arrays | Any |
 | `go` | Go testing (benchfmt) | Go |
 | `rs:criterion` | Criterion | Rust |
 | `rs:divan` | Divan | Rust |

--- a/pkg/parser/json/json.go
+++ b/pkg/parser/json/json.go
@@ -58,12 +58,12 @@ func stringify(v any) string {
 	return ""
 }
 
-// ParseJSON turns a JSON array of objects into benchmark data. Each
+// ParseJSON turns a JSON array of objects or arrays into benchmark data. Each
 // numeric field becomes a chart series (field name = Stat.Type); non-numeric
 // fields are ignored unless named in --group/-g, whose values are joined with
 // the separators from --group-pattern/-p and routed through the grouping
 // machinery (-p/-r). Nested objects are
-// flattened to dotted keys; array-valued fields are skipped.
+// flattened to dotted keys; array-valued fields inside objects are skipped.
 func ParseJSON(filename string, cfg parser.Config) ([]shared.DataPoint, parser.Config) {
 	var err error
 	cfg, err = parser.FinalizeGroupConfig(cfg)
@@ -89,25 +89,9 @@ func ParseJSON(filename string, cfg parser.Config) ([]shared.DataPoint, parser.C
 		return nil, cfg
 	}
 
-	var rows []map[string]any
-	var colOrder []string
-	seenCol := map[string]bool{}
-
-	for dec.More() {
-		leaves, derr := decodeElement(dec)
-		if derr != nil {
-			shared.ExitWithError("Error reading JSON", derr)
-		}
-
-		row := make(map[string]any, len(leaves))
-		for _, lf := range leaves {
-			row[lf.key] = lf.val // last wins on duplicate key
-			if !seenCol[lf.key] {
-				seenCol[lf.key] = true
-				colOrder = append(colOrder, lf.key)
-			}
-		}
-		rows = append(rows, row)
+	rows, colOrder, seenCol, err := decodeTopLevelRows(dec)
+	if err != nil {
+		shared.ExitWithError("Error reading JSON", err)
 	}
 
 	if len(rows) == 0 {
@@ -216,6 +200,273 @@ func ParseJSON(filename string, cfg parser.Config) ([]shared.DataPoint, parser.C
 	}
 
 	return results, cfg
+}
+
+func decodeTopLevelRows(dec *json.Decoder) ([]map[string]any, []string, map[string]bool, error) {
+	seenCol := map[string]bool{}
+
+	if !dec.More() {
+		return nil, nil, seenCol, nil
+	}
+
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if d, ok := tok.(json.Delim); ok {
+		switch d {
+		case '{':
+			return decodeObjectRows(dec, seenCol)
+		case '[':
+			return decodeMatrixRows(dec, seenCol)
+		}
+	}
+
+	rows, colOrder, err := decodeRemainingObjectRows(dec, nil, seenCol)
+	return rows, colOrder, seenCol, err
+}
+
+func decodeObjectRows(dec *json.Decoder, seenCol map[string]bool) ([]map[string]any, []string, map[string]bool, error) {
+	leaves, err := decodeObjectBody(dec, "")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	rows, colOrder, err := decodeRemainingObjectRows(dec, leaves, seenCol)
+	return rows, colOrder, seenCol, err
+}
+
+func decodeRemainingObjectRows(dec *json.Decoder, first []leaf, seenCol map[string]bool) ([]map[string]any, []string, error) {
+	var rows []map[string]any
+	var colOrder []string
+
+	if first != nil {
+		rows = append(rows, leavesToRow(first, seenCol, &colOrder))
+	}
+
+	for dec.More() {
+		leaves, derr := decodeElement(dec)
+		if derr != nil {
+			return nil, nil, derr
+		}
+		rows = append(rows, leavesToRow(leaves, seenCol, &colOrder))
+	}
+
+	return rows, colOrder, nil
+}
+
+func leavesToRow(leaves []leaf, seenCol map[string]bool, colOrder *[]string) map[string]any {
+	row := make(map[string]any, len(leaves))
+	for _, lf := range leaves {
+		row[lf.key] = lf.val // last wins on duplicate key
+		if !seenCol[lf.key] {
+			seenCol[lf.key] = true
+			*colOrder = append(*colOrder, lf.key)
+		}
+	}
+	return row
+}
+
+type matrixCell struct {
+	val      any
+	ok       bool
+	isString bool
+}
+
+func decodeMatrixRows(dec *json.Decoder, seenCol map[string]bool) ([]map[string]any, []string, map[string]bool, error) {
+	first, err := decodeMatrixRowBody(dec)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if matrixHeaderRow(first) {
+		headers := normalizeMatrixHeaders(first)
+		rows, headers, err := decodeMatrixDataRows(dec, headers, nil, false)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		colOrder := nonEmptyMatrixHeaders(headers)
+		for _, h := range colOrder {
+			seenCol[h] = true
+		}
+		return rows, colOrder, seenCol, nil
+	}
+
+	headers := syntheticMatrixHeaders(len(first))
+	rows, headers, err := decodeMatrixDataRows(dec, headers, first, true)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	colOrder := nonEmptyMatrixHeaders(headers)
+	for _, h := range colOrder {
+		seenCol[h] = true
+	}
+	return rows, colOrder, seenCol, nil
+}
+
+func decodeMatrixDataRows(dec *json.Decoder, headers []string, first []matrixCell, extendSynthetic bool) ([]map[string]any, []string, error) {
+	var rows []map[string]any
+	if first != nil {
+		if extendSynthetic {
+			headers = ensureSyntheticMatrixHeaders(headers, len(first))
+		}
+		rows = append(rows, matrixCellsToRow(first, headers))
+	}
+
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		d, ok := tok.(json.Delim)
+		if !ok || d != '[' {
+			if ok && (d == '{' || d == '[') {
+				if err := skipContainerBody(dec); err != nil {
+					return nil, nil, err
+				}
+			}
+			continue
+		}
+
+		cells, err := decodeMatrixRowBody(dec)
+		if err != nil {
+			return nil, nil, err
+		}
+		if extendSynthetic {
+			headers = ensureSyntheticMatrixHeaders(headers, len(cells))
+		}
+		rows = append(rows, matrixCellsToRow(cells, headers))
+	}
+
+	return rows, headers, nil
+}
+
+func decodeMatrixRowBody(dec *json.Decoder) ([]matrixCell, error) {
+	var cells []matrixCell
+
+	for dec.More() {
+		cell, err := decodeMatrixCell(dec)
+		if err != nil {
+			return nil, err
+		}
+		cells = append(cells, cell)
+	}
+
+	if _, err := dec.Token(); err != nil { // consume ']'
+		return nil, err
+	}
+
+	return cells, nil
+}
+
+func decodeMatrixCell(dec *json.Decoder) (matrixCell, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return matrixCell{}, err
+	}
+
+	switch v := tok.(type) {
+	case json.Delim:
+		switch v {
+		case '[', '{':
+			return matrixCell{}, skipContainerBody(dec)
+		}
+		return matrixCell{}, nil
+	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return matrixCell{}, nil
+		}
+		return matrixCell{val: v, ok: true}, nil
+	case string:
+		return matrixCell{val: v, ok: true, isString: true}, nil
+	default: // bool, nil
+		return matrixCell{}, nil
+	}
+}
+
+func matrixHeaderRow(cells []matrixCell) bool {
+	if len(cells) == 0 {
+		return false
+	}
+	for _, c := range cells {
+		if !c.ok || !c.isString {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeMatrixHeaders(cells []matrixCell) []string {
+	headers := make([]string, len(cells))
+	seen := map[string]int{}
+
+	for i, c := range cells {
+		h, _ := c.val.(string)
+		if i == 0 {
+			h = strings.TrimPrefix(h, "\ufeff")
+		}
+		h = strings.TrimSpace(h)
+		if h == "" {
+			continue
+		}
+
+		seen[h]++
+		if seen[h] > 1 {
+			h = fmt.Sprintf("%s (%d)", h, seen[h])
+		}
+		headers[i] = h
+	}
+
+	return headers
+}
+
+func syntheticMatrixHeaders(n int) []string {
+	return ensureSyntheticMatrixHeaders(nil, n)
+}
+
+func ensureSyntheticMatrixHeaders(headers []string, n int) []string {
+	for len(headers) < n {
+		headers = append(headers, syntheticMatrixHeader(len(headers)))
+	}
+	return headers
+}
+
+func syntheticMatrixHeader(i int) string {
+	switch i {
+	case 0:
+		return "x"
+	case 1:
+		return "y"
+	case 2:
+		return "z"
+	case 3:
+		return "metric"
+	default:
+		return fmt.Sprintf("col%d", i+1)
+	}
+}
+
+func nonEmptyMatrixHeaders(headers []string) []string {
+	var out []string
+	for _, h := range headers {
+		if h != "" {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+func matrixCellsToRow(cells []matrixCell, headers []string) map[string]any {
+	row := make(map[string]any)
+	for i, c := range cells {
+		if i >= len(headers) || headers[i] == "" || !c.ok {
+			continue
+		}
+		row[headers[i]] = c.val
+	}
+	return row
 }
 
 // jsonRowReader adapts one JSON row to the parser.RowReader interface.

--- a/pkg/parser/json/json.go
+++ b/pkg/parser/json/json.go
@@ -322,7 +322,7 @@ func decodeMatrixDataRows(dec *json.Decoder, headers []string, first []matrixCel
 
 		d, ok := tok.(json.Delim)
 		if !ok || d != '[' {
-			if ok && (d == '{' || d == '[') {
+			if ok && d == '{' {
 				if err := skipContainerBody(dec); err != nil {
 					return nil, nil, err
 				}
@@ -375,9 +375,6 @@ func decodeMatrixCell(dec *json.Decoder) (matrixCell, error) {
 		}
 		return matrixCell{}, nil
 	case float64:
-		if math.IsNaN(v) || math.IsInf(v, 0) {
-			return matrixCell{}, nil
-		}
 		return matrixCell{val: v, ok: true}, nil
 	case string:
 		return matrixCell{val: v, ok: true, isString: true}, nil

--- a/pkg/parser/json/json_test.go
+++ b/pkg/parser/json/json_test.go
@@ -158,6 +158,24 @@ func (s *JSONSuite) TestMatrixRaggedRowsAndSkippedCellsAreGaps() {
 	s.Equal([]string{"b"}, statTypes(results[2].Stats))
 }
 
+func (s *JSONSuite) TestMatrixBoolNullAndNestedValuesAreSkipped() {
+	j := `[["flag","empty","arr","obj","value"],[true,null,[1,2],{"nested":1},5]]`
+
+	results, _ := ParseJSON(s.writeFile(j), s.cfg)
+
+	s.Require().Len(results, 1)
+	s.Equal([]string{"value"}, statTypes(results[0].Stats))
+}
+
+func (s *JSONSuite) TestNoHeaderMatrixNamesColumnsAfterMetric() {
+	j := `[[1,2,3,4,5,6]]`
+
+	results, _ := ParseJSON(s.writeFile(j), s.cfg)
+
+	s.Require().Len(results, 1)
+	s.Equal([]string{"x", "y", "z", "metric", "col5", "col6"}, statTypes(results[0].Stats))
+}
+
 func (s *JSONSuite) TestMatrixEmptyAndHeaderOnlyReturnNil() {
 	pts, _ := ParseJSON(s.writeFile(`[]`), s.cfg)
 	s.Nil(pts)
@@ -480,6 +498,19 @@ func (s *JSONFatalSuite) TestSelectValueModeAllNumeric() {
 	s.Empty(results[0].Stats)
 }
 
+func (s *JSONFatalSuite) TestSelectValueModeNoHeaderMatrix() {
+	s.cfg.SelectViews = []parser.SelectView{
+		{Columns: []parser.ColumnSpec{{Source: "x", AxisKey: "x"}, {Source: "y", AxisKey: "y"}}},
+	}
+	path := s.writeFile(`[[1,2],[3,4]]`)
+
+	results, _ := ParseJSON(path, s.cfg)
+	s.Require().Len(results, 2)
+	s.Equal("1", results[0].XAxis)
+	s.Equal("2", results[0].YAxis)
+	s.Empty(results[0].Stats)
+}
+
 func TestJSONFatalSuite(t *testing.T) {
 	suite.Run(t, new(JSONFatalSuite))
 }
@@ -508,6 +539,15 @@ func (s *JSONAutoGroupSuite) TestCategoricalFieldBecomesXAxis() {
 	s.Equal("West", results[0].XAxis)
 	s.Equal("East", results[1].XAxis)
 	s.Equal([]string{"sells"}, statTypes(results[0].Stats))
+}
+
+func (s *JSONAutoGroupSuite) TestHeaderMatrixCategoricalColumnBecomesXAxis() {
+	j := `[["region","sales"],["West",10],["East",20]]`
+	results, _ := ParseJSON(s.writeFile(j), s.cfg)
+	s.Require().Len(results, 2)
+	s.Equal("West", results[0].XAxis)
+	s.Equal("East", results[1].XAxis)
+	s.Equal([]string{"sales"}, statTypes(results[0].Stats))
 }
 
 func (s *JSONAutoGroupSuite) TestNestedFlattenedFieldChosen() {
@@ -667,6 +707,14 @@ func (s *JSONAutoValueSuite) TestOneNumericFieldFallsBackToFlat() {
 	s.Require().Len(results, 2)
 	s.Empty(results[0].XAxis)
 	s.NotEmpty(results[0].Stats)
+}
+
+func (s *JSONAutoValueSuite) TestOneColumnMatrixFallsBackToFlat() {
+	j := `[[10],[20]]`
+	results, _ := ParseJSON(s.writeFile(j), s.cfg)
+	s.Require().Len(results, 2)
+	s.Empty(results[0].XAxis)
+	s.Equal([]string{"x"}, statTypes(results[0].Stats))
 }
 
 func (s *JSONAutoValueSuite) TestPieChartFallsBackToFlat() {

--- a/pkg/parser/json/json_test.go
+++ b/pkg/parser/json/json_test.go
@@ -147,6 +147,24 @@ func (s *JSONSuite) TestNumericLookingStringMatrixHeadersStayHeaders() {
 	s.Equal([]string{"10", "20"}, statTypes(results[0].Stats))
 }
 
+func (s *JSONSuite) TestMatrixHeaderEmptyAndDuplicateNames() {
+	j := `[["","sales","sales"],[99,10,20]]`
+
+	results, _ := ParseJSON(s.writeFile(j), s.cfg)
+
+	s.Require().Len(results, 1)
+	s.Equal([]string{"sales", "sales (2)"}, statTypes(results[0].Stats))
+}
+
+func (s *JSONSuite) TestEmptyFirstMatrixRowUsesSyntheticNamesForLaterRows() {
+	j := `[[],[1,2]]`
+
+	results, _ := ParseJSON(s.writeFile(j), s.cfg)
+
+	s.Require().Len(results, 1)
+	s.Equal([]string{"x", "y"}, statTypes(results[0].Stats))
+}
+
 func (s *JSONSuite) TestMatrixRaggedRowsAndSkippedCellsAreGaps() {
 	j := `[["a","b","c"],[1],[2,3,4],[null,5,{"nested":true}]]`
 
@@ -167,6 +185,16 @@ func (s *JSONSuite) TestMatrixBoolNullAndNestedValuesAreSkipped() {
 	s.Equal([]string{"value"}, statTypes(results[0].Stats))
 }
 
+func (s *JSONSuite) TestNoHeaderMatrixSkipsMixedTopLevelElements() {
+	j := `[[1,2],99,{"skip":true},[3,4]]`
+
+	results, _ := ParseJSON(s.writeFile(j), s.cfg)
+
+	s.Require().Len(results, 2)
+	s.Equal([]string{"x", "y"}, statTypes(results[0].Stats))
+	s.Equal([]string{"x", "y"}, statTypes(results[1].Stats))
+}
+
 func (s *JSONSuite) TestNoHeaderMatrixNamesColumnsAfterMetric() {
 	j := `[[1,2,3,4,5,6]]`
 
@@ -182,6 +210,135 @@ func (s *JSONSuite) TestMatrixEmptyAndHeaderOnlyReturnNil() {
 
 	pts, _ = ParseJSON(s.writeFile(`[["x","y"]]`), s.cfg)
 	s.Nil(pts)
+}
+
+func (s *JSONSuite) TestDecodeTopLevelRowsMalformedInputsReturnErrors() {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{name: "first token", input: `[tru`},
+		{name: "object body", input: `[{"x":`},
+		{name: "object tail", input: `[{"x":1},{"y":`},
+		{name: "matrix first row", input: `[[1`},
+		{name: "matrix header data row", input: `[["x"],[`},
+		{name: "matrix data token", input: `[[1], tru`},
+		{name: "matrix data row", input: `[[1],[2`},
+		{name: "matrix skipped object", input: `[[1],{"skip":`},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			dec := json.NewDecoder(strings.NewReader(tc.input))
+			tok, err := dec.Token()
+			s.Require().NoError(err)
+			s.Equal(json.Delim('['), tok)
+
+			_, _, _, err = decodeTopLevelRows(dec)
+			s.Error(err)
+		})
+	}
+}
+
+func (s *JSONSuite) TestDecodeTopLevelRowsScalarFirstFallsBackToObjectRows() {
+	dec := json.NewDecoder(strings.NewReader(`[1,{"x":2}]`))
+	tok, err := dec.Token()
+	s.Require().NoError(err)
+	s.Equal(json.Delim('['), tok)
+
+	rows, colOrder, seenCol, err := decodeTopLevelRows(dec)
+	s.Require().NoError(err)
+	s.Equal([]string{"x"}, colOrder)
+	s.True(seenCol["x"])
+	s.Require().Len(rows, 1)
+	s.Equal(2.0, rows[0]["x"])
+}
+
+func (s *JSONSuite) TestDecodeMatrixCellErrorAndUnexpectedClose() {
+	dec := json.NewDecoder(strings.NewReader(""))
+	_, err := decodeMatrixCell(dec)
+	s.Error(err)
+
+	dec = json.NewDecoder(strings.NewReader(`[tru`))
+	tok, err := dec.Token()
+	s.Require().NoError(err)
+	s.Equal(json.Delim('['), tok)
+	_, err = decodeMatrixRowBody(dec)
+	s.Error(err)
+
+	dec = json.NewDecoder(strings.NewReader(`[]`))
+	tok, err = dec.Token()
+	s.Require().NoError(err)
+	s.Equal(json.Delim('['), tok)
+
+	cell, err := decodeMatrixCell(dec)
+	s.NoError(err)
+	s.False(cell.ok)
+}
+
+func (s *JSONSuite) TestJSONKindFnSkipsRowsMissingAxisField() {
+	rows := []map[string]any{
+		{"y": 2.0},
+		{"x": 1.0, "y": 3.0},
+	}
+	kind := jsonKindFn(rows, map[string]bool{"x": true, "y": true}, []string{"x", "y"}, "--select")
+
+	got, err := kind("x", "x")
+
+	s.NoError(err)
+	s.Equal("value", got)
+}
+
+func (s *JSONSuite) TestResolveGroupKeysSkipsEmptyNames() {
+	keys, set := resolveGroupKeys([]string{"x"}, map[string]bool{"x": true}, []string{"", "x"})
+
+	s.Equal([]string{"x"}, keys)
+	s.True(set["x"])
+}
+
+func (s *JSONSuite) TestLowLevelObjectDecodersReturnErrors() {
+	dec := json.NewDecoder(strings.NewReader(""))
+	_, err := decodeElement(dec)
+	s.Error(err)
+
+	dec = json.NewDecoder(strings.NewReader(`{"x":1`))
+	tok, err := dec.Token()
+	s.Require().NoError(err)
+	s.Equal(json.Delim('{'), tok)
+	_, err = decodeObjectBody(dec, "")
+	s.Error(err)
+
+	dec = json.NewDecoder(strings.NewReader(`{`))
+	tok, err = dec.Token()
+	s.Require().NoError(err)
+	s.Equal(json.Delim('{'), tok)
+	_, err = decodeObjectBody(dec, "")
+	s.Error(err)
+
+	dec = json.NewDecoder(strings.NewReader(`{"`))
+	tok, err = dec.Token()
+	s.Require().NoError(err)
+	s.Equal(json.Delim('{'), tok)
+	_, err = decodeObjectBody(dec, "")
+	s.Error(err)
+
+	dec = json.NewDecoder(strings.NewReader(""))
+	_, err = decodeValue(dec, "x")
+	s.Error(err)
+
+	dec = json.NewDecoder(strings.NewReader(`[]`))
+	tok, err = dec.Token()
+	s.Require().NoError(err)
+	s.Equal(json.Delim('['), tok)
+	leaves, err := decodeValue(dec, "x")
+	s.NoError(err)
+	s.Nil(leaves)
+
+	dec = json.NewDecoder(strings.NewReader(`[[1]]`))
+	tok, err = dec.Token()
+	s.Require().NoError(err)
+	s.Equal(json.Delim('['), tok)
+	s.NoError(skipContainerBody(dec))
 }
 
 func (s *JSONSuite) TestBoolAndNullSkipped() {
@@ -370,8 +527,44 @@ func (s *JSONFatalSuite) TestMissingGroupFieldIsFatal() {
 	s.PanicsWithValue("exit", func() { ParseJSON(path, s.cfg) })
 }
 
+func (s *JSONFatalSuite) TestInvalidGroupConfigIsFatal() {
+	s.cfg.Group = []string{"a", "b"}
+	s.cfg.GroupPattern = "x"
+	path := s.writeFile(`[{"a":"A","b":"B","sales":10}]`)
+
+	s.PanicsWithValue("exit", func() { ParseJSON(path, s.cfg) })
+}
+
+func (s *JSONFatalSuite) TestOpenFileErrorIsFatal() {
+	path := filepath.Join(s.T().TempDir(), "missing.json")
+
+	s.PanicsWithValue("exit", func() { ParseJSON(path, s.cfg) })
+}
+
 func (s *JSONFatalSuite) TestNoNumericFieldsIsFatal() {
 	path := s.writeFile(`[{"name":"a","label":"foo"}]`)
+
+	s.PanicsWithValue("exit", func() { ParseJSON(path, s.cfg) })
+}
+
+func (s *JSONFatalSuite) TestAutoDetectGroupConfigErrorIsFatal() {
+	s.cfg.AutoGroup = true
+	s.cfg.ChartTypes = []string{"bar"}
+	path := s.writeFile(`[{"a/b":"cat","sales":10}]`)
+
+	s.PanicsWithValue("exit", func() { ParseJSON(path, s.cfg) })
+}
+
+func (s *JSONFatalSuite) TestMalformedMatrixIsFatal() {
+	path := s.writeFile(`[["x"],[`)
+
+	s.PanicsWithValue("exit", func() { ParseJSON(path, s.cfg) })
+}
+
+func (s *JSONFatalSuite) TestGroupTabularRowErrorIsFatal() {
+	s.cfg.Group = []string{"a"}
+	s.cfg.GroupRegex = ".*"
+	path := s.writeFile(`[{"a":"A","sales":10}]`)
 
 	s.PanicsWithValue("exit", func() { ParseJSON(path, s.cfg) })
 }

--- a/pkg/parser/json/json_test.go
+++ b/pkg/parser/json/json_test.go
@@ -116,6 +116,56 @@ func (s *JSONSuite) TestArrayValuedFieldSkipped() {
 	s.Equal([]string{"sells"}, statTypes(results[0].Stats))
 }
 
+func (s *JSONSuite) TestHeaderMatrixUsesFirstRowAsColumns() {
+	s.cfg.Group = []string{"region"}
+	j := `[["region","sales"],["West",10],["East",20]]`
+
+	results, _ := ParseJSON(s.writeFile(j), s.cfg)
+
+	s.Require().Len(results, 2)
+	s.Equal("West", results[0].XAxis)
+	s.Equal("East", results[1].XAxis)
+	s.Equal([]string{"sales"}, statTypes(results[0].Stats))
+}
+
+func (s *JSONSuite) TestMixedFirstMatrixRowUsesSyntheticColumns() {
+	j := `[["x",2],[3,4]]`
+
+	results, _ := ParseJSON(s.writeFile(j), s.cfg)
+
+	s.Require().Len(results, 2)
+	s.Equal([]string{"y"}, statTypes(results[0].Stats))
+	s.Equal([]string{"x", "y"}, statTypes(results[1].Stats))
+}
+
+func (s *JSONSuite) TestNumericLookingStringMatrixHeadersStayHeaders() {
+	j := `[["10","20"],[1,2]]`
+
+	results, _ := ParseJSON(s.writeFile(j), s.cfg)
+
+	s.Require().Len(results, 1)
+	s.Equal([]string{"10", "20"}, statTypes(results[0].Stats))
+}
+
+func (s *JSONSuite) TestMatrixRaggedRowsAndSkippedCellsAreGaps() {
+	j := `[["a","b","c"],[1],[2,3,4],[null,5,{"nested":true}]]`
+
+	results, _ := ParseJSON(s.writeFile(j), s.cfg)
+
+	s.Require().Len(results, 3)
+	s.Equal([]string{"a"}, statTypes(results[0].Stats))
+	s.Equal([]string{"a", "b", "c"}, statTypes(results[1].Stats))
+	s.Equal([]string{"b"}, statTypes(results[2].Stats))
+}
+
+func (s *JSONSuite) TestMatrixEmptyAndHeaderOnlyReturnNil() {
+	pts, _ := ParseJSON(s.writeFile(`[]`), s.cfg)
+	s.Nil(pts)
+
+	pts, _ = ParseJSON(s.writeFile(`[["x","y"]]`), s.cfg)
+	s.Nil(pts)
+}
+
 func (s *JSONSuite) TestBoolAndNullSkipped() {
 	j := `[{"name":"a","sells":10,"active":true,"note":null}]`
 
@@ -544,6 +594,17 @@ func (s *JSONAutoValueSuite) TestTwoNumericFields() {
 	s.Empty(results[0].Stats)
 }
 
+func (s *JSONAutoValueSuite) TestNoHeaderMatrixTwoNumericColumnsAutoValue() {
+	j := `[[1,2],[3,4],[5,6]]`
+
+	results, _ := ParseJSON(s.writeFile(j), s.cfg)
+
+	s.Require().Len(results, 3)
+	s.Equal("1", results[0].XAxis)
+	s.Equal("2", results[0].YAxis)
+	s.Empty(results[0].Stats)
+}
+
 func (s *JSONAutoValueSuite) TestThreeNumericFields() {
 	j := `[{"price":10,"latency":5,"mem":100},{"price":20,"latency":7,"mem":200}]`
 	results, _ := ParseJSON(s.writeFile(j), s.cfg)
@@ -551,6 +612,32 @@ func (s *JSONAutoValueSuite) TestThreeNumericFields() {
 	s.Equal("10", results[0].XAxis)
 	s.Equal("5", results[0].YAxis)
 	s.Equal("100", results[0].ZAxis)
+	s.Empty(results[0].Stats)
+}
+
+func (s *JSONAutoValueSuite) TestNoHeaderMatrixFourNumericColumnsUsesMetric() {
+	j := `[[1,2,3,4],[5,6,7,8]]`
+
+	results, _ := ParseJSON(s.writeFile(j), s.cfg)
+
+	s.Require().Len(results, 2)
+	s.Equal("1", results[0].XAxis)
+	s.Equal("2", results[0].YAxis)
+	s.Equal("3", results[0].ZAxis)
+	s.Equal("4", results[0].Metric)
+	s.Empty(results[0].Stats)
+}
+
+func (s *JSONAutoValueSuite) TestNestedMatrixViaJSONPathAutoValue() {
+	source := s.writeFile(`{"payload":{"rows":[[1,2],[3,4]]}}`)
+	selected, err := SelectPath(source, ".payload.rows")
+	s.Require().NoError(err)
+
+	results, _ := ParseJSON(s.writeFile(string(selected)), s.cfg)
+
+	s.Require().Len(results, 2)
+	s.Equal("1", results[0].XAxis)
+	s.Equal("2", results[0].YAxis)
 	s.Empty(results[0].Stats)
 }
 

--- a/pkg/parser/json/jsonpath_test.go
+++ b/pkg/parser/json/jsonpath_test.go
@@ -94,3 +94,31 @@ func TestSelectPath(t *testing.T) {
 		})
 	}
 }
+
+func TestSelectPathReadAndParseErrors(t *testing.T) {
+	_, err := SelectPath(filepath.Join(t.TempDir(), "missing.json"), ".rows")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error reading JSON")
+
+	f := filepath.Join(t.TempDir(), "bad.json")
+	require.NoError(t, os.WriteFile(f, []byte(`{"rows":`), 0o644))
+	_, err = SelectPath(f, ".rows")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error parsing JSON")
+}
+
+func TestTokenizeLenientMalformedSegments(t *testing.T) {
+	require.Empty(t, tokenize("[]"))
+
+	gapped := tokenize(".rows..items")
+	require.Len(t, gapped, 2)
+	require.Equal(t, "rows", gapped[0].key)
+	require.Equal(t, "items", gapped[1].key)
+
+	got := tokenize(".rows[].items[x][1]")
+	require.Len(t, got, 2)
+	require.Equal(t, "rows", got[0].key)
+	require.Empty(t, got[0].indices)
+	require.Equal(t, "items", got[1].key)
+	require.Equal(t, []int{1}, got[1].indices)
+}


### PR DESCRIPTION
## Related Issue
Added #202 

---
## Summary: 
implemented JSON 2D array support in the tabular JSON
  parser, reusing the existing CSV-style tabular pipeline for
  grouping, select mode, and auto-value charts.

---
## Change points:

  - Added first-element shape detection for top-level JSON arrays:
      - { keeps existing array-of-objects behavior.
      - [ enables matrix / 2D array parsing.

  - Added matrix header detection:
      - All-string first row becomes column headers.
      - Numeric-looking strings like "10" still count as headers.

  - Added synthetic column names for no-header matrices:
      - x, y, z, metric, then col5, col6, etc.

  - Matrix rows now normalize into the existing named-column row
    model.

  - Supported matrix cell rules:
      - JSON numbers and strings are accepted.
      - bool, null, nested arrays, and nested objects are skipped.
      - Ragged rows create gaps.

  - Preserved existing object-array behavior, including nested
    object flattening and skipped array-valued fields.

  - Added tests for:
      - Header matrix.
      - No-header 2-column auto-value.
      - No-header 4-column x/y/z + metric.
      - Mixed first row synthetic naming.
      - Numeric-looking string headers.
      - Ragged rows and skipped cells.
      - Empty/header-only arrays.
      - Nested matrix via --json-path.

  - Updated tabular JSON docs and parser docs.
  - Added changelog entry.
 
---
## Test Result
### Case 1
```bash
# commands
env GOCACHE=/private/tmp/vizb-go-build go test ./pkg/parser/json
env GOCACHE=/private/tmp/vizb-go-build go test ./pkg/parser/...

# result
ok      github.com/goptics/vizb/pkg/parser/json (cached)
ok      github.com/goptics/vizb/pkg/parser      (cached)
ok      github.com/goptics/vizb/pkg/parser/csv  (cached)
ok      github.com/goptics/vizb/pkg/parser/golang       (cached)
ok      github.com/goptics/vizb/pkg/parser/javascript   (cached)
ok      github.com/goptics/vizb/pkg/parser/json (cached)
ok      github.com/goptics/vizb/pkg/parser/rust (cached)
```
### Case 2
```bash
# command
printf '[["region","sales"],["West",10],["East",20]]' > /tmp/header-matrix.json
./bin/vizb /tmp/header-matrix.json -P json -o /tmp/header-matrix.out.json
cat /tmp/header-matrix.out.json | jq
# result
{
  "timestamp": "2026-07-12T22:33:10Z",
  "name": "Comparisons",
  "theme": "default",
  "axes": [
    {
      "key": "x",                                                         
     "label": "region"
    }
  ],
  "settings": [
    {
      "type": "bar",
      "scale": "linear"
    },
    {
      "type": "line",
      "scale": "linear"
    },
    {
      "type": "pie"
    }
  ],
  "data": [
    {
      "xAxis": "West",
      "stats": [
        {
          "type": "sales",
          "value": 10
        }
      ]
    },
    {
      "xAxis": "East",
      "stats": [
        {                                                                     
          "type": "sales",
          "value": 20                                                       
        }
      ]                                                                 
    }
  ]                                                                 
}
```
### Case 3
```bash
# commands
printf '[[1,2],[3,4],[5,6]]' > /tmp/xy-matrix.json
./bin/vizb scatter /tmp/xy-matrix.json -P json -o /tmp/xy-matrix.out.json
cat /tmp/xy-matrix.out.json | jq
# result
{
  "timestamp": "2026-07-12T22:39:56Z",
  "name": "Comparisons",
  "theme": "default",
  "axes": [
    {
      "key": "x",
      "label": "x",
      "type": "value"
    },                                                                  
  {
      "key": "y",
      "label": "y",                                                       
      "type": "value"
    }
  ],
  "settings": [
    {
      "type": "scatter",
      "scale": "linear"
    }
  ],
  "data": [
    {                                                                     
      "xAxis": "1",
      "yAxis": "2"
    },
    {
      "xAxis": "3",
      "yAxis": "4"
    },
    {
      "xAxis": "5",
      "yAxis": "6"
    }
  ],
  "preserveRows": true
}
```
### Case 4
```bash
# commands
printf '[[1,2,3,4],[5,6,7,8]]' > /tmp/xyz-metric.json
./bin/vizb scatter /tmp/xyz-metric.json -P json -o /tmp/xyz-metric.out.json
cat /tmp/xyz-metric.out.json | jq
# result
{
  "timestamp": "2026-07-12T22:41:17Z",
  "name": "Comparisons",
  "theme": "default",
  "axes": [
    {
      "key": "x",
      "label": "x",
      "type": "value"                                                   
    },
    {
      "key": "y",                                                         
      "label": "y",
      "type": "value"
    },
    {
      "key": "z",
      "label": "z",
      "type": "value"
    },
    {
      "key": "metric",
      "label": "metric",                                                  
      "type": "value"
    }
  ],
  "settings": [
    {
      "type": "scatter",
      "scale": "linear",
      "threeD": true,
      "threeDVisualMap": true
    }
  ],
  "data": [                                                             {
      "xAxis": "1",
      "yAxis": "2",
      "zAxis": "3",
      "metric": "4"
    },
    {
      "xAxis": "5",
      "yAxis": "6",
      "zAxis": "7",
      "metric": "8"
    }
  ],
  "preserveRows": true
}
```
### Case 5
```bash
# HTML smoke test
# command
./bin/vizb scatter /tmp/xy-matrix.json -P json -o /tmp/xy-matrix.html
open /tmp/xy-matrix.html
```
<img width="1044" height="879" alt="Screenshot 2026-07-12 at 3 42 46 PM" src="https://github.com/user-attachments/assets/edb60f9d-1351-44ae-8fd9-d8ce32d4b0b3" />

### Case 6
```bash
# 4 column case 
# z + metric
# command
printf '[[1,2,3,4],[5,6,7,8]]' > /tmp/xyz-metric.json
./bin/vizb scatter /tmp/xyz-metric.json -P json -o /tmp/xyz-metric.html
open /tmp/xyz-metric.html
```
<img width="1041" height="884" alt="Screenshot 2026-07-12 at 3 44 06 PM" src="https://github.com/user-attachments/assets/d1f2b65e-ccab-41a5-a617-f35af5dde56f" />


