### PR TITLE
ci: serialize release site publishing

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,35 +2,59 @@ name: Deploy Docs
 
 on:
   workflow_call:
+    inputs:
+      publish:
+        required: false
+        type: boolean
+        default: false
+        description: "Publish the generated docs immediately"
   workflow_dispatch:
+    inputs:
+      publish:
+        required: false
+        type: boolean
+        default: true
+        description: "Publish the generated docs immediately"
 
 permissions:
   contents: write
 
-concurrency:
-  group: pages
-  cancel-in-progress: true
-
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
         with:
           version: 9
+
       - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: docs/pnpm-lock.yaml
-      - run: pnpm install
+
+      - run: pnpm install --frozen-lockfile
         working-directory: docs
+
       - run: pnpm build
         working-directory: docs
-      - uses: peaceiris/actions-gh-pages@v4
+
+      - name: Upload docs site
+        uses: actions/upload-artifact@v7
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: website
-          publish_dir: docs/dist
-          keep_files: true
+          name: site-docs
+          path: docs/dist
+          if-no-files-found: error
+
+  publish:
+    if: inputs.publish
+    needs: build
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-site.yml
+    with:
+      artifact_pattern: site-docs
+      keep_files: true

--- a/.github/workflows/merge-examples.yml
+++ b/.github/workflows/merge-examples.yml
@@ -1,4 +1,4 @@
-name: Merge Examples & Deploy
+name: Merge Examples
 on:
   workflow_call:
     inputs:
@@ -6,13 +6,18 @@ on:
         required: true
         type: string
         description: "Language subdirectory under examples/ (e.g. go, javascript, rust)"
+      publish:
+        required: false
+        type: boolean
+        default: false
+        description: "Publish the generated example page immediately"
 
 jobs:
-  merge-deploy:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+  merge:
+    name: Merge ${{ inputs.language }} examples
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v7
 
@@ -20,7 +25,7 @@ jobs:
         if: env.ACT != 'true'
         uses: actions/download-artifact@v8
         with:
-          pattern: json-*
+          pattern: json-${{ inputs.language }}-*
           path: /tmp/jsons
           merge-multiple: true
 
@@ -44,11 +49,21 @@ jobs:
         if: env.ACT == 'true'
         run: echo "::notice::Local preview at dist/examples/${{ inputs.language }}/index.html"
 
-      - name: Deploying to Github pages
+      - name: Upload example site
         if: env.ACT != 'true'
-        uses: peaceiris/actions-gh-pages@v4
+        uses: actions/upload-artifact@v7
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: website
-          publish_dir: dist
-          keep_files: true
+          name: site-examples-${{ inputs.language }}
+          path: dist
+          if-no-files-found: error
+
+  publish:
+    name: Publish ${{ inputs.language }} examples
+    if: inputs.publish
+    needs: merge
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-site.yml
+    with:
+      artifact_pattern: site-examples-${{ inputs.language }}
+      keep_files: true

--- a/.github/workflows/prepare-csv-examples.yml
+++ b/.github/workflows/prepare-csv-examples.yml
@@ -1,9 +1,19 @@
-name: Deploy CSV Examples
+name: Prepare CSV Examples
 on:
-  workflow_run:
-    workflows: [Release]
-    types: [completed]
+  workflow_call:
+    inputs:
+      publish:
+        required: false
+        type: boolean
+        default: false
+        description: "Publish the generated CSV examples immediately"
   workflow_dispatch:
+    inputs:
+      publish:
+        required: false
+        type: boolean
+        default: true
+        description: "Publish the generated CSV examples immediately"
 
 jobs:
   convert:
@@ -119,14 +129,15 @@ jobs:
         if: env.ACT != 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: json-${{ matrix.id }}
+          name: json-csv-${{ matrix.id }}
           path: ${{ matrix.id }}.json
 
-  merge-deploy:
-    name: Merge and Deploy CSV Data
+  merge:
+    name: Merge CSV Data
     needs: convert
     permissions:
       contents: write
-    uses: ./.github/workflows/merge-deploy-examples.yml
+    uses: ./.github/workflows/merge-examples.yml
     with:
       language: csv
+      publish: ${{ inputs.publish }}

--- a/.github/workflows/prepare-go-examples.yml
+++ b/.github/workflows/prepare-go-examples.yml
@@ -1,9 +1,19 @@
-name: Deploy Go Examples
+name: Prepare Go Examples
 on:
-  workflow_run:
-    workflows: [Release]
-    types: [completed]
+  workflow_call:
+    inputs:
+      publish:
+        required: false
+        type: boolean
+        default: false
+        description: "Publish the generated Go examples immediately"
   workflow_dispatch:
+    inputs:
+      publish:
+        required: false
+        type: boolean
+        default: true
+        description: "Publish the generated Go examples immediately"
 
 jobs:
   convert:
@@ -104,14 +114,15 @@ jobs:
         if: env.ACT != 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: json-${{ matrix.id }}
+          name: json-go-${{ matrix.id }}
           path: ${{ matrix.id }}.json
 
-  merge-deploy:
-    name: Merge and Deploy Go Benchmarks
+  merge:
+    name: Merge Go Benchmarks
     needs: convert
     permissions:
       contents: write
-    uses: ./.github/workflows/merge-deploy-examples.yml
+    uses: ./.github/workflows/merge-examples.yml
     with:
       language: go
+      publish: ${{ inputs.publish }}

--- a/.github/workflows/prepare-javascript-examples.yml
+++ b/.github/workflows/prepare-javascript-examples.yml
@@ -1,13 +1,23 @@
-name: Deploy Javascript Examples
+name: Prepare JavaScript Examples
 on:
-  workflow_run:
-    workflows: [Release]
-    types: [completed]
+  workflow_call:
+    inputs:
+      publish:
+        required: false
+        type: boolean
+        default: false
+        description: "Publish the generated JavaScript examples immediately"
   workflow_dispatch:
+    inputs:
+      publish:
+        required: false
+        type: boolean
+        default: true
+        description: "Publish the generated JavaScript examples immediately"
 
 jobs:
   convert:
-    name: Convert Javascript Benchmarks
+    name: Convert JavaScript Benchmarks
     strategy:
       matrix:
         include:
@@ -51,14 +61,15 @@ jobs:
         if: env.ACT != 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: json-${{ matrix.id }}
+          name: json-javascript-${{ matrix.id }}
           path: ${{ matrix.id }}.json
 
-  merge-deploy:
-    name: Merge and Deploy Javascript Benchmarks
+  merge:
+    name: Merge JavaScript Benchmarks
     needs: convert
     permissions:
       contents: write
-    uses: ./.github/workflows/merge-deploy-examples.yml
+    uses: ./.github/workflows/merge-examples.yml
     with:
       language: javascript
+      publish: ${{ inputs.publish }}

--- a/.github/workflows/prepare-json-examples.yml
+++ b/.github/workflows/prepare-json-examples.yml
@@ -1,9 +1,19 @@
-name: Deploy JSON Examples
+name: Prepare JSON Examples
 on:
-  workflow_run:
-    workflows: [Release]
-    types: [completed]
+  workflow_call:
+    inputs:
+      publish:
+        required: false
+        type: boolean
+        default: false
+        description: "Publish the generated JSON examples immediately"
   workflow_dispatch:
+    inputs:
+      publish:
+        required: false
+        type: boolean
+        default: true
+        description: "Publish the generated JSON examples immediately"
 
 jobs:
   convert:
@@ -60,14 +70,15 @@ jobs:
         if: env.ACT != 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: json-${{ matrix.id }}
+          name: json-json-${{ matrix.id }}
           path: ${{ matrix.id }}.json
 
-  merge-deploy:
-    name: Merge and Deploy JSON Data
+  merge:
+    name: Merge JSON Data
     needs: convert
     permissions:
       contents: write
-    uses: ./.github/workflows/merge-deploy-examples.yml
+    uses: ./.github/workflows/merge-examples.yml
     with:
       language: json
+      publish: ${{ inputs.publish }}

--- a/.github/workflows/prepare-rust-examples.yml
+++ b/.github/workflows/prepare-rust-examples.yml
@@ -1,9 +1,19 @@
-name: Deploy Rust Examples
+name: Prepare Rust Examples
 on:
-  workflow_run:
-    workflows: [Release]
-    types: [completed]
+  workflow_call:
+    inputs:
+      publish:
+        required: false
+        type: boolean
+        default: false
+        description: "Publish the generated Rust examples immediately"
   workflow_dispatch:
+    inputs:
+      publish:
+        required: false
+        type: boolean
+        default: true
+        description: "Publish the generated Rust examples immediately"
 
 jobs:
   convert:
@@ -51,14 +61,15 @@ jobs:
         if: env.ACT != 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: json-${{ matrix.id }}
+          name: json-rust-${{ matrix.id }}
           path: ${{ matrix.id }}.json
 
-  merge-deploy:
-    name: Merge and Deploy Rust Benchmarks
+  merge:
+    name: Merge Rust Benchmarks
     needs: convert
     permissions:
       contents: write
-    uses: ./.github/workflows/merge-deploy-examples.yml
+    uses: ./.github/workflows/merge-examples.yml
     with:
       language: rust
+      publish: ${{ inputs.publish }}

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -1,0 +1,39 @@
+name: Publish Site
+
+on:
+  workflow_call:
+    inputs:
+      artifact_pattern:
+        required: true
+        type: string
+        description: "Site artifacts to combine before publishing"
+      keep_files:
+        required: false
+        type: boolean
+        default: true
+        description: "Preserve files already present on the website branch"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: website-pages
+      queue: max
+    steps:
+      - name: Download site artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: ${{ inputs.artifact_pattern }}
+          path: dist
+          merge-multiple: true
+
+      - name: Publish website
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: website
+          publish_dir: dist
+          keep_files: ${{ inputs.keep_files }}
+          cname: vizb.goptics.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,9 +95,60 @@ jobs:
           installers-regex: '\.zip$'
           token: ${{ secrets.WINGET_TOKEN }}
 
-  deploy-docs:
+  prepare-docs:
+    name: Prepare Docs
     needs: goreleaser
     uses: ./.github/workflows/deploy-docs.yml
-    secrets: inherit
     permissions:
       contents: write
+
+  prepare-csv-examples:
+    name: Prepare CSV Examples
+    needs: goreleaser
+    uses: ./.github/workflows/prepare-csv-examples.yml
+    permissions:
+      contents: write
+
+  prepare-json-examples:
+    name: Prepare JSON Examples
+    needs: goreleaser
+    uses: ./.github/workflows/prepare-json-examples.yml
+    permissions:
+      contents: write
+
+  prepare-go-examples:
+    name: Prepare Go Examples
+    needs: goreleaser
+    uses: ./.github/workflows/prepare-go-examples.yml
+    permissions:
+      contents: write
+
+  prepare-javascript-examples:
+    name: Prepare JavaScript Examples
+    needs: goreleaser
+    uses: ./.github/workflows/prepare-javascript-examples.yml
+    permissions:
+      contents: write
+
+  prepare-rust-examples:
+    name: Prepare Rust Examples
+    needs: goreleaser
+    uses: ./.github/workflows/prepare-rust-examples.yml
+    permissions:
+      contents: write
+
+  publish-site:
+    name: Publish Site
+    needs:
+      - prepare-docs
+      - prepare-csv-examples
+      - prepare-json-examples
+      - prepare-go-examples
+      - prepare-javascript-examples
+      - prepare-rust-examples
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-site.yml
+    with:
+      artifact_pattern: site-*
+      keep_files: false

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -196,7 +196,7 @@ tasks:
       - act --bind --container-options "--user $(id -u):$(id -g)" workflow_dispatch -W .github/workflows/action-ci.yml --job stateful --matrix os:ubuntu-latest
 
   act:examples:
-    desc: Run deploy-examples workflows locally via act (opens browser preview)
+    desc: Run example preparation workflows locally via act (opens browser preview)
     deps: [act:check]
     cmds:
       - ./scripts/act-examples.sh {{.CLI_ARGS}}

--- a/docs/src/content/docs/examples.mdx
+++ b/docs/src/content/docs/examples.mdx
@@ -11,18 +11,18 @@ Sample inputs live under [`examples/`](https://github.com/goptics/vizb/tree/main
 
 | Category | Workflow | Dashboard |
 |----------|----------|-----------|
-| CSV | [deploy-examples-csv.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/deploy-examples-csv.yml) | [vizb.goptics.org/examples/csv/](https://vizb.goptics.org/examples/csv/) |
-| JSON | [deploy-examples-json.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/deploy-examples-json.yml) | [vizb.goptics.org/examples/json/](https://vizb.goptics.org/examples/json/) |
-| Go | [deploy-examples-go.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/deploy-examples-go.yml) | [vizb.goptics.org/examples/go/](https://vizb.goptics.org/examples/go/) |
-| JavaScript | [deploy-examples-javascript.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/deploy-examples-javascript.yml) | [vizb.goptics.org/examples/javascript/](https://vizb.goptics.org/examples/javascript/) |
-| Rust | [deploy-examples-rust.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/deploy-examples-rust.yml) | [vizb.goptics.org/examples/rust/](https://vizb.goptics.org/examples/rust/) |
+| CSV | [prepare-csv-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-csv-examples.yml) | [vizb.goptics.org/examples/csv/](https://vizb.goptics.org/examples/csv/) |
+| JSON | [prepare-json-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-json-examples.yml) | [vizb.goptics.org/examples/json/](https://vizb.goptics.org/examples/json/) |
+| Go | [prepare-go-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-go-examples.yml) | [vizb.goptics.org/examples/go/](https://vizb.goptics.org/examples/go/) |
+| JavaScript | [prepare-javascript-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-javascript-examples.yml) | [vizb.goptics.org/examples/javascript/](https://vizb.goptics.org/examples/javascript/) |
+| Rust | [prepare-rust-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-rust-examples.yml) | [vizb.goptics.org/examples/rust/](https://vizb.goptics.org/examples/rust/) |
 
 ## Adding an example
 
 Same steps for every category — see [examples/README.MD](https://github.com/goptics/vizb/blob/main/examples/README.MD):
 
 1. Add the file under `examples/{category}/`
-2. Add a matrix entry in `.github/workflows/deploy-examples-{category}.yml`
+2. Add a matrix entry in `.github/workflows/prepare-{category}-examples.yml`
 3. Push to `main` — CI rebuilds that dashboard
 
 ## CSV examples
@@ -87,7 +87,7 @@ Fetched live in CI from the [jogruber GitHub contributions API](https://github-c
 
 | Repository | Short Description | Workflow | Dashboard |
 |------------|-------------------|----------|-----------|
-| [goptics/vizb](https://github.com/goptics/vizb) | Vizb's own example dashboards for CSV, JSON, Go, JavaScript, and Rust. | [deploy-examples-*.yml](https://github.com/goptics/vizb/tree/main/.github/workflows) | [Live](https://vizb.goptics.org/examples/) |
+| [goptics/vizb](https://github.com/goptics/vizb) | Vizb's own example dashboards for CSV, JSON, Go, JavaScript, and Rust. | [prepare-*-examples.yml](https://github.com/goptics/vizb/tree/main/.github/workflows) | [Live](https://vizb.goptics.org/examples/) |
 | [goptics/varmq-benchmarks](https://github.com/goptics/varmq-benchmarks) | Worker pool benchmarks comparing VarMQ vs PondV2 across workload patterns and CPU configs. | [bench.yml](https://github.com/goptics/varmq-benchmarks/blob/main/.github/workflows/bench.yml) | [Live](https://goptics.github.io/varmq-benchmarks/) |
 | [goptics/sortbench](https://github.com/goptics/sortbench) | Sorting algorithm benchmarks across git versions using per-tag vizb merging (bubble, insertion, shell, quicksort, merge). | [bench.yml](https://github.com/goptics/sortbench/blob/main/.github/workflows/bench.yml) | [Live](https://goptics.github.io/sortbench/) |
 | [goptics/varmq](https://github.com/goptics/varmq) | Tracks benchmark evolution across VarMQ release versions, generating a cumulative bench log dashboard via vizb action on each release. | [deploy-bench-log.yml](https://github.com/goptics/varmq/blob/main/.github/workflows/deploy-bench-log.yml) | [Live](https://varmq.goptics.org/bench-log/) |

--- a/examples/README.MD
+++ b/examples/README.MD
@@ -6,11 +6,11 @@ Sample inputs for the live dashboards on [vizb.goptics.org/examples/](https://vi
 
 | Category | Folder | File | Workflow |
 |----------|--------|------|----------|
-| CSV | `examples/csv/` | `.csv` | [deploy-examples-csv.yml](../.github/workflows/deploy-examples-csv.yml) |
-| JSON | _(API-fetched in CI)_ | jogruber contributions API | [deploy-examples-json.yml](../.github/workflows/deploy-examples-json.yml) |
-| Go | `examples/go/` | `.txt` | [deploy-examples-go.yml](../.github/workflows/deploy-examples-go.yml) |
-| JavaScript | `examples/javascript/` | `.txt` | [deploy-examples-javascript.yml](../.github/workflows/deploy-examples-javascript.yml) |
-| Rust | `examples/rust/` | `.txt` | [deploy-examples-rust.yml](../.github/workflows/deploy-examples-rust.yml) |
+| CSV | `examples/csv/` | `.csv` | [prepare-csv-examples.yml](../.github/workflows/prepare-csv-examples.yml) |
+| JSON | _(API-fetched in CI)_ | jogruber contributions API | [prepare-json-examples.yml](../.github/workflows/prepare-json-examples.yml) |
+| Go | `examples/go/` | `.txt` | [prepare-go-examples.yml](../.github/workflows/prepare-go-examples.yml) |
+| JavaScript | `examples/javascript/` | `.txt` | [prepare-javascript-examples.yml](../.github/workflows/prepare-javascript-examples.yml) |
+| Rust | `examples/rust/` | `.txt` | [prepare-rust-examples.yml](../.github/workflows/prepare-rust-examples.yml) |
 
 Tabular CSV recipes (auto-group, auto-value, 3D): [csv/README.md](csv/README.md).
 
@@ -30,7 +30,7 @@ Open a specific chart with `?id=<id>` — each matrix entry sets a numbered id v
 
 ### JSON (GitHub contributions)
 
-No repo file to add. Append one row to the matrix in [deploy-examples-json.yml](../.github/workflows/deploy-examples-json.yml) — only `id` and `user`:
+No repo file to add. Append one row to the matrix in [prepare-json-examples.yml](../.github/workflows/prepare-json-examples.yml) — only `id` and `user`:
 
 ```yaml
 - id: 07-octocat        # numbered ?id= deep link; prefix matches ?d=7 in matrix order
@@ -44,7 +44,7 @@ Optionally add a row to [docs/src/content/docs/examples.mdx](../docs/src/content
 ### CSV / Go / JavaScript / Rust
 
 1. **Add the file** — `examples/{category}/my-data.{csv,txt}`
-2. **Add a matrix entry** — in `.github/workflows/deploy-examples-{category}.yml`, under `strategy.matrix.include`
+2. **Add a matrix entry** — in `.github/workflows/prepare-{category}-examples.yml`, under `strategy.matrix.include`
 3. **Push** — CI rebuilds that dashboard on [vizb.goptics.org](https://vizb.goptics.org)
 
 ```yaml

--- a/examples/csv/README.md
+++ b/examples/csv/README.md
@@ -33,7 +33,7 @@ Use a chart subcommand (`bar`, `line`, `scatter`, `pie`, …) or the root comman
 | Sales by date + category | `vizb bar examples/csv/sales.csv -g order_date,category -p "[n{Year}-y{Month}-x{Date}],z{Category}"` |
 | Line / scatter on same data | `vizb line examples/csv/sales.csv` · `vizb scatter examples/csv/sales.csv` |
 
-These variants are also built in CI as `00-sales-auto-group`, `01-sales-grouped`, and `02-sales-by-date` (see `.github/workflows/deploy-examples-csv.yml`).
+These variants are also built in CI as `00-sales-auto-group`, `01-sales-grouped`, and `02-sales-by-date` (see `.github/workflows/prepare-csv-examples.yml`).
 
 ---
 
@@ -144,7 +144,7 @@ Use `noise-grid.csv` for faster loads; use this file when you need the complete 
 | Frameworks on X, load as series | `vizb bar examples/csv/concurrency.csv -g load -p y -A x` |
 | Load on X, frameworks as series | `vizb bar examples/csv/concurrency.csv -g load -p x -A y` |
 
-CI id: `10-concurrency-frameworks` (see `.github/workflows/deploy-examples-csv.yml`).
+CI id: `10-concurrency-frameworks` (see `.github/workflows/prepare-csv-examples.yml`).
 
 ---
 

--- a/scripts/act-examples.sh
+++ b/scripts/act-examples.sh
@@ -11,7 +11,7 @@ REUSE=false
 
 usage() {
   cat <<'EOF'
-Run deploy-examples workflows locally via act (skips GitHub Pages deploy).
+Run example preparation workflows locally via act (skips site publishing).
 
 Usage:
   ./scripts/act-examples.sh [options]
@@ -59,13 +59,13 @@ mkdir -p .act/jsons
 echo "Building vizb..."
 go build -o bin/vizb .
 
-ACT_ARGS=(workflow_dispatch)
+ACT_ARGS=(workflow_dispatch --input publish=false)
 if $REUSE; then
   ACT_ARGS+=(--reuse)
 fi
 
 for lang in "${LANGS[@]}"; do
-  wf=".github/workflows/deploy-examples-${lang}.yml"
+  wf=".github/workflows/prepare-${lang}-examples.yml"
   if [[ ! -f "$wf" ]]; then
     echo "Unknown language or missing workflow: $lang ($wf)" >&2
     exit 1


### PR DESCRIPTION
## Summary

- prepare docs and all example galleries in parallel as reusable workflow artifacts
- publish the combined site once at the end of Release to prevent concurrent website branch push failures
- queue standalone site publishes and preserve existing website files for manual workflow runs
- rename example workflows from deploy to prepare terminology and update scripts and documentation

## Why

Parallel example workflows previously pushed independently to the same website branch. Two jobs could start from the same branch state, causing one peaceiris/actions-gh-pages push to be rejected as a non-fast-forward update. The workflows also appeared as separate runs instead of jobs in the Release summary.

## Validation

- actionlint passes, with the local schema compatibility warning for concurrency queue suppressed
- Release and all renamed workflows parse successfully with act
- task act:examples -- --only rust --reuse --no-open
- all five example workflows previously completed locally through act
- docs pnpm install --frozen-lockfile and pnpm build
- task test
- git diff --check and bash -n scripts/act-examples.sh
