### PR TITLE
chore: standardize agent guidance, tests, and task commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,6 @@ Desktop.ini
 
 # ─── Project ──────────────────────────────────────────────────────────
 # Agent instruction files
-CLAUDE.md
-AGENTS.md
 superpowers
 .superpowers
 openspec

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# Vizb Agent Guide
+
+## Project
+
+Vizb is a Go CLI that converts CSV, JSON arrays, structured data, and Go, Rust,
+or JavaScript benchmark output into self-contained interactive HTML charts or
+JSON datasets. It embeds a Vue 3 UI and also ships as a GitHub composite action.
+
+## Commands
+
+Use [Task](https://taskfile.dev/) from the repository root.
+
+```bash
+task init        # install Go, UI, and docs dependencies; generate UI embed
+task build       # build docs, embedded UI, and CLI
+task build:ui    # build UI and write pkg/template/vizb-ui.gen.go
+task build:cli   # build ./bin/vizb
+task dev:ui      # run Vue dev server
+task dev:docs    # run docs dev server
+task test        # run CLI and UI tests
+task test:cli    # run Go CLI tests without cache
+task test:ui     # run Vitest UI tests
+task test:cover  # run cross-package Go coverage
+task lint        # run CLI and UI linters
+task lint:cli    # run Go linter
+task lint:ui     # run Vue/TypeScript type checking
+task format      # format CLI and UI files
+task format:cli  # format Go files
+task format:ui   # format UI files
+task format:check     # check all formatting without writing
+task format:check:cli # check Go formatting
+task format:check:ui  # check UI formatting
+```
+
+After a fresh clone or any `ui/` change, run `task build:ui` before Go tests or
+CLI builds. Generated `pkg/template/vizb-ui.gen.go` is gitignored: never edit or
+commit it.
+
+## Architecture
+
+```text
+main.go -> cmd/                 Cobra root, merge, ui, and chart commands
+           cmd/charts/<type>/   chart registration and Cobra metadata
+           cmd/cli/             FlagBag, command builder, linear pipeline
+           internal/charts/     chart configs, flags, rules, materialisation
+           pkg/parser/          format detection and parsers
+           pkg/template/        Vue embed and HTML generation
+           shared/              datasets, merge logic, common utilities
+           ui/                  Vue 3 + TypeScript application
+```
+
+Root flow: read file or stdin -> detect/parse format -> group data -> build
+`shared.Dataset` -> emit JSON or self-contained HTML.
+
+## Engineering Rules
+
+- Keep changes scoped. Read nearby implementation and tests before editing.
+- Bind CLI flags through `cli.FlagBag`; define chart flags in
+  `internal/charts` and compose them in `cmd/charts/<type>`.
+- New chart types must register their factory, flags, and Cobra metadata, then
+  be blank-imported by `cmd/root.go`.
+- Manage temporary files through `shared.TempFiles` and preserve cleanup on all
+  exit paths.
+- Preserve output compatibility unless the task explicitly changes it. `.json`
+  output is JSON; other extensions produce HTML. Stdin format detection uses
+  content, not extension.
+- Do not hand-edit generated files or unrelated user changes.
+
+## Test Design
+
+- New or materially expanded Go tests use `testify/suite`. Name suites
+  `<Subject>Suite`, write `TestX` methods, and add one `suite.Run` entry point
+  per suite.
+- Put shared fixtures and setup on the suite. Use `s.Run` for subcases;
+  table-driven cases may live inside suite methods.
+- UI tests group related behavior with Vitest `describe`, use `it` for cases,
+  and keep hooks at the narrowest useful scope.
+- Keep tests deterministic and beside tested code. Parser additions include a
+  small representative fixture.
+- Do not migrate unrelated existing tests solely to satisfy these conventions.
+- After every change, assess affected-feature coverage, add or update tests when
+  needed, run focused checks, and call out remaining coverage gaps.
+
+Run the narrowest relevant tests while developing. Before handoff, run checks
+matching the touched areas:
+
+```bash
+go test -count=1 ./path/to/package   # focused Go change
+task test:cli                        # all CLI tests
+task test:ui                         # all UI tests
+task lint:cli                        # Go linting
+task lint:ui                         # UI type checking
+task format:check                    # all formatting checks
+task test && task lint               # repository-wide test and lint validation
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,15 +103,24 @@ CI on Node 22). Never commit it. (In the Dev Container this runs once on first c
 task build       # build UI + binary
 task build:ui    # build the Vue UI only (writes pkg/template/vizb-ui.gen.go)
 task build:cli   # build the Go binary to ./bin/vizb
-task test        # go test -count=1 ./...
-task lint        # golangci-lint run
-task format      # gofmt + pnpm format
+task test        # run CLI and UI tests
+task test:cli    # run Go tests only
+task test:ui     # run Vitest tests only
+task lint        # run CLI and UI linters
+task lint:cli    # run golangci-lint only
+task lint:ui     # run Vue/TypeScript type checking only
+task format      # format CLI and UI files
+task format:cli  # format Go files only
+task format:ui   # format UI files only
+task format:check     # check all formatting without writing
+task format:check:cli # check Go formatting only
+task format:check:ui  # check UI formatting only
 ```
 
 Run a single test:
 
 ```bash
-go test -run TestName -v ./path/to/package
+go test -run 'TestSubjectSuite/TestCase' -v ./path/to/package
 ```
 
 ### Local example workflows

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,186 +1,103 @@
 # Contributing to Vizb
 
-Thanks for your interest in improving Vizb! This guide covers how to set up the
-project, make a change, and get it merged. By participating you agree to abide
-by our [Code of Conduct](CODE_OF_CONDUCT.md).
+Vizb turns benchmark and tabular data into interactive HTML charts or JSON
+datasets. Use this guide for local setup and pull requests. See the
+[Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
 
-## Ways to contribute
+## Ways to help
 
-- **Report a bug** — open an issue with input, command, and what you expected.
-- **Request a feature** — describe the use case, not just the solution.
-- **Add a parser** — bring a new benchmark framework or data format (see below).
-- **Improve the docs** — the site lives in `docs/`.
+- Report bugs with the input, command, expected result, and actual result.
+- Request features with the use case and desired outcome.
+- Add parsers for benchmark frameworks or data formats.
+- Improve documentation under `docs/`.
 
-## Prerequisites
+## Requirements
 
-- **Go 1.26+**
-- **[Task](https://taskfile.dev/)** — the task runner used for all workflows
-- **pnpm** — for the Vue UI and docs site
+- Go 1.26+
+- [Task](https://taskfile.dev/)
+- pnpm
+
+Install Task if needed:
 
 ```bash
 go install github.com/go-task/task/v3/cmd/task@latest
 ```
 
-### Dev Container (no local Go/Task/pnpm)
+The Dev Container is optional. Reopen the repository in the container; it
+installs the toolchain and runs `task init`. Ports 5173 (UI) and 4321 (docs)
+are forwarded.
 
-If you use [VS Code](https://code.visualstudio.com/), [Cursor](https://cursor.com/),
-or [GitHub Codespaces](https://github.com/features/codespaces) with Docker, you
-can skip installing Go, Task, and pnpm on the host:
-
-1. Install the [Dev Containers](https://containers.dev/) extension (VS Code/Cursor)
-   and a Docker-compatible runtime.
-2. Open the repo and choose **Reopen in Container** (or create a Codespace).
-3. On first create, the container installs the toolchain and runs `task init`
-   automatically (deps + UI embed).
-
-After that, use the same commands as a local setup (`task test`, `task build`,
-`task dev:ui`, etc.). Ports **5173** (UI) and **4321** (docs) are forwarded.
-
-> **Note:** `task act:*` (local GitHub Actions via [act](https://github.com/nektos/act))
-> still needs Docker access from inside the container; that is not enabled by
-> default in this Dev Container.
-
-#### Host agent configs (Claude / Grok / Codex / OpenCode / …)
-
-The container user is **`vizber`** (UID 1000) — the Microsoft image’s default
-`vscode` login is renamed in the Dockerfile so nothing in the shell identity
-uses that name. (`customizations.vscode` in `devcontainer.json` is only the
-Dev Containers schema key for editor extensions; it is not the OS user.)
-
-To reuse **your** machine’s agent setup (auth, skills, MCP, history), the
-container bind-mounts common host directories from `$HOME` **twice**:
-
-1. Under `/home/vizber/…` — what agents see via `$HOME`
-2. Under the same absolute host path (e.g. `/home/<you>/…`) — so hardcoded
-   hooks/settings and **path-keyed** MCP/project state still resolve
-
-The repo is also mounted at the **same absolute host path**
-(`workspaceFolder` = host path, not `/workspaces/vizb`). Agents key skills/MCP
-by that path; using `/workspaces/…` would look like a different project.
-
-| Host path | Inside container |
-|-----------|------------------|
-| repo checkout | **same absolute path** as on the host |
-| `~/.claude`, `~/.agents`, `~/.grok`, `~/.codex`, … | `/home/vizber/…` **and** `$HOME/…` (host absolute) |
-| `~/.orca`, `~/.junie` | same dual mount (hooks / extra skills) |
-| `~/.local/bin` | `/home/vizber/.host-local-bin` **and** host `~/.local/bin` |
-| `~/.local/share`, `~/.local/opt` | host absolute paths only (resolves symlinks like `claude` → `…/share/claude/versions/…`) |
-
-Host CLIs are on `PATH`. Optional API keys (`ANTHROPIC_API_KEY`,
-`OPENAI_API_KEY`, `XAI_API_KEY`) are forwarded from the host when set.
-
-After changing mounts or the user rename, **fully rebuild** the Dev Container
-(delete any old container first). Host binaries that depend on host-only libraries
-may still fail inside the container; install the CLI in the container or run the
-agent on the host against the mounted workspace.
-
-If `pnpm` fails with `attempt to write a readonly database`, a root-owned
-`.pnpm-store/` is left in the repo (often from an old Docker-as-root run). On the
-**host**:
+## Setup and commands
 
 ```bash
-sudo rm -rf .pnpm-store
-# or without sudo:
-docker run --rm -v "$PWD":/w -w /w alpine rm -rf .pnpm-store
+task init            # install dependencies and generate the UI embed
+task build           # build UI, CLI, and docs
+task build:ui        # build UI; writes pkg/template/vizb-ui.gen.go
+task build:cli       # build ./bin/vizb
+task dev:ui          # run the UI dev server
+task dev:docs        # run the docs dev server
+task test            # run CLI and UI tests
+task test:cli        # run Go tests
+task test:ui         # run Vitest tests
+task test:cover      # run Go coverage
+task lint            # run CLI and UI linters
+task lint:cli        # run golangci-lint
+task lint:ui         # run Vue/TypeScript checks
+task format          # format Go and UI files
+task format:check    # check formatting without writing
 ```
 
-The Dev Container pins **pnpm 10.x** and forces the store under
-`/home/vizber/.local/share/pnpm/store` so installs do not use a repo-local store.
-
-## Setup
-
-```bash
-task init    # install deps (Go, UI, docs) and generate the UI embed
-```
-
-`task init` runs `task build:ui` so `pkg/template/vizb-ui.gen.go` exists for
-`go test` / `go build`. That file is **gitignored** (generated locally and in
-CI on Node 22). Never commit it. (In the Dev Container this runs once on first create.)
-
-## Build & test
-
-```bash
-task build       # build UI + binary
-task build:ui    # build the Vue UI only (writes pkg/template/vizb-ui.gen.go)
-task build:cli   # build the Go binary to ./bin/vizb
-task test        # run CLI and UI tests
-task test:cli    # run Go tests only
-task test:ui     # run Vitest tests only
-task lint        # run CLI and UI linters
-task lint:cli    # run golangci-lint only
-task lint:ui     # run Vue/TypeScript type checking only
-task format      # format CLI and UI files
-task format:cli  # format Go files only
-task format:ui   # format UI files only
-task format:check     # check all formatting without writing
-task format:check:cli # check Go formatting only
-task format:check:ui  # check UI formatting only
-```
-
-Run a single test:
+Run one Go test:
 
 ```bash
 go test -run 'TestSubjectSuite/TestCase' -v ./path/to/package
 ```
 
-### Local example workflows
+`pkg/template/vizb-ui.gen.go` is generated and gitignored. Never edit or commit
+it. Run `task build:ui` after changing `ui/` and before Go builds or tests.
 
-You can run the `deploy-examples` CI workflows on your machine with
-[act](https://github.com/nektos/act) and Docker (GitHub Pages deploy is skipped).
-Install act via `task act:install`, then:
+Run deploy-example workflows locally with `task act:install` and Docker:
 
 ```bash
-task act:examples                              # all languages, opens browser preview
-task act:examples -- --only csv,go             # subset of languages
-task act:examples -- --reuse --no-open         # faster reruns, no browser
+task act:examples -- --only csv,go
+task act:examples -- --reuse --no-open
 ```
 
-Output lands under `dist/examples/` with an overview at `dist/examples/index.html`.
-Equivalent script: `./scripts/act-examples.sh` (same options).
+## Layout
 
-> **Important:** `pkg/template/vizb-ui.gen.go` is generated from the Vue app
-> (`EMBED_UI=True pnpm build` / `task build:ui`). Do **not** hand-edit it and
-> do **not** commit it. After any change under `ui/`, run `task build:ui` before
-> Go commands so the embedded UI is current.
-
-## Project layout
-
-```
+```text
 main.go        entry point
-cmd/           Cobra CLI commands (root, merge, ui, chart subcommands)
-pkg/parser/    input parsing — CSV, JSON, and benchmark frameworks
-pkg/template/  embeds the built Vue UI and generates the HTML output
-shared/        cross-package types, merge logic, utilities
-ui/            Vue 3 + TypeScript app (built into a single inline HTML bundle)
-docs/          Astro Starlight documentation site
+cmd/           Cobra commands and chart registration
+pkg/parser/    CSV, JSON, and benchmark parsers
+pkg/template/  embedded UI and HTML generation
+shared/        shared types and utilities
+ui/            Vue 3 + TypeScript app
+docs/          Astro Starlight site
 ```
 
-See [Internals → How It Works](https://vizb.goptics.org/internals/how-it-works/)
-for the full data pipeline.
+See [How It Works](https://vizb.goptics.org/internals/how-it-works/) for the
+full data pipeline.
 
-## Adding a parser
+## Add a parser
 
-Vizb's biggest contribution surface is new input formats. The parser registry
-lives in `pkg/parser/`. The end-to-end steps — choose a key, implement the parse
-function, register it, and add tests — are documented in the
-[Parser Guide → Add a New Parser](https://vizb.goptics.org/guides/parsers/#add-a-new-parser).
-Please include a small sample input file with your tests.
+Parser code lives in `pkg/parser/`. Follow the
+[Parser Guide](https://vizb.goptics.org/guides/parsers/#add-a-new-parser): choose
+an identifier, implement and register the parser, then add tests with a small
+representative input fixture.
 
-## Submitting a change
+## Submit a change
 
-1. Fork the repo and create a branch (`feat/…`, `fix/…`, or `docs/…`).
-2. Make your change with tests where it makes sense.
-3. Run `task test` and `task lint` — both must pass.
-4. Use [Conventional Commit](https://www.conventionalcommits.org/) messages
-   (e.g. `feat(parser): add Python pytest-benchmark support`), matching the
-   existing history.
-5. Open a pull request describing **what** changed and **why**. Link any
-   related issue.
+1. Create a focused branch: `feat/...`, `fix/...`, `refactor/...`, or `docs/...`.
+2. Add or update tests for affected behavior.
+3. Check affected-feature coverage; add tests for gaps or describe remaining gaps.
+4. Run `task test`, `task lint`, and `task format:check`.
+5. Use [Conventional Commits](https://www.conventionalcommits.org/), such as
+   `feat(parser): add Python pytest-benchmark support`.
+6. Open a focused pull request describing what changed and why. Link related
+   issues.
 
-CI runs the test suite and coverage on every PR. Keep PRs focused — one logical
-change per PR is easier to review and merge.
+CI runs tests, coverage, linting, formatting, and builds on pull requests.
 
 ## Questions
 
-Open an issue or start a discussion on
-[GitHub](https://github.com/goptics/vizb). We're happy to help.
+Open an [issue](https://github.com/goptics/vizb/issues) or discussion on GitHub.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,9 +56,19 @@ tasks:
       - cd docs; pnpm preview; cd -
 
   test:
-    desc: Run all tests (no cache)
+    desc: Run all CLI and UI tests (no cache)
     cmds:
-      - go test -count=1 ./...
+      - task: test:cli
+      - task: test:ui
+
+  test:cli:
+    desc: Run CLI tests (no cache)
+    cmds:
+      - go test -v -count=1 ./...
+
+  test:ui:
+    desc: Run UI tests
+    cmds:
       - cd ui; pnpm test; cd -
 
   # Pragmatic Go coverage (excludes main.go, vizb-ui.gen.go, pkg/style from review).
@@ -69,15 +79,54 @@ tasks:
       - go tool cover -func=coverage.out | tail -1
 
   lint:
-    desc: Run linter
+    desc: Run all CLI and UI linters
+    cmds:
+      - task: lint:cli
+      - task: lint:ui
+
+  lint:cli:
+    desc: Run CLI linter
     cmds:
       - golangci-lint run
 
+  lint:ui:
+    desc: Run UI type checker
+    cmds:
+      - cd ui; pnpm typecheck; cd -
+
   format:
-    desc: Format codes
+    desc: Format all CLI and UI files
+    cmds:
+      - task: format:cli
+      - task: format:ui
+
+  format:cli:
+    desc: Format CLI files
     cmds:
       - gofmt -w .
+
+  format:ui:
+    desc: Format UI files
+    cmds:
       - cd ui; [ -d node_modules ] || pnpm install; pnpm format; cd -
+
+  format:check:
+    desc: Check all CLI and UI formatting
+    cmds:
+      - task: format:check:cli
+      - task: format:check:ui
+
+  format:check:cli:
+    desc: Check CLI formatting
+    cmds:
+      - |
+        unformatted=$(gofmt -l .)
+        test -z "$unformatted" || { echo "$unformatted"; exit 1; }
+
+  format:check:ui:
+    desc: Check UI formatting
+    cmds:
+      - cd ui; pnpm format:check; cd -
 
   release:check:
     desc: Check Goreleaser configuration

--- a/cmd/cli/statflag_test.go
+++ b/cmd/cli/statflag_test.go
@@ -7,9 +7,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestStatValueSetAndString(t *testing.T) {
+type StatFlagSuite struct {
+	suite.Suite
+}
+
+func (s *StatFlagSuite) TestStatValueSetAndString() {
+	t := s.T()
 	var math []string
 	sv := &statValue{value: &math}
 
@@ -23,7 +29,8 @@ func TestStatValueSetAndString(t *testing.T) {
 	assert.Equal(t, "counts,center", sv.String())
 }
 
-func TestLooksLikeStatValue(t *testing.T) {
+func (s *StatFlagSuite) TestLooksLikeStatValue() {
+	t := s.T()
 	assert.False(t, looksLikeStatValue(""))
 	assert.False(t, looksLikeStatValue("-h"))
 	assert.True(t, looksLikeStatValue("all"))
@@ -31,7 +38,8 @@ func TestLooksLikeStatValue(t *testing.T) {
 	assert.False(t, looksLikeStatValue("counts,bogus"))
 }
 
-func TestRewriteStatArg(t *testing.T) {
+func (s *StatFlagSuite) TestRewriteStatArg() {
+	t := s.T()
 	assert.Equal(t, []string{"--stat=counts"}, RewriteStatArg([]string{"--stat", "counts"}))
 	assert.Equal(t, []string{"--stat", "-o"}, RewriteStatArg([]string{"--stat", "-o"}))
 
@@ -39,4 +47,8 @@ func TestRewriteStatArg(t *testing.T) {
 	file := filepath.Join(dir, "bench.json")
 	require.NoError(t, os.WriteFile(file, []byte("{}"), 0644))
 	assert.Equal(t, []string{"--stat", file}, RewriteStatArg([]string{"--stat", file}))
+}
+
+func TestStatFlagSuite(t *testing.T) {
+	suite.Run(t, new(StatFlagSuite))
 }

--- a/internal/charts/flag_test.go
+++ b/internal/charts/flag_test.go
@@ -6,16 +6,27 @@ import (
 	"github.com/goptics/vizb/internal/charts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestValidateScaleValue(t *testing.T) {
+type ChartFlagSuite struct {
+	suite.Suite
+}
+
+func (s *ChartFlagSuite) TestValidateScaleValue() {
+	t := s.T()
 	require.NoError(t, charts.ValidateScaleValue("linear"))
 	require.NoError(t, charts.ValidateScaleValue("LOG"))
 	assert.Error(t, charts.ValidateScaleValue("sqrt"))
 }
 
-func TestValidateSymbolSizeValue(t *testing.T) {
+func (s *ChartFlagSuite) TestValidateSymbolSizeValue() {
+	t := s.T()
 	require.NoError(t, charts.ValidateSymbolSizeValue("12"))
 	assert.Error(t, charts.ValidateSymbolSizeValue("nope"))
 	assert.Error(t, charts.ValidateSymbolSizeValue("0"))
+}
+
+func TestChartFlagSuite(t *testing.T) {
+	suite.Run(t, new(ChartFlagSuite))
 }

--- a/internal/flags/flag_test.go
+++ b/internal/flags/flag_test.go
@@ -4,9 +4,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestFlagHelpers(t *testing.T) {
+type FlagSuite struct {
+	suite.Suite
+}
+
+func (s *FlagSuite) TestFlagHelpers() {
+	t := s.T()
 	f := Flag{Name: "show-labels", Label: "labels", Key: "labels", JSONKey: "showLabels", ValidSet: []string{"a"}}
 	assert.Equal(t, "labels", f.EffectiveLabel())
 	assert.Equal(t, "labels", f.EffectiveKey())
@@ -18,4 +24,8 @@ func TestFlagHelpers(t *testing.T) {
 	assert.Equal(t, "parser", plain.EffectiveKey())
 	assert.False(t, plain.IsChart())
 	assert.False(t, plain.IsSoft())
+}
+
+func TestFlagSuite(t *testing.T) {
+	suite.Run(t, new(FlagSuite))
 }

--- a/pkg/parser/axes_spec_test.go
+++ b/pkg/parser/axes_spec_test.go
@@ -5,9 +5,15 @@ import (
 	"testing"
 
 	"github.com/goptics/vizb/shared"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestResolveAxesTypesMixed(t *testing.T) {
+type AxesSpecSuite struct {
+	suite.Suite
+}
+
+func (s *AxesSpecSuite) TestResolveAxesTypesMixed() {
+	t := s.T()
 	cfg := Config{Axes: []ColumnSpec{
 		{Source: "region", AxisKey: "x"},
 		{Source: "latency", AxisKey: "y"},
@@ -31,7 +37,8 @@ func TestResolveAxesTypesMixed(t *testing.T) {
 	}
 }
 
-func TestResolveAxesTypesAllValue(t *testing.T) {
+func (s *AxesSpecSuite) TestResolveAxesTypesAllValue() {
+	t := s.T()
 	cfg := Config{Axes: []ColumnSpec{
 		{Source: "x", AxisKey: "x"},
 		{Source: "y", AxisKey: "y"},
@@ -45,7 +52,8 @@ func TestResolveAxesTypesAllValue(t *testing.T) {
 	}
 }
 
-func TestResolveAxesTypesRejectsCategoryNotOnX(t *testing.T) {
+func (s *AxesSpecSuite) TestResolveAxesTypesRejectsCategoryNotOnX() {
+	t := s.T()
 	cfg := Config{Axes: []ColumnSpec{
 		{Source: "latency", AxisKey: "x"},
 		{Source: "region", AxisKey: "y"},
@@ -61,7 +69,8 @@ func TestResolveAxesTypesRejectsCategoryNotOnX(t *testing.T) {
 	}
 }
 
-func TestResolveAxesTypesRejectsMultipleCategories(t *testing.T) {
+func (s *AxesSpecSuite) TestResolveAxesTypesRejectsMultipleCategories() {
+	t := s.T()
 	cfg := Config{Axes: []ColumnSpec{
 		{Source: "region", AxisKey: "x"},
 		{Source: "product", AxisKey: "y"},
@@ -78,7 +87,8 @@ func TestResolveAxesTypesRejectsMultipleCategories(t *testing.T) {
 	}
 }
 
-func TestDatasetAxesForSelectViewMixed(t *testing.T) {
+func (s *AxesSpecSuite) TestDatasetAxesForSelectViewMixed() {
+	t := s.T()
 	view := []ColumnSpec{
 		{Source: "region", AxisKey: "x", Label: "Region", AxisType: "category"},
 		{Source: "latency", AxisKey: "y", AxisType: "value"},
@@ -90,7 +100,8 @@ func TestDatasetAxesForSelectViewMixed(t *testing.T) {
 	}
 }
 
-func TestDatasetAxesForSelectViewValue(t *testing.T) {
+func (s *AxesSpecSuite) TestDatasetAxesForSelectViewValue() {
+	t := s.T()
 	view := []ColumnSpec{
 		{Source: "x", AxisKey: "x", AxisType: "value"},
 		{Source: "y", AxisKey: "y", AxisType: "value"},
@@ -102,7 +113,8 @@ func TestDatasetAxesForSelectViewValue(t *testing.T) {
 	}
 }
 
-func TestValueAxes(t *testing.T) {
+func (s *AxesSpecSuite) TestValueAxes() {
+	t := s.T()
 	cfg := Config{Axes: []ColumnSpec{{Source: "price"}, {Source: "latency", Label: "Lat"}}}
 	axes := ValueAxes(cfg)
 	if len(axes) != 2 {
@@ -116,7 +128,8 @@ func TestValueAxes(t *testing.T) {
 	}
 }
 
-func TestValueAxesThreeColumns(t *testing.T) {
+func (s *AxesSpecSuite) TestValueAxesThreeColumns() {
+	t := s.T()
 	cfg := Config{Axes: []ColumnSpec{
 		{Source: "x", Label: "X"},
 		{Source: "y", Label: "Y"},
@@ -131,7 +144,8 @@ func TestValueAxesThreeColumns(t *testing.T) {
 	}
 }
 
-func TestResolveAxesTypesEmptyAxes(t *testing.T) {
+func (s *AxesSpecSuite) TestResolveAxesTypesEmptyAxes() {
+	t := s.T()
 	cfg := Config{}
 	err := ResolveAxesTypes(&cfg, func(_, _ string) (string, error) {
 		return "", fmt.Errorf("kindFn should not run")
@@ -141,7 +155,8 @@ func TestResolveAxesTypesEmptyAxes(t *testing.T) {
 	}
 }
 
-func TestResolveAxesTypesKindFnError(t *testing.T) {
+func (s *AxesSpecSuite) TestResolveAxesTypesKindFnError() {
+	t := s.T()
 	cfg := Config{Axes: []ColumnSpec{{Source: "x", AxisKey: "x"}}}
 	err := ResolveAxesTypes(&cfg, func(_, _ string) (string, error) {
 		return "", fmt.Errorf("kind error")
@@ -151,7 +166,8 @@ func TestResolveAxesTypesKindFnError(t *testing.T) {
 	}
 }
 
-func TestDatasetAxesForSelectViewInfersMixed(t *testing.T) {
+func (s *AxesSpecSuite) TestDatasetAxesForSelectViewInfersMixed() {
+	t := s.T()
 	view := []ColumnSpec{
 		{Source: "region", AxisKey: "x"},
 		{Source: "latency", AxisKey: "y"},
@@ -163,7 +179,8 @@ func TestDatasetAxesForSelectViewInfersMixed(t *testing.T) {
 	}
 }
 
-func TestDatasetAxesForSelectViewInfersMixedAfterEmptyXAxis(t *testing.T) {
+func (s *AxesSpecSuite) TestDatasetAxesForSelectViewInfersMixedAfterEmptyXAxis() {
+	t := s.T()
 	view := []ColumnSpec{
 		{Source: "region", AxisKey: "x"},
 		{Source: "latency", AxisKey: "y"},
@@ -178,7 +195,8 @@ func TestDatasetAxesForSelectViewInfersMixedAfterEmptyXAxis(t *testing.T) {
 	}
 }
 
-func TestDatasetAxesForSelectViewInfersValue(t *testing.T) {
+func (s *AxesSpecSuite) TestDatasetAxesForSelectViewInfersValue() {
+	t := s.T()
 	view := []ColumnSpec{
 		{Source: "x", AxisKey: "x"},
 		{Source: "y", AxisKey: "y"},
@@ -190,7 +208,8 @@ func TestDatasetAxesForSelectViewInfersValue(t *testing.T) {
 	}
 }
 
-func TestDatasetAxesForSelectViewSkipsInferenceWhenEmptyResults(t *testing.T) {
+func (s *AxesSpecSuite) TestDatasetAxesForSelectViewSkipsInferenceWhenEmptyResults() {
+	t := s.T()
 	view := []ColumnSpec{
 		{Source: "region", AxisKey: "x"},
 		{Source: "latency", AxisKey: "y"},
@@ -201,7 +220,8 @@ func TestDatasetAxesForSelectViewSkipsInferenceWhenEmptyResults(t *testing.T) {
 	}
 }
 
-func TestValueAxesExplicitAxisKeyAndCap(t *testing.T) {
+func (s *AxesSpecSuite) TestValueAxesExplicitAxisKeyAndCap() {
+	t := s.T()
 	cfg := Config{Axes: []ColumnSpec{
 		{Source: "a", AxisKey: "y"},
 		{Source: "b", AxisKey: "x"},
@@ -215,4 +235,8 @@ func TestValueAxesExplicitAxisKeyAndCap(t *testing.T) {
 	if axes[0].Key != "y" || axes[1].Key != "x" || axes[2].Key != "z" {
 		t.Fatalf("unexpected axis keys: %+v", axes)
 	}
+}
+
+func TestAxesSpecSuite(t *testing.T) {
+	suite.Run(t, new(AxesSpecSuite))
 }

--- a/pkg/parser/detect_test.go
+++ b/pkg/parser/detect_test.go
@@ -6,7 +6,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
+
+type DetectSuite struct {
+	suite.Suite
+}
 
 func writeDetectFile(t *testing.T, name, content string) string {
 	t.Helper()
@@ -44,7 +49,8 @@ const (
 	vizbBenchmarkSample = `{"name":"Benchmarks","data":[{"name":"a","stats":[]}]}`
 )
 
-func TestDetectParser(t *testing.T) {
+func (s *DetectSuite) TestDetectParser() {
+	t := s.T()
 	cases := []struct {
 		name    string
 		file    string
@@ -73,7 +79,8 @@ func TestDetectParser(t *testing.T) {
 	}
 }
 
-func TestLooksLikeCSVEdgeCases(t *testing.T) {
+func (s *DetectSuite) TestLooksLikeCSVEdgeCases() {
+	t := s.T()
 	t.Run("single line is not CSV", func(t *testing.T) {
 		path := writeDetectFile(t, "one.txt", "just one line")
 		assert.Equal(t, "go", DetectParser(path))
@@ -82,4 +89,8 @@ func TestLooksLikeCSVEdgeCases(t *testing.T) {
 		path := writeDetectFile(t, "header.txt", "a,b,c\n")
 		assert.Equal(t, "go", DetectParser(path))
 	})
+}
+
+func TestDetectSuite(t *testing.T) {
+	suite.Run(t, new(DetectSuite))
 }

--- a/pkg/parser/group_spec_test.go
+++ b/pkg/parser/group_spec_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+type GroupingHelpersSuite struct {
+	suite.Suite
+}
+
 type GroupSpecSuite struct {
 	suite.Suite
 }
@@ -365,7 +369,8 @@ func (s *GroupSpecSuite) TestParseGroupSpecSeparatorMismatch() {
 	s.Contains(err.Error(), "separators do not match")
 }
 
-func TestNoExplicitGrouping(t *testing.T) {
+func (s *GroupingHelpersSuite) TestNoExplicitGrouping() {
+	t := s.T()
 	if !NoExplicitGrouping(Config{GroupPattern: "x"}) {
 		t.Fatal("expected true for default config")
 	}
@@ -389,7 +394,8 @@ func TestNoExplicitGrouping(t *testing.T) {
 	}
 }
 
-func TestAutoGroupApplies(t *testing.T) {
+func (s *GroupingHelpersSuite) TestAutoGroupApplies() {
+	t := s.T()
 	if !AutoGroupApplies(Config{AutoGroup: true, GroupPattern: "x"}) {
 		t.Fatal("expected true")
 	}
@@ -401,7 +407,8 @@ func TestAutoGroupApplies(t *testing.T) {
 	}
 }
 
-func TestFilterHeadersForAutoDetect(t *testing.T) {
+func (s *GroupingHelpersSuite) TestFilterHeadersForAutoDetect() {
+	t := s.T()
 	headers := []string{"z", "x", "y", "w"}
 	got := FilterHeadersForAutoDetect(headers, nil)
 	if len(got) != 4 || got[0] != "z" {
@@ -413,7 +420,8 @@ func TestFilterHeadersForAutoDetect(t *testing.T) {
 	}
 }
 
-func TestEffectiveGroupColumnsFallback(t *testing.T) {
+func (s *GroupingHelpersSuite) TestEffectiveGroupColumnsFallback() {
+	t := s.T()
 	cfg := Config{Group: []string{" region ", ""}}
 	got := EffectiveGroupColumns(cfg)
 	if len(got) != 1 || got[0] != "region" {
@@ -421,21 +429,24 @@ func TestEffectiveGroupColumnsFallback(t *testing.T) {
 	}
 }
 
-func TestEffectiveLabelSeparators(t *testing.T) {
+func (s *GroupingHelpersSuite) TestEffectiveLabelSeparators() {
+	t := s.T()
 	cfg := Config{LabelSeparators: []string{",", "/"}}
 	if len(EffectiveLabelSeparators(cfg)) != 2 {
 		t.Fatal("expected label separators from config")
 	}
 }
 
-func TestLogAutoGroupEmptyIsNoOp(t *testing.T) {
+func (s *GroupingHelpersSuite) TestLogAutoGroupEmptyIsNoOp() {
+	t := s.T()
 	out := testutil.CaptureStdout(func() { LogAutoGroup(nil) })
 	if out != "" {
 		t.Fatalf("expected no output, got %q", out)
 	}
 }
 
-func TestLogAutoValueBranches(t *testing.T) {
+func (s *GroupingHelpersSuite) TestLogAutoValueBranches() {
+	t := s.T()
 	out := testutil.CaptureStdout(func() { LogAutoValue([]string{"x", "y"}, "") })
 	if !strings.Contains(out, "2D") || !strings.Contains(out, "x, y") {
 		t.Fatalf("unexpected 2D log: %q", out)
@@ -526,7 +537,8 @@ func TestAutoDetectTabularConfigSuite(t *testing.T) {
 	suite.Run(t, new(AutoDetectTabularConfigSuite))
 }
 
-func TestAutoValueEligible(t *testing.T) {
+func (s *GroupingHelpersSuite) TestAutoValueEligible() {
+	t := s.T()
 	tests := []struct {
 		name  string
 		types []string
@@ -550,4 +562,8 @@ func TestAutoValueEligible(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGroupingHelpersSuite(t *testing.T) {
+	suite.Run(t, new(GroupingHelpersSuite))
 }

--- a/pkg/parser/json/jsonpath_test.go
+++ b/pkg/parser/json/jsonpath_test.go
@@ -6,9 +6,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestSelectPath(t *testing.T) {
+type JSONPathSuite struct {
+	suite.Suite
+}
+
+func (s *JSONPathSuite) TestSelectPath() {
+	t := s.T()
 	cases := []struct {
 		name    string
 		input   string
@@ -95,7 +101,8 @@ func TestSelectPath(t *testing.T) {
 	}
 }
 
-func TestSelectPathReadAndParseErrors(t *testing.T) {
+func (s *JSONPathSuite) TestSelectPathReadAndParseErrors() {
+	t := s.T()
 	_, err := SelectPath(filepath.Join(t.TempDir(), "missing.json"), ".rows")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error reading JSON")
@@ -107,7 +114,8 @@ func TestSelectPathReadAndParseErrors(t *testing.T) {
 	require.Contains(t, err.Error(), "error parsing JSON")
 }
 
-func TestTokenizeLenientMalformedSegments(t *testing.T) {
+func (s *JSONPathSuite) TestTokenizeLenientMalformedSegments() {
+	t := s.T()
 	require.Empty(t, tokenize("[]"))
 
 	gapped := tokenize(".rows..items")
@@ -121,4 +129,8 @@ func TestTokenizeLenientMalformedSegments(t *testing.T) {
 	require.Empty(t, got[0].indices)
 	require.Equal(t, "items", got[1].key)
 	require.Equal(t, []int{1}, got[1].indices)
+}
+
+func TestJSONPathSuite(t *testing.T) {
+	suite.Run(t, new(JSONPathSuite))
 }

--- a/pkg/parser/select_view_spec_test.go
+++ b/pkg/parser/select_view_spec_test.go
@@ -4,9 +4,15 @@ import (
 	"testing"
 
 	"github.com/goptics/vizb/shared"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestParseSelectViewFlagTwoColumns(t *testing.T) {
+type SelectViewSpecSuite struct {
+	suite.Suite
+}
+
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagTwoColumns() {
+	t := s.T()
 	view, err := ParseSelectViewFlag("region,latency")
 	if err != nil {
 		t.Fatal(err)
@@ -23,7 +29,8 @@ func TestParseSelectViewFlagTwoColumns(t *testing.T) {
 	}
 }
 
-func TestParseSelectViewFlagThreeColumnsWithLabel(t *testing.T) {
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagThreeColumnsWithLabel() {
+	t := s.T()
 	view, err := ParseSelectViewFlag("region{Region},latency{Latency (ms)},sales")
 	if err != nil {
 		t.Fatal(err)
@@ -34,7 +41,8 @@ func TestParseSelectViewFlagThreeColumnsWithLabel(t *testing.T) {
 	}
 }
 
-func TestParseSelectViewFlagExplicitSyntax(t *testing.T) {
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagExplicitSyntax() {
+	t := s.T()
 	view, err := ParseSelectViewFlag("x:region,y:latency,z:sales")
 	if err != nil {
 		t.Fatal(err)
@@ -52,7 +60,8 @@ func TestParseSelectViewFlagExplicitSyntax(t *testing.T) {
 	}
 }
 
-func TestParseSelectViewFlagTrailingParenTypeLabel(t *testing.T) {
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagTrailingParenTypeLabel() {
+	t := s.T()
 	view, err := ParseSelectViewFlag("region,latency (Latency by Region)")
 	if err != nil {
 		t.Fatal(err)
@@ -65,7 +74,8 @@ func TestParseSelectViewFlagTrailingParenTypeLabel(t *testing.T) {
 	}
 }
 
-func TestParseSelectViewFlagAxisLabelAndParenTypeLabel(t *testing.T) {
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagAxisLabelAndParenTypeLabel() {
+	t := s.T()
 	view, err := ParseSelectViewFlag("region{Region},latency (Custom Title)")
 	if err != nil {
 		t.Fatal(err)
@@ -78,7 +88,8 @@ func TestParseSelectViewFlagAxisLabelAndParenTypeLabel(t *testing.T) {
 	}
 }
 
-func TestParseSelectViewFlagParenOverridesMetricBraceLabel(t *testing.T) {
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagParenOverridesMetricBraceLabel() {
+	t := s.T()
 	view, err := ParseSelectViewFlag("region,latency{Legacy} (New Title)")
 	if err != nil {
 		t.Fatal(err)
@@ -91,7 +102,8 @@ func TestParseSelectViewFlagParenOverridesMetricBraceLabel(t *testing.T) {
 	}
 }
 
-func TestParseSelectViewFlagRejectsArity(t *testing.T) {
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagRejectsArity() {
+	t := s.T()
 	if _, err := ParseSelectViewFlag("region"); err == nil {
 		t.Fatal("want error for 1 column")
 	}
@@ -103,13 +115,15 @@ func TestParseSelectViewFlagRejectsArity(t *testing.T) {
 	}
 }
 
-func TestParseSelectViewFlagRejectsDuplicateColumn(t *testing.T) {
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagRejectsDuplicateColumn() {
+	t := s.T()
 	if _, err := ParseSelectViewFlag("region,region"); err == nil {
 		t.Fatal("want duplicate column error")
 	}
 }
 
-func TestParseSelectViewFlagRejectsIncompleteExplicitSyntax(t *testing.T) {
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagRejectsIncompleteExplicitSyntax() {
+	t := s.T()
 	if _, err := ParseSelectViewFlag("x:region,latency"); err == nil {
 		t.Fatal("want mixed explicit/implicit error")
 	}
@@ -118,13 +132,15 @@ func TestParseSelectViewFlagRejectsIncompleteExplicitSyntax(t *testing.T) {
 	}
 }
 
-func TestParseSelectViewFlagRejectsEmptyParenTitle(t *testing.T) {
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagRejectsEmptyParenTitle() {
+	t := s.T()
 	if _, err := ParseSelectViewFlag("region,latency ()"); err == nil {
 		t.Fatal("want error for empty ()")
 	}
 }
 
-func TestHasSelect(t *testing.T) {
+func (s *SelectViewSpecSuite) TestHasSelect() {
+	t := s.T()
 	if HasSelect(Config{}) {
 		t.Fatal("expected false for empty config")
 	}
@@ -136,7 +152,8 @@ func TestHasSelect(t *testing.T) {
 	}
 }
 
-func TestIsExplicitGrouping(t *testing.T) {
+func (s *SelectViewSpecSuite) TestIsExplicitGrouping() {
+	t := s.T()
 	if IsExplicitGrouping(Config{}) {
 		t.Fatal("expected false for empty config")
 	}
@@ -154,7 +171,8 @@ func TestIsExplicitGrouping(t *testing.T) {
 	}
 }
 
-func TestResolveMode(t *testing.T) {
+func (s *SelectViewSpecSuite) TestResolveMode() {
+	t := s.T()
 	if ResolveMode(Config{}) != ModeAuto {
 		t.Fatal("empty config should be ModeAuto")
 	}
@@ -173,7 +191,8 @@ func TestResolveMode(t *testing.T) {
 	}
 }
 
-func TestSelectStatType(t *testing.T) {
+func (s *SelectViewSpecSuite) TestSelectStatType() {
+	t := s.T()
 	view := SelectView{Columns: []ColumnSpec{{Source: "region"}, {Source: "latency"}}}
 	if got := SelectStatType(view); got != "latency by region" {
 		t.Fatalf("got %q", got)
@@ -195,7 +214,8 @@ func TestSelectStatType(t *testing.T) {
 	}
 }
 
-func TestValidateMultiSelectStatViews(t *testing.T) {
+func (s *SelectViewSpecSuite) TestValidateMultiSelectStatViews() {
+	t := s.T()
 	if err := ValidateMultiSelectStatViews([]SelectView{{Columns: []ColumnSpec{{Source: "a"}, {Source: "b"}}}}); err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +224,8 @@ func TestValidateMultiSelectStatViews(t *testing.T) {
 	}
 }
 
-func TestMultiSelectSharedDim(t *testing.T) {
+func (s *SelectViewSpecSuite) TestMultiSelectSharedDim() {
+	t := s.T()
 	shared := []SelectView{
 		{Columns: []ColumnSpec{{Source: "region"}, {Source: "tax"}}},
 		{Columns: []ColumnSpec{{Source: "region"}, {Source: "amount"}}},
@@ -221,7 +242,8 @@ func TestMultiSelectSharedDim(t *testing.T) {
 	}
 }
 
-func TestMultiSelectStatAxesUsesDimLabel(t *testing.T) {
+func (s *SelectViewSpecSuite) TestMultiSelectStatAxesUsesDimLabel() {
+	t := s.T()
 	views := []SelectView{{
 		Columns: []ColumnSpec{{Source: "region", Label: "Region", AxisKey: "x"}, {Source: "tax", AxisKey: "y"}},
 	}}
@@ -231,7 +253,8 @@ func TestMultiSelectStatAxesUsesDimLabel(t *testing.T) {
 	}
 }
 
-func TestMultiSelectStatAxesFallsBackToSource(t *testing.T) {
+func (s *SelectViewSpecSuite) TestMultiSelectStatAxesFallsBackToSource() {
+	t := s.T()
 	views := []SelectView{{
 		Columns: []ColumnSpec{{Source: "region", AxisKey: "x"}, {Source: "tax", AxisKey: "y"}},
 	}}
@@ -241,7 +264,8 @@ func TestMultiSelectStatAxesFallsBackToSource(t *testing.T) {
 	}
 }
 
-func TestSelectViewDatasetName(t *testing.T) {
+func (s *SelectViewSpecSuite) TestSelectViewDatasetName() {
+	t := s.T()
 	view := []ColumnSpec{
 		{Source: "region", Label: "Region", AxisKey: "x"},
 		{Source: "latency", AxisKey: "y"},
@@ -254,7 +278,8 @@ func TestSelectViewDatasetName(t *testing.T) {
 	}
 }
 
-func TestParseSelectViewFlagQuotedParenInColumn(t *testing.T) {
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagQuotedParenInColumn() {
+	t := s.T()
 	view, err := ParseSelectViewFlag(`"region (EU)",latency (Latency by Region)`)
 	if err != nil {
 		t.Fatal(err)
@@ -267,7 +292,8 @@ func TestParseSelectViewFlagQuotedParenInColumn(t *testing.T) {
 	}
 }
 
-func TestParseSelectViewFlagInvalidAxisKeyTreatedAsColumnName(t *testing.T) {
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagInvalidAxisKeyTreatedAsColumnName() {
+	t := s.T()
 	view, err := ParseSelectViewFlag("w:region,latency")
 	if err != nil {
 		t.Fatal(err)
@@ -277,19 +303,22 @@ func TestParseSelectViewFlagInvalidAxisKeyTreatedAsColumnName(t *testing.T) {
 	}
 }
 
-func TestParseSelectViewFlagExplicitMissingY(t *testing.T) {
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagExplicitMissingY() {
+	t := s.T()
 	if _, err := ParseSelectViewFlag("x:region,z:latency"); err == nil {
 		t.Fatal("want missing y error")
 	}
 }
 
-func TestMultiSelectSharedDimEmptyViews(t *testing.T) {
+func (s *SelectViewSpecSuite) TestMultiSelectSharedDimEmptyViews() {
+	t := s.T()
 	if MultiSelectSharedDim(nil) {
 		t.Fatal("expected false for empty views")
 	}
 }
 
-func TestAppendMultiSelectStatPointNonMergeSkipsFailedRead(t *testing.T) {
+func (s *SelectViewSpecSuite) TestAppendMultiSelectStatPointNonMergeSkipsFailedRead() {
+	t := s.T()
 	views := []SelectView{
 		{Columns: []ColumnSpec{{Source: "region", AxisKey: "x"}, {Source: "tax", AxisKey: "y"}}},
 		{Columns: []ColumnSpec{{Source: "product", AxisKey: "x"}, {Source: "sales", AxisKey: "y"}}},
@@ -306,26 +335,30 @@ func TestAppendMultiSelectStatPointNonMergeSkipsFailedRead(t *testing.T) {
 	}
 }
 
-func TestParseSelectViewFlagDuplicateExplicitAxisKey(t *testing.T) {
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagDuplicateExplicitAxisKey() {
+	t := s.T()
 	if _, err := ParseSelectViewFlag("x:region,y:latency,y:sales"); err == nil {
 		t.Fatal("want duplicate axis key error")
 	}
 }
 
-func TestParseSelectViewFlagExplicitMissingZ(t *testing.T) {
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagExplicitMissingZ() {
+	t := s.T()
 	if _, err := ParseSelectViewFlag("x:region,y:latency,sales"); err == nil {
 		t.Fatal("want mixed explicit/implicit error")
 	}
 }
 
-func TestSelectStatTypeUsesSourceWhenDimLabelEmpty(t *testing.T) {
+func (s *SelectViewSpecSuite) TestSelectStatTypeUsesSourceWhenDimLabelEmpty() {
+	t := s.T()
 	view := SelectView{Columns: []ColumnSpec{{Source: "region"}, {Source: "latency", Label: ""}}}
 	if got := SelectStatType(view); got != "latency by region" {
 		t.Fatalf("got %q", got)
 	}
 }
 
-func TestModeIsGrouped(t *testing.T) {
+func (s *SelectViewSpecSuite) TestModeIsGrouped() {
+	t := s.T()
 	if !ModeGrouped.IsGrouped() {
 		t.Fatal("ModeGrouped should report grouped")
 	}
@@ -334,4 +367,8 @@ func TestModeIsGrouped(t *testing.T) {
 			t.Fatalf("mode %v should not be grouped", m)
 		}
 	}
+}
+
+func TestSelectViewSpecSuite(t *testing.T) {
+	suite.Run(t, new(SelectViewSpecSuite))
 }

--- a/pkg/parser/tabular_test.go
+++ b/pkg/parser/tabular_test.go
@@ -4,7 +4,12 @@ import (
 	"testing"
 
 	"github.com/goptics/vizb/shared"
+	"github.com/stretchr/testify/suite"
 )
+
+type TabularSuite struct {
+	suite.Suite
+}
 
 type mockRowReader struct {
 	cells   map[string]string
@@ -26,7 +31,8 @@ func (m mockRowReader) Numeric(source string) (float64, bool) {
 func (m mockRowReader) AvailableColumns() []string { return m.headers }
 func (m mockRowReader) FlagLabel() string          { return m.flag }
 
-func TestParseMixedMode(t *testing.T) {
+func (s *TabularSuite) TestParseMixedMode() {
+	t := s.T()
 	cfg := Config{Axes: []ColumnSpec{
 		{Source: "region", AxisKey: "x", AxisType: "category"},
 		{Source: "latency", AxisKey: "y", AxisType: "value"},
@@ -50,7 +56,8 @@ func TestParseMixedMode(t *testing.T) {
 	}
 }
 
-func TestParseValueModeSkipsIncompleteRowsAndSetsMetric(t *testing.T) {
+func (s *TabularSuite) TestParseValueModeSkipsIncompleteRowsAndSetsMetric() {
+	t := s.T()
 	cfg := Config{
 		Axes: []ColumnSpec{
 			{Source: "x", AxisKey: "x"},
@@ -78,7 +85,8 @@ func TestParseValueModeSkipsIncompleteRowsAndSetsMetric(t *testing.T) {
 	}
 }
 
-func TestParseValueModeRejectsMissingMetricColumn(t *testing.T) {
+func (s *TabularSuite) TestParseValueModeRejectsMissingMetricColumn() {
+	t := s.T()
 	restore, exitCalled := shared.TrapOsExitPanic(t)
 	defer restore()
 
@@ -106,7 +114,8 @@ func TestParseValueModeRejectsMissingMetricColumn(t *testing.T) {
 	}
 }
 
-func TestParseSelectStatModeMergedRow(t *testing.T) {
+func (s *TabularSuite) TestParseSelectStatModeMergedRow() {
+	t := s.T()
 	cfg := Config{
 		SelectViews: []SelectView{
 			{Columns: []ColumnSpec{{Source: "region", AxisKey: "x"}, {Source: "tax", AxisKey: "y"}}},
@@ -125,7 +134,8 @@ func TestParseSelectStatModeMergedRow(t *testing.T) {
 	}
 }
 
-func TestParseSelectStatModeEmptyResultsExits(t *testing.T) {
+func (s *TabularSuite) TestParseSelectStatModeEmptyResultsExits() {
+	t := s.T()
 	restore, exitCalled := shared.TrapOsExitPanic(t)
 	defer restore()
 
@@ -150,7 +160,8 @@ func TestParseSelectStatModeEmptyResultsExits(t *testing.T) {
 	}
 }
 
-func TestParseMixedModeSkipsUnknownAxisKey(t *testing.T) {
+func (s *TabularSuite) TestParseMixedModeSkipsUnknownAxisKey() {
+	t := s.T()
 	cfg := Config{Axes: []ColumnSpec{
 		{Source: "region", AxisKey: "x", AxisType: "category"},
 		{Source: "missing", AxisKey: "w", AxisType: "value"},
@@ -163,7 +174,8 @@ func TestParseMixedModeSkipsUnknownAxisKey(t *testing.T) {
 	}
 }
 
-func TestParseValueModeRejectsNonNumericMetric(t *testing.T) {
+func (s *TabularSuite) TestParseValueModeRejectsNonNumericMetric() {
+	t := s.T()
 	restore, exitCalled := shared.TrapOsExitPanic(t)
 	defer restore()
 
@@ -192,7 +204,8 @@ func TestParseValueModeRejectsNonNumericMetric(t *testing.T) {
 	}
 }
 
-func TestParseSelectStatModeNonMerge(t *testing.T) {
+func (s *TabularSuite) TestParseSelectStatModeNonMerge() {
+	t := s.T()
 	cfg := Config{
 		SelectViews: []SelectView{
 			{Columns: []ColumnSpec{{Source: "region", AxisKey: "x"}, {Source: "tax", AxisKey: "y"}}},
@@ -211,7 +224,8 @@ func TestParseSelectStatModeNonMerge(t *testing.T) {
 	}
 }
 
-func TestDispatchSelectModePropagatesAxisType(t *testing.T) {
+func (s *TabularSuite) TestDispatchSelectModePropagatesAxisType() {
+	t := s.T()
 	cfg := Config{
 		Mode: ModeValue,
 		SelectViews: []SelectView{
@@ -240,4 +254,8 @@ func TestDispatchSelectModePropagatesAxisType(t *testing.T) {
 	if cfg.SelectViews[0].Columns[0].AxisType != "category" || cfg.SelectViews[0].Columns[1].AxisType != "value" {
 		t.Fatalf("axis types not propagated: %+v", cfg.SelectViews[0].Columns)
 	}
+}
+
+func TestTabularSuite(t *testing.T) {
+	suite.Run(t, new(TabularSuite))
 }

--- a/pkg/template/chunks_test.go
+++ b/pkg/template/chunks_test.go
@@ -6,7 +6,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
+
+type ChunksSuite struct {
+	suite.Suite
+}
 
 // decodeChunks unmarshals the JS object literal SelectChunks emits into a set of keys.
 func decodeChunks(t *testing.T, js string) map[string]string {
@@ -16,7 +21,8 @@ func decodeChunks(t *testing.T, js string) map[string]string {
 	return m
 }
 
-func TestSelectChunks(t *testing.T) {
+func (s *ChunksSuite) TestSelectChunks() {
+	t := s.T()
 	entry := VizbEntryKey
 	barRoot := VizbChartRoots["bar"]
 	lineRoot := VizbChartRoots["line"]
@@ -124,4 +130,8 @@ func chartRootSet() map[string]bool {
 		s[k] = true
 	}
 	return s
+}
+
+func TestChunksSuite(t *testing.T) {
+	suite.Run(t, new(ChunksSuite))
 }

--- a/pkg/template/generate_ui_test.go
+++ b/pkg/template/generate_ui_test.go
@@ -8,9 +8,15 @@ import (
 
 	"github.com/goptics/vizb/shared"
 	"github.com/goptics/vizb/version"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestGenerateUI(t *testing.T) {
+type GenerateUISuite struct {
+	suite.Suite
+}
+
+func (s *GenerateUISuite) TestGenerateUI() {
+	t := s.T()
 	originalOsExit := shared.OsExit
 	defer func() { shared.OsExit = originalOsExit }()
 
@@ -88,7 +94,8 @@ func TestGenerateUI(t *testing.T) {
 	})
 }
 
-func TestGenerateRemoteUI(t *testing.T) {
+func (s *GenerateUISuite) TestGenerateRemoteUI() {
+	t := s.T()
 	testTemplate := `<!DOCTYPE html><html><body>` +
 		`<script>window.VIZB_DATA = [[VIZB .Data VIZB]];` +
 		`window.VIZB_DATA_URL = [[VIZB .DataURL VIZB]];` +
@@ -102,11 +109,16 @@ func TestGenerateRemoteUI(t *testing.T) {
 	assert.Contains(t, result, `"bar"`)
 }
 
-func TestChartListJSEmptyDefaults(t *testing.T) {
+func (s *GenerateUISuite) TestChartListJSEmptyDefaults() {
+	t := s.T()
 	testTemplate := `<!DOCTYPE html><html><body><script>window.VIZB_CHARTS = [[VIZB .ChartList VIZB]];</script></body></html>`
 	result := GenerateUI([]byte(`[]`), nil, false, false, testTemplate)
 
 	assert.Contains(t, result, `"bar"`)
 	assert.Contains(t, result, `"line"`)
 	assert.Contains(t, result, `"pie"`)
+}
+
+func TestGenerateUISuite(t *testing.T) {
+	suite.Run(t, new(GenerateUISuite))
 }

--- a/shared/dataset_test.go
+++ b/shared/dataset_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+type AxisJSONSuite struct {
+	suite.Suite
+}
+
 type DatasetSuite struct {
 	suite.Suite
 }
@@ -123,7 +127,8 @@ func TestDatasetSuite(t *testing.T) {
 	suite.Run(t, new(DatasetSuite))
 }
 
-func TestAxisTypeOmittedWhenCategory(t *testing.T) {
+func (s *AxisJSONSuite) TestAxisTypeOmittedWhenCategory() {
+	t := s.T()
 	b, err := json.Marshal(shared.Axis{Key: "x", Label: "Price"})
 	if err != nil {
 		t.Fatal(err)
@@ -133,7 +138,8 @@ func TestAxisTypeOmittedWhenCategory(t *testing.T) {
 	}
 }
 
-func TestAxisTypeEmittedWhenValue(t *testing.T) {
+func (s *AxisJSONSuite) TestAxisTypeEmittedWhenValue() {
+	t := s.T()
 	b, err := json.Marshal(shared.Axis{Key: "x", Label: "Price", Type: "value"})
 	if err != nil {
 		t.Fatal(err)
@@ -141,4 +147,8 @@ func TestAxisTypeEmittedWhenValue(t *testing.T) {
 	if got := string(b); got != `{"key":"x","label":"Price","type":"value"}` {
 		t.Fatalf("value axis should emit type, got %s", got)
 	}
+}
+
+func TestAxisJSONSuite(t *testing.T) {
+	suite.Run(t, new(AxisJSONSuite))
 }

--- a/shared/dimension_test.go
+++ b/shared/dimension_test.go
@@ -4,12 +4,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestDimensionAxisKey(t *testing.T) {
+type DimensionSuite struct {
+	suite.Suite
+}
+
+func (s *DimensionSuite) TestDimensionAxisKey() {
+	t := s.T()
 	assert.Equal(t, "name", DimensionName.AxisKey())
 	assert.Equal(t, "x", DimensionXAxis.AxisKey())
 	assert.Equal(t, "y", DimensionYAxis.AxisKey())
 	assert.Equal(t, "z", DimensionZAxis.AxisKey())
 	assert.Equal(t, "name", Dimension("unknown").AxisKey())
+}
+
+func TestDimensionSuite(t *testing.T) {
+	suite.Run(t, new(DimensionSuite))
 }

--- a/shared/stat_test.go
+++ b/shared/stat_test.go
@@ -6,7 +6,12 @@ import (
 	barchart "github.com/goptics/vizb/internal/charts/bar"
 	"github.com/goptics/vizb/shared"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
+
+type StatSuite struct {
+	suite.Suite
+}
 
 type statChartStub struct {
 	enabled bool
@@ -18,7 +23,8 @@ func (s statChartStub) StatEnabled() bool  { return s.enabled }
 func (s statChartStub) StatMath() []string { return s.math }
 func (statChartStub) SwapString() string   { return "" }
 
-func TestMaterialiseStatFlags(t *testing.T) {
+func (s *StatSuite) TestMaterialiseStatFlags() {
+	t := s.T()
 	assert.Nil(t, shared.MaterialiseStatFlags(nil))
 	got := shared.MaterialiseStatFlags([]string{})
 	assert.NotNil(t, got)
@@ -28,14 +34,16 @@ func TestMaterialiseStatFlags(t *testing.T) {
 	assert.Equal(t, []string{"counts", "center"}, got.Math)
 }
 
-func TestStatNeedsCorrelation(t *testing.T) {
+func (s *StatSuite) TestStatNeedsCorrelation() {
+	t := s.T()
 	assert.True(t, shared.StatNeedsCorrelation(nil))
 	assert.True(t, shared.StatNeedsCorrelation([]string{}))
 	assert.True(t, shared.StatNeedsCorrelation([]string{"correlations"}))
 	assert.False(t, shared.StatNeedsCorrelation([]string{"counts"}))
 }
 
-func TestStatConfigNeedsCorrelation(t *testing.T) {
+func (s *StatSuite) TestStatConfigNeedsCorrelation() {
+	t := s.T()
 	assert.False(t, (*shared.StatConfig)(nil).NeedsCorrelation())
 	assert.False(t, (&shared.StatConfig{Enabled: false, Math: []string{"correlations"}}).NeedsCorrelation())
 	assert.True(t, (&shared.StatConfig{Enabled: true, Math: []string{}}).NeedsCorrelation())
@@ -43,12 +51,14 @@ func TestStatConfigNeedsCorrelation(t *testing.T) {
 	assert.False(t, (&shared.StatConfig{Enabled: true, Math: []string{"counts"}}).NeedsCorrelation())
 }
 
-func TestStatConfigStatMath(t *testing.T) {
+func (s *StatSuite) TestStatConfigStatMath() {
+	t := s.T()
 	assert.Nil(t, (*shared.StatConfig)(nil).StatMath())
 	assert.Equal(t, []string{"shape"}, (&shared.StatConfig{Math: []string{"shape"}}).StatMath())
 }
 
-func TestChartConfigNeedsCorrelation(t *testing.T) {
+func (s *StatSuite) TestChartConfigNeedsCorrelation() {
+	t := s.T()
 	assert.False(t, shared.ChartConfigNeedsCorrelation(statChartStub{}))
 	assert.False(t, shared.ChartConfigNeedsCorrelation(statChartStub{enabled: true, math: []string{"counts"}}))
 	assert.True(t, shared.ChartConfigNeedsCorrelation(statChartStub{enabled: true, math: []string{"correlations"}}))
@@ -60,4 +70,8 @@ func TestChartConfigNeedsCorrelation(t *testing.T) {
 	assert.False(t, shared.ChartConfigNeedsCorrelation(bar))
 	bar.Stat.Math = []string{"correlations"}
 	assert.True(t, shared.ChartConfigNeedsCorrelation(bar))
+}
+
+func TestStatSuite(t *testing.T) {
+	suite.Run(t, new(StatSuite))
 }


### PR DESCRIPTION
## Summary

- publish concise public AGENTS.md guidance with CLAUDE.md as the single-source reference
- standardize Go tests on testify suite architecture
- add scoped CLI/UI test, lint, and format tasks
- require coverage assessment after every change

## Validation

- `task test` — CLI and UI tests pass
- `task lint` — golangci-lint: 0 issues; UI typecheck passes
- `task format:check` — Go and UI formatting pass
- `task test:cover` — 94.3% total Go statement coverage
- `git diff --check` — clean

Node 22 engine warning appears in this environment using Node 25; checks still pass.