### PR TITLE
ci(action): verify generated outputs

### DIFF
--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -57,11 +57,21 @@ jobs:
         run: go build -o ./bin/vizb .
 
       - name: Run action (stateless)
+        id: vizb
         uses: ./
         with:
           file: examples/go/hash.txt
           output-html: index.html
+          output-json: results/stateless.json
           vizb-binary: ./bin/vizb
+
+      - name: Verify action outputs
+        env:
+          EXPECTED_JSON_KIND: object
+          EXPECTED_NAMES: '["Comparisons"]'
+          HTML_FILE: ${{ steps.vizb.outputs.output-file-html }}
+          JSON_FILE: ${{ steps.vizb.outputs.output-file-json }}
+        run: node scripts/verify-action-output.mjs
 
   stateful:
     needs: embed-ui
@@ -100,6 +110,7 @@ jobs:
           vizb-binary: ./bin/vizb
 
       - name: Run action (stateful)
+        id: vizb
         uses: ./
         with:
           name: HTTP Frameworks Comparisons
@@ -110,3 +121,11 @@ jobs:
           output-html: index.html
           output-json: results/bench.json
           vizb-binary: ./bin/vizb
+
+      - name: Verify action outputs
+        env:
+          EXPECTED_JSON_KIND: array
+          EXPECTED_NAMES: '["Hash", "HTTP Frameworks Comparisons"]'
+          HTML_FILE: ${{ steps.vizb.outputs.output-file-html }}
+          JSON_FILE: ${{ steps.vizb.outputs.output-file-json }}
+        run: node scripts/verify-action-output.mjs

--- a/scripts/verify-action-output.mjs
+++ b/scripts/verify-action-output.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const { EXPECTED_JSON_KIND, EXPECTED_NAMES, HTML_FILE, JSON_FILE } = process.env
+
+assert.ok(HTML_FILE, 'HTML_FILE is required')
+assert.ok(JSON_FILE, 'JSON_FILE is required')
+assert.ok(EXPECTED_NAMES, 'EXPECTED_NAMES is required')
+assert.ok(
+  EXPECTED_JSON_KIND === 'object' || EXPECTED_JSON_KIND === 'array',
+  'EXPECTED_JSON_KIND must be "object" or "array"',
+)
+
+const expectedNames = JSON.parse(EXPECTED_NAMES)
+assert.ok(Array.isArray(expectedNames), 'EXPECTED_NAMES must be a JSON array')
+
+const json = JSON.parse(readFileSync(JSON_FILE, 'utf8'))
+if (EXPECTED_JSON_KIND === 'array') {
+  assert.ok(Array.isArray(json), `${JSON_FILE} must contain a dataset array`)
+} else {
+  assert.ok(!Array.isArray(json), `${JSON_FILE} must contain a single dataset`)
+}
+
+const datasets = Array.isArray(json) ? json : [json]
+assert.deepEqual(
+  datasets.map(({ name }) => name).sort(),
+  [...expectedNames].sort(),
+  `${JSON_FILE} contains unexpected datasets`,
+)
+
+for (const dataset of datasets) {
+  assert.ok(Array.isArray(dataset.data), `${dataset.name} must contain data`)
+  assert.ok(dataset.data.length > 0, `${dataset.name} data must not be empty`)
+  assert.ok(Array.isArray(dataset.settings), `${dataset.name} must contain settings`)
+  assert.ok(dataset.settings.length > 0, `${dataset.name} settings must not be empty`)
+}
+
+const html = readFileSync(HTML_FILE, 'utf8')
+assert.match(html, /^<!DOCTYPE html>/, `${HTML_FILE} must be an HTML document`)
+assert.ok(html.includes('window.VIZB_DATA = '), `${HTML_FILE} must embed vizb data`)
+
+for (const name of expectedNames) {
+  assert.ok(html.includes(JSON.stringify(name)), `${HTML_FILE} must contain ${name}`)
+}
+
+console.log(`Verified ${JSON_FILE} and ${HTML_FILE}`)


### PR DESCRIPTION
## Summary

- validate stateless JSON and HTML action outputs
- validate stateful merged JSON and HTML action outputs
- share the verifier across the OS matrix and local `act` runs

## Testing

- `task act:test:stateless`
- `task act:test:stateful`
- `node --check scripts/verify-action-output.mjs`
- `git diff --check`

Closes #224
