### PR TITLE
feat(dx): add Dev Container and bump Go to 1.26.5

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,57 +1,63 @@
-# Dev container toolchain for vizb.
-# Node 22 is added via the node feature in devcontainer.json.
+# Dev container toolchain for vizb ("vizber").
 #
-# Keep the base image user `vscode` (UID 1000). Renaming it breaks Zed/VS Code
-# feature installs and `docker exec -u …` (passwd entry missing). The cool
-# project identity is the container *name* ("vizber") and shell prompt, not the
-# OS login name.
+# The Microsoft Go image ships a non-root user named `vscode`. We rename it to
+# `vizber` (same UID/GID 1000) so the OS login matches the project identity.
+# Node is installed here (not via a Dev Container feature) so feature scripts
+# cannot reintroduce a `vscode` user after the rename.
 FROM mcr.microsoft.com/devcontainers/go:1.26-bookworm
-
-ENV PATH="/go/bin:/home/vscode/go/bin:${PATH}"
 
 USER root
 
-# Writable dirs for editor / package managers (must not be root-owned).
-RUN mkdir -p \
-      /home/vscode/.local/share/pnpm/store \
-      /home/vscode/.local/bin \
-      /home/vscode/.host-local-bin \
-      /home/vscode/.cache \
-  && chown -R vscode:vscode /home/vscode/.local /home/vscode/.host-local-bin /home/vscode/.cache
+# ── Rename vscode → vizber (UID/GID stay 1000 for host bind-mount ownership) ──
+RUN set -eux; \
+    groupmod --new-name vizber vscode; \
+    usermod --login vizber --move-home --home /home/vizber vscode; \
+    echo 'vizber ALL=(root) NOPASSWD:ALL' > /etc/sudoers.d/vizber; \
+    chmod 0440 /etc/sudoers.d/vizber; \
+    # Drop any leftover vscode identity
+    if getent passwd vscode >/dev/null 2>&1; then userdel -r vscode || true; fi; \
+    if getent group vscode >/dev/null 2>&1; then groupdel vscode || true; fi; \
+    getent passwd vizber; \
+    test ! -d /home/vscode; \
+    test -d /home/vizber
 
-# Task (taskfile.dev) — install prebuilt binary (faster/more reliable than go install).
+# Tell Dev Container tooling the remote user is vizber (overrides image metadata).
+LABEL devcontainer.metadata='[{"remoteUser":"vizber"}]'
+
+ENV HOME=/home/vizber \
+    PATH="/go/bin:/home/vizber/go/bin:/usr/local/go/bin:${PATH}"
+
+# Writable dirs for editor / package managers
+RUN mkdir -p \
+      /home/vizber/.local/share/pnpm/store \
+      /home/vizber/.local/bin \
+      /home/vizber/.host-local-bin \
+      /home/vizber/.cache \
+      /home/vizber/go \
+  && chown -R vizber:vizber /home/vizber
+
+# Node 22 + corepack (no node feature — keeps user rename intact)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+  && apt-get install -y --no-install-recommends nodejs \
+  && corepack enable \
+  && corepack prepare pnpm@10.33.2 --activate \
+  && node -v && pnpm -v \
+  && rm -rf /var/lib/apt/lists/*
+
+# Task (taskfile.dev)
 RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin \
   && task --version
 
-USER vscode
+USER vizber
+WORKDIR /home/vizber
 
-# pnpm: use a home-local store (never repo .pnpm-store — that can be root-owned
-# from old Docker runs and causes "readonly database"). Pin pnpm 10.x — pnpm 11
-# treats ignored dependency build scripts as hard errors and breaks `pnpm dev`.
+# pnpm: home-local store only (repo .pnpm-store can be root-owned from old Docker runs)
 RUN printf '%s\n' \
-      'store-dir=/home/vscode/.local/share/pnpm/store' \
+      'store-dir=/home/vizber/.local/share/pnpm/store' \
       'confirm-modules-purge=false' \
-      > /home/vscode/.npmrc
+      > /home/vizber/.npmrc
 
-# Shell branding: show "vizber" in the prompt while the OS user stays vscode.
-# Appended after the image's oh-my-zsh setup so it wins over the default theme.
-RUN printf '%s\n' \
-      '' \
-      '# vizber Dev Container branding (OS user remains vscode for tooling compatibility)' \
-      'export DEVCONTAINER_NAME=vizber' \
-      'if [ -n "$ZSH_VERSION" ]; then' \
-      '  PROMPT="%F{magenta}vizber%f %F{blue}%~%f %# "' \
-      'elif [ -n "$BASH_VERSION" ]; then' \
-      '  PS1="\[\e[35m\]vizber\[\e[0m\] \[\e[34m\]\w\[\e[0m\] \$ "' \
-      'fi' \
-      >> /home/vscode/.zshrc \
-  && printf '%s\n' \
-      '' \
-      'export DEVCONTAINER_NAME=vizber' \
-      'PS1="\[\e[35m\]vizber\[\e[0m\] \[\e[34m\]\w\[\e[0m\] \$ "' \
-      >> /home/vscode/.bashrc
-
-# golangci-lint v2 (matches .golangci.yml version: "2") — prebuilt binary
+# golangci-lint v2 (matches .golangci.yml version: "2")
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
   | sh -s -- -b "$(go env GOPATH)/bin" \
   && golangci-lint --version

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+# Dev container toolchain for vizb.
+# Node 22 is added via the node feature in devcontainer.json.
+#
+# Keep the base image user `vscode` (UID 1000). Renaming it breaks Zed/VS Code
+# feature installs and `docker exec -u …` (passwd entry missing). The cool
+# project identity is the container name in devcontainer.json, not the OS user.
+FROM mcr.microsoft.com/devcontainers/go:1.26-bookworm
+
+ENV PATH="/go/bin:/home/vscode/go/bin:${PATH}"
+
+USER root
+
+# Ensure vscode owns ~/.local so the remote editor (Zed/VS Code) can write
+# ~/.local/share. Do NOT bind-mount over ~/.local/bin — that makes Docker create
+# ~/.local as root and breaks the remote server (exit status 1).
+RUN mkdir -p /home/vscode/.local/share /home/vscode/.local/bin /home/vscode/.host-local-bin \
+  && chown -R vscode:vscode /home/vscode/.local /home/vscode/.host-local-bin
+
+# Task (taskfile.dev) — install prebuilt binary (faster/more reliable than go install).
+RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin \
+  && task --version
+
+# golangci-lint v2 (matches .golangci.yml version: "2") — prebuilt binary
+USER vscode
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
+  | sh -s -- -b "$(go env GOPATH)/bin" \
+  && golangci-lint --version

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,9 +24,11 @@ RUN set -eux; \
 # Tell Dev Container tooling the remote user is vizber (overrides image metadata).
 LABEL devcontainer.metadata='[{"remoteUser":"vizber"}]'
 
+# Base image pins GOTOOLCHAIN=local and ships 1.26.4; go.mod needs 1.26.5.
+# auto = download the newer toolchain when the module requires it.
 ENV HOME=/home/vizber \
-    PATH="/go/bin:/home/vizber/go/bin:/usr/local/go/bin:${PATH}"
-
+    PATH="/go/bin:/home/vizber/go/bin:/usr/local/go/bin:${PATH}" \
+    GOTOOLCHAIN=auto
 # Writable dirs for editor / package managers
 RUN mkdir -p \
       /home/vizber/.local/share/pnpm/store \
@@ -57,11 +59,13 @@ RUN printf '%s\n' \
       'confirm-modules-purge=false' \
       > /home/vizber/.npmrc
 
+# Pre-fetch go1.26.5 (go.mod) so first builds do not wait on download.
+RUN GOTOOLCHAIN=go1.26.5 go version
+
 # golangci-lint v2 (matches .golangci.yml version: "2")
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
   | sh -s -- -b "$(go env GOPATH)/bin" \
   && golangci-lint --version
-
 # Prompt: basename only via zsh/bash built-ins (%1~ / \W). No custom precmd.
 # Appended after the image oh-my-zsh setup so it wins over the default theme.
 RUN printf '%s\n' \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -61,3 +61,24 @@ RUN printf '%s\n' \
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
   | sh -s -- -b "$(go env GOPATH)/bin" \
   && golangci-lint --version
+
+# Prompt: show only the project folder name (basename), not the full host path.
+# Appended after the image oh-my-zsh setup so it wins over the default theme.
+RUN printf '%s\n' \
+      '' \
+      '# vizber: short prompt (project name only — full path is still `pwd`)' \
+      'prompt_vizber() {' \
+      '  local dir="${PWD:t}"' \
+      '  local branch=""' \
+      '  if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then' \
+      '    branch=" ($(git branch --show-current 2>/dev/null))"' \
+      '  fi' \
+      '  PROMPT="%F{magenta}vizber%f %F{cyan}${dir}%f%F{yellow}${branch}%f %# "' \
+      '}' \
+      'precmd_functions+=(prompt_vizber)' \
+      >> /home/vizber/.zshrc \
+  && printf '%s\n' \
+      '' \
+      '# vizber: short prompt (project name only)' \
+      'PS1="\[\e[35m\]vizber\[\e[0m\] \[\e[36m\]\W\[\e[0m\] \$ "' \
+      >> /home/vizber/.bashrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -62,23 +62,15 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/ins
   | sh -s -- -b "$(go env GOPATH)/bin" \
   && golangci-lint --version
 
-# Prompt: show only the project folder name (basename), not the full host path.
+# Prompt: basename only via zsh/bash built-ins (%1~ / \W). No custom precmd.
 # Appended after the image oh-my-zsh setup so it wins over the default theme.
 RUN printf '%s\n' \
       '' \
-      '# vizber: short prompt (project name only — full path is still `pwd`)' \
-      'prompt_vizber() {' \
-      '  local dir="${PWD:t}"' \
-      '  local branch=""' \
-      '  if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then' \
-      '    branch=" ($(git branch --show-current 2>/dev/null))"' \
-      '  fi' \
-      '  PROMPT="%F{magenta}vizber%f %F{cyan}${dir}%f%F{yellow}${branch}%f %# "' \
-      '}' \
-      'precmd_functions+=(prompt_vizber)' \
+      '# vizber: %1~ = last path segment only (project name); full path is still `pwd`' \
+      "PROMPT='%F{magenta}vizber%f %F{cyan}%1~%f %# '" \
       >> /home/vizber/.zshrc \
   && printf '%s\n' \
       '' \
-      '# vizber: short prompt (project name only)' \
+      '# vizber: \W = basename only' \
       'PS1="\[\e[35m\]vizber\[\e[0m\] \[\e[36m\]\W\[\e[0m\] \$ "' \
       >> /home/vizber/.bashrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,25 +3,55 @@
 #
 # Keep the base image user `vscode` (UID 1000). Renaming it breaks Zed/VS Code
 # feature installs and `docker exec -u …` (passwd entry missing). The cool
-# project identity is the container name in devcontainer.json, not the OS user.
+# project identity is the container *name* ("vizber") and shell prompt, not the
+# OS login name.
 FROM mcr.microsoft.com/devcontainers/go:1.26-bookworm
 
 ENV PATH="/go/bin:/home/vscode/go/bin:${PATH}"
 
 USER root
 
-# Ensure vscode owns ~/.local so the remote editor (Zed/VS Code) can write
-# ~/.local/share. Do NOT bind-mount over ~/.local/bin — that makes Docker create
-# ~/.local as root and breaks the remote server (exit status 1).
-RUN mkdir -p /home/vscode/.local/share /home/vscode/.local/bin /home/vscode/.host-local-bin \
-  && chown -R vscode:vscode /home/vscode/.local /home/vscode/.host-local-bin
+# Writable dirs for editor / package managers (must not be root-owned).
+RUN mkdir -p \
+      /home/vscode/.local/share/pnpm/store \
+      /home/vscode/.local/bin \
+      /home/vscode/.host-local-bin \
+      /home/vscode/.cache \
+  && chown -R vscode:vscode /home/vscode/.local /home/vscode/.host-local-bin /home/vscode/.cache
 
 # Task (taskfile.dev) — install prebuilt binary (faster/more reliable than go install).
 RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin \
   && task --version
 
-# golangci-lint v2 (matches .golangci.yml version: "2") — prebuilt binary
 USER vscode
+
+# pnpm: use a home-local store (never repo .pnpm-store — that can be root-owned
+# from old Docker runs and causes "readonly database"). Pin pnpm 10.x — pnpm 11
+# treats ignored dependency build scripts as hard errors and breaks `pnpm dev`.
+RUN printf '%s\n' \
+      'store-dir=/home/vscode/.local/share/pnpm/store' \
+      'confirm-modules-purge=false' \
+      > /home/vscode/.npmrc
+
+# Shell branding: show "vizber" in the prompt while the OS user stays vscode.
+# Appended after the image's oh-my-zsh setup so it wins over the default theme.
+RUN printf '%s\n' \
+      '' \
+      '# vizber Dev Container branding (OS user remains vscode for tooling compatibility)' \
+      'export DEVCONTAINER_NAME=vizber' \
+      'if [ -n "$ZSH_VERSION" ]; then' \
+      '  PROMPT="%F{magenta}vizber%f %F{blue}%~%f %# "' \
+      'elif [ -n "$BASH_VERSION" ]; then' \
+      '  PS1="\[\e[35m\]vizber\[\e[0m\] \[\e[34m\]\w\[\e[0m\] \$ "' \
+      'fi' \
+      >> /home/vscode/.zshrc \
+  && printf '%s\n' \
+      '' \
+      'export DEVCONTAINER_NAME=vizber' \
+      'PS1="\[\e[35m\]vizber\[\e[0m\] \[\e[34m\]\w\[\e[0m\] \$ "' \
+      >> /home/vscode/.bashrc
+
+# golangci-lint v2 (matches .golangci.yml version: "2") — prebuilt binary
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
   | sh -s -- -b "$(go env GOPATH)/bin" \
   && golangci-lint --version

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "initializeCommand": "mkdir -p \"${localEnv:HOME}/.claude\" \"${localEnv:HOME}/.agents\" \"${localEnv:HOME}/.grok\" \"${localEnv:HOME}/.codex\" \"${localEnv:HOME}/.config/opencode\" \"${localEnv:HOME}/.opencode\" \"${localEnv:HOME}/.local/bin\" \"${localEnv:HOME}/.cursor\"",
+  "workspaceMount": "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
+  "workspaceFolder": "${localWorkspaceFolder}",
+  "initializeCommand": "mkdir -p \"${localEnv:HOME}/.claude\" \"${localEnv:HOME}/.agents\" \"${localEnv:HOME}/.grok\" \"${localEnv:HOME}/.codex\" \"${localEnv:HOME}/.config/opencode\" \"${localEnv:HOME}/.opencode\" \"${localEnv:HOME}/.local/bin\" \"${localEnv:HOME}/.cursor\" \"${localEnv:HOME}/.orca\" \"${localEnv:HOME}/.junie\"",
   "mounts": [
     "source=${localEnv:HOME}/.claude,target=/home/vizber/.claude,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.agents,target=/home/vizber/.agents,type=bind,consistency=cached",
@@ -13,10 +15,23 @@
     "source=${localEnv:HOME}/.config/opencode,target=/home/vizber/.config/opencode,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.opencode,target=/home/vizber/.opencode,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.cursor,target=/home/vizber/.cursor,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.local/bin,target=/home/vizber/.host-local-bin,type=bind,consistency=cached"
+    "source=${localEnv:HOME}/.local/bin,target=/home/vizber/.host-local-bin,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.orca,target=/home/vizber/.orca,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.junie,target=/home/vizber/.junie,type=bind,consistency=cached",
+
+    "source=${localEnv:HOME}/.claude,target=${localEnv:HOME}/.claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.agents,target=${localEnv:HOME}/.agents,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.grok,target=${localEnv:HOME}/.grok,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.codex,target=${localEnv:HOME}/.codex,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.config/opencode,target=${localEnv:HOME}/.config/opencode,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.opencode,target=${localEnv:HOME}/.opencode,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.cursor,target=${localEnv:HOME}/.cursor,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.local/bin,target=${localEnv:HOME}/.local/bin,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.orca,target=${localEnv:HOME}/.orca,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.junie,target=${localEnv:HOME}/.junie,type=bind,consistency=cached"
   ],
   "remoteEnv": {
-    "PATH": "/home/vizber/.host-local-bin:/home/vizber/.grok/bin:/home/vizber/.opencode/bin:${containerEnv:PATH}",
+    "PATH": "/home/vizber/.host-local-bin:/home/vizber/.grok/bin:/home/vizber/.opencode/bin:${localEnv:HOME}/.local/bin:${localEnv:HOME}/.grok/bin:${localEnv:HOME}/.opencode/bin:${containerEnv:PATH}",
     "HOME": "/home/vizber",
     "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
     "OPENAI_API_KEY": "${localEnv:OPENAI_API_KEY}",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,9 +25,11 @@
     "PATH": "/home/vscode/.host-local-bin:/home/vscode/.grok/bin:/home/vscode/.opencode/bin:${containerEnv:PATH}",
     "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
     "OPENAI_API_KEY": "${localEnv:OPENAI_API_KEY}",
-    "XAI_API_KEY": "${localEnv:XAI_API_KEY}"
+    "XAI_API_KEY": "${localEnv:XAI_API_KEY}",
+    "npm_config_store_dir": "/home/vscode/.local/share/pnpm/store",
+    "npm_config_confirm_modules_purge": "false"
   },
-  "postCreateCommand": "corepack enable && corepack prepare pnpm@latest --activate && task init",
+  "postCreateCommand": "corepack enable && corepack prepare pnpm@10.33.2 --activate && task init",
   "forwardPorts": [5173, 4321],
   "portsAttributes": {
     "5173": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,29 +4,24 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "features": {
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "22",
-      "installYarnUsingApt": false
-    }
-  },
   "initializeCommand": "mkdir -p \"${localEnv:HOME}/.claude\" \"${localEnv:HOME}/.agents\" \"${localEnv:HOME}/.grok\" \"${localEnv:HOME}/.codex\" \"${localEnv:HOME}/.config/opencode\" \"${localEnv:HOME}/.opencode\" \"${localEnv:HOME}/.local/bin\" \"${localEnv:HOME}/.cursor\"",
   "mounts": [
-    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.agents,target=/home/vscode/.agents,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.grok,target=/home/vscode/.grok,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.config/opencode,target=/home/vscode/.config/opencode,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.opencode,target=/home/vscode/.opencode,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.cursor,target=/home/vscode/.cursor,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.local/bin,target=/home/vscode/.host-local-bin,type=bind,consistency=cached"
+    "source=${localEnv:HOME}/.claude,target=/home/vizber/.claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.agents,target=/home/vizber/.agents,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.grok,target=/home/vizber/.grok,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.codex,target=/home/vizber/.codex,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.config/opencode,target=/home/vizber/.config/opencode,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.opencode,target=/home/vizber/.opencode,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.cursor,target=/home/vizber/.cursor,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.local/bin,target=/home/vizber/.host-local-bin,type=bind,consistency=cached"
   ],
   "remoteEnv": {
-    "PATH": "/home/vscode/.host-local-bin:/home/vscode/.grok/bin:/home/vscode/.opencode/bin:${containerEnv:PATH}",
+    "PATH": "/home/vizber/.host-local-bin:/home/vizber/.grok/bin:/home/vizber/.opencode/bin:${containerEnv:PATH}",
+    "HOME": "/home/vizber",
     "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
     "OPENAI_API_KEY": "${localEnv:OPENAI_API_KEY}",
     "XAI_API_KEY": "${localEnv:XAI_API_KEY}",
-    "npm_config_store_dir": "/home/vscode/.local/share/pnpm/store",
+    "npm_config_store_dir": "/home/vizber/.local/share/pnpm/store",
     "npm_config_confirm_modules_purge": "false"
   },
   "postCreateCommand": "corepack enable && corepack prepare pnpm@10.33.2 --activate && task init",
@@ -56,5 +51,6 @@
       }
     }
   },
-  "remoteUser": "vscode"
+  "remoteUser": "vizber",
+  "containerUser": "vizber"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,6 +35,7 @@
   "remoteEnv": {
     "PATH": "/home/vizber/.host-local-bin:/home/vizber/.grok/bin:/home/vizber/.opencode/bin:${localEnv:HOME}/.local/bin:${localEnv:HOME}/.grok/bin:${localEnv:HOME}/.opencode/bin:${containerEnv:PATH}",
     "HOME": "/home/vizber",
+    "GOTOOLCHAIN": "auto",
     "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
     "OPENAI_API_KEY": "${localEnv:OPENAI_API_KEY}",
     "XAI_API_KEY": "${localEnv:XAI_API_KEY}",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
   "workspaceFolder": "${localWorkspaceFolder}",
-  "initializeCommand": "mkdir -p \"${localEnv:HOME}/.claude\" \"${localEnv:HOME}/.agents\" \"${localEnv:HOME}/.grok\" \"${localEnv:HOME}/.codex\" \"${localEnv:HOME}/.config/opencode\" \"${localEnv:HOME}/.opencode\" \"${localEnv:HOME}/.local/bin\" \"${localEnv:HOME}/.cursor\" \"${localEnv:HOME}/.orca\" \"${localEnv:HOME}/.junie\"",
+  "initializeCommand": "mkdir -p \"${localEnv:HOME}/.claude\" \"${localEnv:HOME}/.agents\" \"${localEnv:HOME}/.grok\" \"${localEnv:HOME}/.codex\" \"${localEnv:HOME}/.config/opencode\" \"${localEnv:HOME}/.opencode\" \"${localEnv:HOME}/.local/bin\" \"${localEnv:HOME}/.local/share\" \"${localEnv:HOME}/.local/opt\" \"${localEnv:HOME}/.cursor\" \"${localEnv:HOME}/.orca\" \"${localEnv:HOME}/.junie\"",
   "mounts": [
     "source=${localEnv:HOME}/.claude,target=/home/vizber/.claude,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.agents,target=/home/vizber/.agents,type=bind,consistency=cached",
@@ -27,6 +27,8 @@
     "source=${localEnv:HOME}/.opencode,target=${localEnv:HOME}/.opencode,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.cursor,target=${localEnv:HOME}/.cursor,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.local/bin,target=${localEnv:HOME}/.local/bin,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.local/share,target=${localEnv:HOME}/.local/share,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.local/opt,target=${localEnv:HOME}/.local/opt,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.orca,target=${localEnv:HOME}/.orca,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.junie,target=${localEnv:HOME}/.junie,type=bind,consistency=cached"
   ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,58 @@
+{
+  "name": "vizber",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22",
+      "installYarnUsingApt": false
+    }
+  },
+  "initializeCommand": "mkdir -p \"${localEnv:HOME}/.claude\" \"${localEnv:HOME}/.agents\" \"${localEnv:HOME}/.grok\" \"${localEnv:HOME}/.codex\" \"${localEnv:HOME}/.config/opencode\" \"${localEnv:HOME}/.opencode\" \"${localEnv:HOME}/.local/bin\" \"${localEnv:HOME}/.cursor\"",
+  "mounts": [
+    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.agents,target=/home/vscode/.agents,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.grok,target=/home/vscode/.grok,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.config/opencode,target=/home/vscode/.config/opencode,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.opencode,target=/home/vscode/.opencode,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.cursor,target=/home/vscode/.cursor,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.local/bin,target=/home/vscode/.host-local-bin,type=bind,consistency=cached"
+  ],
+  "remoteEnv": {
+    "PATH": "/home/vscode/.host-local-bin:/home/vscode/.grok/bin:/home/vscode/.opencode/bin:${containerEnv:PATH}",
+    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
+    "OPENAI_API_KEY": "${localEnv:OPENAI_API_KEY}",
+    "XAI_API_KEY": "${localEnv:XAI_API_KEY}"
+  },
+  "postCreateCommand": "corepack enable && corepack prepare pnpm@latest --activate && task init",
+  "forwardPorts": [5173, 4321],
+  "portsAttributes": {
+    "5173": {
+      "label": "UI (task dev:ui)",
+      "onAutoForward": "notify"
+    },
+    "4321": {
+      "label": "Docs (task dev:docs)",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "Vue.volar",
+        "bradlc.vscode-tailwindcss",
+        "esbenp.prettier-vscode",
+        "task.vscode-task"
+      ],
+      "settings": {
+        "go.useLanguageServer": true,
+        "go.toolsManagement.checkForUpdates": "local"
+      }
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,10 @@ After that, use the same commands as a local setup (`task test`, `task build`,
 
 #### Host agent configs (Claude / Grok / Codex / OpenCode / …)
 
-The Dev Container is named **vizber** and the shell prompt says **vizber**, but the
-Linux login stays **`vscode`** (UID 1000). That is required by the Microsoft Go base
-image and Dev Container / Zed attach (`docker exec -u …`). Renaming the OS user
-breaks the remote editor — do not change `remoteUser`.
+The container user is **`vizber`** (UID 1000) — the Microsoft image’s default
+`vscode` login is renamed in the Dockerfile so nothing in the shell identity
+uses that name. (`customizations.vscode` in `devcontainer.json` is only the
+Dev Containers schema key for editor extensions; it is not the OS user.)
 
 To reuse **your** machine’s agent setup, the container bind-mounts common host
 directories from `$HOME` (each contributor gets their own mounts — nothing
@@ -53,21 +53,22 @@ personal is committed):
 
 | Host path | Inside container |
 |-----------|------------------|
-| `~/.claude` | `/home/vscode/.claude` |
-| `~/.agents` | `/home/vscode/.agents` |
-| `~/.grok` | `/home/vscode/.grok` |
-| `~/.codex` | `/home/vscode/.codex` |
-| `~/.config/opencode`, `~/.opencode` | same under `/home/vscode/…` |
-| `~/.local/bin` | `/home/vscode/.host-local-bin` (not `~/.local/bin` — that breaks Zed) |
-| `~/.cursor` | `/home/vscode/.cursor` |
+| `~/.claude` | `/home/vizber/.claude` |
+| `~/.agents` | `/home/vizber/.agents` |
+| `~/.grok` | `/home/vizber/.grok` |
+| `~/.codex` | `/home/vizber/.codex` |
+| `~/.config/opencode`, `~/.opencode` | same under `/home/vizber/…` |
+| `~/.local/bin` | `/home/vizber/.host-local-bin` (not `~/.local/bin` — that breaks Zed) |
+| `~/.cursor` | `/home/vizber/.cursor` |
 
 Host CLIs are on `PATH` via `~/.host-local-bin`, `~/.grok/bin`, and
 `~/.opencode/bin`. Optional API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
 `XAI_API_KEY`) are forwarded from the host when set.
 
-After changing mounts, **rebuild** the Dev Container. Host binaries that depend on
-host-only libraries may still fail inside the container; install the CLI in the
-container or run the agent on the host against the mounted workspace.
+After changing mounts or the user rename, **fully rebuild** the Dev Container
+(delete any old container first). Host binaries that depend on host-only libraries
+may still fail inside the container; install the CLI in the container or run the
+agent on the host against the mounted workspace.
 
 If `pnpm` fails with `attempt to write a readonly database`, a root-owned
 `.pnpm-store/` is left in the repo (often from an old Docker-as-root run). On the
@@ -80,7 +81,7 @@ docker run --rm -v "$PWD":/w -w /w alpine rm -rf .pnpm-store
 ```
 
 The Dev Container pins **pnpm 10.x** and forces the store under
-`~/.local/share/pnpm/store` so installs do not use a repo-local store.
+`/home/vizber/.local/share/pnpm/store` so installs do not use a repo-local store.
 
 ## Setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,10 @@ After that, use the same commands as a local setup (`task test`, `task build`,
 
 #### Host agent configs (Claude / Grok / Codex / OpenCode / …)
 
-The Dev Container is named **vizber**; the Linux user stays **`vscode`** (UID 1000)
-because that is what the Microsoft Go base image and Dev Container features expect.
-Renaming the OS user breaks `docker exec` / Zed attach.
+The Dev Container is named **vizber** and the shell prompt says **vizber**, but the
+Linux login stays **`vscode`** (UID 1000). That is required by the Microsoft Go base
+image and Dev Container / Zed attach (`docker exec -u …`). Renaming the OS user
+breaks the remote editor — do not change `remoteUser`.
 
 To reuse **your** machine’s agent setup, the container bind-mounts common host
 directories from `$HOME` (each contributor gets their own mounts — nothing
@@ -64,10 +65,22 @@ Host CLIs are on `PATH` via `~/.host-local-bin`, `~/.grok/bin`, and
 `~/.opencode/bin`. Optional API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
 `XAI_API_KEY`) are forwarded from the host when set.
 
-After changing mounts, **rebuild** the Dev Container (remove any old container that
-was created with `remoteUser: vizber`). Host binaries that depend on host-only
-libraries may still fail inside the container; install the CLI in the container or
-run the agent on the host against the mounted workspace.
+After changing mounts, **rebuild** the Dev Container. Host binaries that depend on
+host-only libraries may still fail inside the container; install the CLI in the
+container or run the agent on the host against the mounted workspace.
+
+If `pnpm` fails with `attempt to write a readonly database`, a root-owned
+`.pnpm-store/` is left in the repo (often from an old Docker-as-root run). On the
+**host**:
+
+```bash
+sudo rm -rf .pnpm-store
+# or without sudo:
+docker run --rm -v "$PWD":/w -w /w alpine rm -rf .pnpm-store
+```
+
+The Dev Container pins **pnpm 10.x** and forces the store under
+`~/.local/share/pnpm/store` so installs do not use a repo-local store.
 
 ## Setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,13 +13,61 @@ by our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Prerequisites
 
-- **Go 1.24+**
+- **Go 1.26+**
 - **[Task](https://taskfile.dev/)** — the task runner used for all workflows
 - **pnpm** — for the Vue UI and docs site
 
 ```bash
 go install github.com/go-task/task/v3/cmd/task@latest
 ```
+
+### Dev Container (no local Go/Task/pnpm)
+
+If you use [VS Code](https://code.visualstudio.com/), [Cursor](https://cursor.com/),
+or [GitHub Codespaces](https://github.com/features/codespaces) with Docker, you
+can skip installing Go, Task, and pnpm on the host:
+
+1. Install the [Dev Containers](https://containers.dev/) extension (VS Code/Cursor)
+   and a Docker-compatible runtime.
+2. Open the repo and choose **Reopen in Container** (or create a Codespace).
+3. On first create, the container installs the toolchain and runs `task init`
+   automatically (deps + UI embed).
+
+After that, use the same commands as a local setup (`task test`, `task build`,
+`task dev:ui`, etc.). Ports **5173** (UI) and **4321** (docs) are forwarded.
+
+> **Note:** `task act:*` (local GitHub Actions via [act](https://github.com/nektos/act))
+> still needs Docker access from inside the container; that is not enabled by
+> default in this Dev Container.
+
+#### Host agent configs (Claude / Grok / Codex / OpenCode / …)
+
+The Dev Container is named **vizber**; the Linux user stays **`vscode`** (UID 1000)
+because that is what the Microsoft Go base image and Dev Container features expect.
+Renaming the OS user breaks `docker exec` / Zed attach.
+
+To reuse **your** machine’s agent setup, the container bind-mounts common host
+directories from `$HOME` (each contributor gets their own mounts — nothing
+personal is committed):
+
+| Host path | Inside container |
+|-----------|------------------|
+| `~/.claude` | `/home/vscode/.claude` |
+| `~/.agents` | `/home/vscode/.agents` |
+| `~/.grok` | `/home/vscode/.grok` |
+| `~/.codex` | `/home/vscode/.codex` |
+| `~/.config/opencode`, `~/.opencode` | same under `/home/vscode/…` |
+| `~/.local/bin` | `/home/vscode/.host-local-bin` (not `~/.local/bin` — that breaks Zed) |
+| `~/.cursor` | `/home/vscode/.cursor` |
+
+Host CLIs are on `PATH` via `~/.host-local-bin`, `~/.grok/bin`, and
+`~/.opencode/bin`. Optional API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+`XAI_API_KEY`) are forwarded from the host when set.
+
+After changing mounts, **rebuild** the Dev Container (remove any old container that
+was created with `remoteUser: vizber`). Host binaries that depend on host-only
+libraries may still fail inside the container; install the CLI in the container or
+run the agent on the host against the mounted workspace.
 
 ## Setup
 
@@ -29,7 +77,7 @@ task init    # install deps (Go, UI, docs) and generate the UI embed
 
 `task init` runs `task build:ui` so `pkg/template/vizb-ui.gen.go` exists for
 `go test` / `go build`. That file is **gitignored** (generated locally and in
-CI on Node 22). Never commit it.
+CI on Node 22). Never commit it. (In the Dev Container this runs once on first create.)
 
 ## Build & test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,23 +47,26 @@ The container user is **`vizber`** (UID 1000) — the Microsoft image’s defaul
 uses that name. (`customizations.vscode` in `devcontainer.json` is only the
 Dev Containers schema key for editor extensions; it is not the OS user.)
 
-To reuse **your** machine’s agent setup, the container bind-mounts common host
-directories from `$HOME` (each contributor gets their own mounts — nothing
-personal is committed):
+To reuse **your** machine’s agent setup (auth, skills, MCP, history), the
+container bind-mounts common host directories from `$HOME` **twice**:
+
+1. Under `/home/vizber/…` — what agents see via `$HOME`
+2. Under the same absolute host path (e.g. `/home/<you>/…`) — so hardcoded
+   hooks/settings and **path-keyed** MCP/project state still resolve
+
+The repo is also mounted at the **same absolute host path**
+(`workspaceFolder` = host path, not `/workspaces/vizb`). Agents key skills/MCP
+by that path; using `/workspaces/…` would look like a different project.
 
 | Host path | Inside container |
 |-----------|------------------|
-| `~/.claude` | `/home/vizber/.claude` |
-| `~/.agents` | `/home/vizber/.agents` |
-| `~/.grok` | `/home/vizber/.grok` |
-| `~/.codex` | `/home/vizber/.codex` |
-| `~/.config/opencode`, `~/.opencode` | same under `/home/vizber/…` |
-| `~/.local/bin` | `/home/vizber/.host-local-bin` (not `~/.local/bin` — that breaks Zed) |
-| `~/.cursor` | `/home/vizber/.cursor` |
+| repo checkout | **same absolute path** as on the host |
+| `~/.claude`, `~/.agents`, `~/.grok`, `~/.codex`, … | `/home/vizber/…` **and** `$HOME/…` (host absolute) |
+| `~/.orca`, `~/.junie` | same dual mount (hooks / extra skills) |
+| `~/.local/bin` | `/home/vizber/.host-local-bin` **and** host `~/.local/bin` |
 
-Host CLIs are on `PATH` via `~/.host-local-bin`, `~/.grok/bin`, and
-`~/.opencode/bin`. Optional API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
-`XAI_API_KEY`) are forwarded from the host when set.
+Host CLIs are on `PATH`. Optional API keys (`ANTHROPIC_API_KEY`,
+`OPENAI_API_KEY`, `XAI_API_KEY`) are forwarded from the host when set.
 
 After changing mounts or the user rename, **fully rebuild** the Dev Container
 (delete any old container first). Host binaries that depend on host-only libraries

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ by that path; using `/workspaces/…` would look like a different project.
 | `~/.claude`, `~/.agents`, `~/.grok`, `~/.codex`, … | `/home/vizber/…` **and** `$HOME/…` (host absolute) |
 | `~/.orca`, `~/.junie` | same dual mount (hooks / extra skills) |
 | `~/.local/bin` | `/home/vizber/.host-local-bin` **and** host `~/.local/bin` |
+| `~/.local/share`, `~/.local/opt` | host absolute paths only (resolves symlinks like `claude` → `…/share/claude/versions/…`) |
 
 Host CLIs are on `PATH`. Optional API keys (`ANTHROPIC_API_KEY`,
 `OPENAI_API_KEY`, `XAI_API_KEY`) are forwarded from the host when set.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     <a href="https://github.com/goptics/vizb/actions/workflows/ui.yml"><img src="https://github.com/goptics/vizb/actions/workflows/ui.yml/badge.svg" alt="UI" /></a>
     <a href="https://codecov.io/gh/goptics/vizb"><img src="https://codecov.io/gh/goptics/vizb/branch/main/graph/badge.svg" alt="Codecov" /></a>
     <a href="https://github.com/goptics/vizb/releases"><img src="https://img.shields.io/github/downloads/goptics/vizb/total?color=green&label=downloads" alt="Downloads" /></a>
-    <a href="https://golang.org/doc/devel/release.html"><img src="https://img.shields.io/badge/Go-1.24+-00ADD8?style=for&logo=go" alt="Go Version" /></a>
+    <a href="https://golang.org/doc/devel/release.html"><img src="https://img.shields.io/badge/Go-1.26+-00ADD8?style=for&logo=go" alt="Go Version" /></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg?style=for" alt="License" /></a>
   </p>
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,14 +18,14 @@ tasks:
       - go run github.com/evilmartians/lefthook@latest install
 
   dev:docs:
-    desc: Run docs dev server on localhost:4321
+    desc: Run docs dev server on localhost:4321 (bind 0.0.0.0 for Dev Containers)
     cmds:
-      - cd docs; pnpm dev --open; cd -
+      - cd docs; pnpm dev --host 0.0.0.0; cd -
 
   dev:ui:
-    desc: Run development UI server
+    desc: Run development UI server (bind 0.0.0.0 for Dev Containers)
     cmds:
-      - cd ui; pnpm dev --open
+      - cd ui; pnpm dev --host 0.0.0.0
 
   build:docs:
     desc: Build docs for production

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -74,7 +74,7 @@ Pipe benchmark output straight in. The framework is detected from the content. N
   ```
 
   <Aside type="note">
-    To build from source, **Go 1.24+** is required. Pre-built binaries from the [installation page](/installation) need no Go runtime.
+    To build from source, **Go 1.26+** is required. Pre-built binaries from the [installation page](/installation) need no Go runtime.
   </Aside>
 
   </TabItem>

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -21,7 +21,7 @@ go install github.com/goptics/vizb@latest
 ```
 
 <Aside type="note">
-  Building from source requires **Go 1.24+**. Install Go from the [official site](https://go.dev/dl) or via [webi](https://webinstall.dev/go/). Pre-built binaries and the install script need no Go runtime.
+  Building from source requires **Go 1.26+**. Install Go from the [official site](https://go.dev/dl) or via [webi](https://webinstall.dev/go/). Pre-built binaries and the install script need no Go runtime.
 </Aside>
 
 ## Download Binary

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/goptics/vizb
 
-go 1.24.0
-
-toolchain go1.24.3
+go 1.26.5
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/scripts/act-examples.sh
+++ b/scripts/act-examples.sh
@@ -22,7 +22,7 @@ Options:
   --reuse        Reuse act containers between runs (faster reruns)
   -h, --help     Show this help
 
-Prerequisites: act (>= 0.2.50), Docker, Go 1.24+
+Prerequisites: act (>= 0.2.50), Docker, Go 1.26+
 EOF
 }
 


### PR DESCRIPTION
## Summary

- Add a **Dev Container** (`.devcontainer/`) so contributors can develop without installing Go, Task, or pnpm on the host.
  - Go 1.26 base image, Node 22 feature, Task + golangci-lint in the image
  - `postCreateCommand` runs `task init` once on first create (deps + UI embed)
  - Named **vizber**; Linux user stays **`vscode`** (required by the Microsoft base image / Zed attach)
  - Optional host agent mounts (`~/.claude`, `~/.agents`, `~/.grok`, `~/.codex`, OpenCode, Cursor) via `${localEnv:HOME}` so each person brings their own setup
  - Host CLIs mount to `~/.host-local-bin` (not `~/.local/bin`) to avoid breaking Zed’s remote server
  - Empty host agent dirs are created if missing so launch still works without any agents installed
- Bump **Go to 1.26.5** in `go.mod` and update docs/badges/prereqs accordingly.

## Test plan

- [ ] Rebuild Dev Container in VS Code / Cursor / Zed
- [ ] Confirm `whoami` is `vscode` and `task`, `go`, `node`, `pnpm` resolve
- [ ] Confirm first create runs `task init` and `pkg/template/vizb-ui.gen.go` exists
- [ ] `task test` / `task build:cli` inside the container
- [ ] Without host agent dirs: container still starts (empty mounts)
- [ ] With host agents: `ls ~/.claude ~/.grok` and CLIs via `~/.host-local-bin` work
- [ ] CI uses `go-version-file: go.mod` and picks up Go 1.26.5