### PR TITLE
feat(serve): add REST API server command

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -3,6 +3,11 @@
 `openapi.yaml` is Vizb's canonical public REST contract. It describes only
 `POST /`, `POST /merge`, and `POST /ui`.
 
+Errors use `application/problem+json`: malformed JSON returns `400`, bodies
+over 10 MiB return `413`, and valid JSON that violates schema or semantic rules
+returns `422`. Unknown paths return `404`; unsupported methods return `405`
+with `Allow: POST`.
+
 Run the contract checks from this directory:
 
 ```bash

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -70,6 +70,8 @@ paths:
           $ref: '#/components/responses/MergeSuccess'
         '400':
           $ref: '#/components/responses/ValidationProblem'
+        '406':
+          $ref: '#/components/responses/NotAcceptableProblem'
         '415':
           $ref: '#/components/responses/UnsupportedMediaTypeProblem'
         '422':
@@ -394,7 +396,51 @@ components:
           items: { $ref: '#/components/schemas/Axis' }
         settings:
           type: array
+          description: Each chart type may appear at most once.
           items: { $ref: '#/components/schemas/ChartConfig' }
+          allOf:
+            - contains:
+                type: object
+                required: [type]
+                properties:
+                  type: { const: bar }
+              minContains: 0
+              maxContains: 1
+            - contains:
+                type: object
+                required: [type]
+                properties:
+                  type: { const: line }
+              minContains: 0
+              maxContains: 1
+            - contains:
+                type: object
+                required: [type]
+                properties:
+                  type: { const: scatter }
+              minContains: 0
+              maxContains: 1
+            - contains:
+                type: object
+                required: [type]
+                properties:
+                  type: { const: pie }
+              minContains: 0
+              maxContains: 1
+            - contains:
+                type: object
+                required: [type]
+                properties:
+                  type: { const: heatmap }
+              minContains: 0
+              maxContains: 1
+            - contains:
+                type: object
+                required: [type]
+                properties:
+                  type: { const: radar }
+              minContains: 0
+              maxContains: 1
         data:
           type: array
           items: { $ref: '#/components/schemas/DataPoint' }

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -36,7 +36,7 @@ paths:
       operationId: convert
       summary: Convert supported input into a Vizb Dataset or self-contained HTML.
       description: |
-        Input is inline text or JSON. Parser, grouping, metadata, units, selection,
+        Input is inline text or JSON. Parser, grouping, units, selection,
         and chart options are structured request data. Unknown or inapplicable
         options are rejected; CLI-style option strings are not accepted.
       requestBody:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -45,13 +45,15 @@ paths:
         '200':
           $ref: '#/components/responses/ConvertSuccess'
         '400':
-          $ref: '#/components/responses/ValidationProblem'
+          $ref: '#/components/responses/MalformedJSONProblem'
         '406':
           $ref: '#/components/responses/NotAcceptableProblem'
         '415':
           $ref: '#/components/responses/UnsupportedMediaTypeProblem'
+        '413':
+          $ref: '#/components/responses/ContentTooLargeProblem'
         '422':
-          $ref: '#/components/responses/ProcessingProblem'
+          $ref: '#/components/responses/UnprocessableContentProblem'
         '500':
           $ref: '#/components/responses/InternalProblem'
   /merge:
@@ -69,13 +71,15 @@ paths:
         '200':
           $ref: '#/components/responses/MergeSuccess'
         '400':
-          $ref: '#/components/responses/ValidationProblem'
+          $ref: '#/components/responses/MalformedJSONProblem'
         '406':
           $ref: '#/components/responses/NotAcceptableProblem'
         '415':
           $ref: '#/components/responses/UnsupportedMediaTypeProblem'
+        '413':
+          $ref: '#/components/responses/ContentTooLargeProblem'
         '422':
-          $ref: '#/components/responses/ProcessingProblem'
+          $ref: '#/components/responses/UnprocessableContentProblem'
         '500':
           $ref: '#/components/responses/InternalProblem'
   /ui:
@@ -93,13 +97,15 @@ paths:
         '200':
           $ref: '#/components/responses/UISuccess'
         '400':
-          $ref: '#/components/responses/ValidationProblem'
+          $ref: '#/components/responses/MalformedJSONProblem'
         '406':
           $ref: '#/components/responses/NotAcceptableProblem'
         '415':
           $ref: '#/components/responses/UnsupportedMediaTypeProblem'
+        '413':
+          $ref: '#/components/responses/ContentTooLargeProblem'
         '422':
-          $ref: '#/components/responses/ProcessingProblem'
+          $ref: '#/components/responses/UnprocessableContentProblem'
         '500':
           $ref: '#/components/responses/InternalProblem'
 components:
@@ -210,18 +216,30 @@ components:
           examples:
             selfContainedHTML:
               value: '<!doctype html><html><head><title>Vizb</title></head><body>...</body></html>'
-    ValidationProblem:
-      description: The request JSON is malformed or violates a strict request schema or option rule.
+    MalformedJSONProblem:
+      description: The request body is not a single valid JSON value.
       content:
         application/problem+json:
           schema:
             $ref: '#/components/schemas/ValidationProblem'
+    ContentTooLargeProblem:
+      description: The request body exceeds the 10 MiB limit.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    UnprocessableContentProblem:
+      description: Valid JSON violates request schema or semantic constraints, or the supplied input cannot be processed.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
           examples:
             unknownOption:
               value:
                 type: https://vizb.goptics.org/problems/validation
-                title: Invalid request
-                status: 400
+                title: Unprocessable content
+                status: 422
                 detail: Request validation failed.
                 instance: /merge
                 errors:
@@ -229,6 +247,13 @@ components:
                     path: /tagAxis
                     code: invalid_enum
                     message: tagAxis must be one of name, x, y, or z.
+            invalidCSV:
+              value:
+                type: https://vizb.goptics.org/problems/processing
+                title: Input processing failed
+                status: 422
+                detail: The selected columns could not be read from the CSV input.
+                instance: /
     NotAcceptableProblem:
       description: The request's Accept header does not allow an operation's selected response media type.
       content:
@@ -241,20 +266,6 @@ components:
         application/problem+json:
           schema:
             $ref: '#/components/schemas/ProblemDetails'
-    ProcessingProblem:
-      description: The request passed structural validation but could not be processed.
-      content:
-        application/problem+json:
-          schema:
-            $ref: '#/components/schemas/ProblemDetails'
-          examples:
-            invalidCSV:
-              value:
-                type: https://vizb.goptics.org/problems/processing
-                title: Input processing failed
-                status: 422
-                detail: The selected columns could not be read from the CSV input.
-                instance: /
     InternalProblem:
       description: An unexpected server-side failure occurred.
       content:

--- a/api/openapi_test.go
+++ b/api/openapi_test.go
@@ -106,6 +106,25 @@ func (s *OpenAPISuite) TestMergeDeclaresNotAcceptableResponse() {
 	s.Equal("#/components/responses/NotAcceptableProblem", notAcceptable["$ref"])
 }
 
+func (s *OpenAPISuite) TestOperationsDeclareRequestProblemResponses() {
+	contract := readContract(s.T())
+	paths := mustMap(s.T(), contract["paths"], "paths")
+	for _, path := range []string{"/", "/merge", "/ui"} {
+		s.Run(path, func() {
+			operation := mustMap(s.T(), mustMap(s.T(), paths[path], "paths."+path)["post"], "paths."+path+".post")
+			responses := mustMap(s.T(), operation["responses"], "paths."+path+".post.responses")
+			for status, responseName := range map[string]string{
+				"400": "MalformedJSONProblem",
+				"413": "ContentTooLargeProblem",
+				"422": "UnprocessableContentProblem",
+			} {
+				response := mustMap(s.T(), responses[status], "paths."+path+".post.responses."+status)
+				s.Equal("#/components/responses/"+responseName, response["$ref"])
+			}
+		})
+	}
+}
+
 func (s *OpenAPISuite) TestDatasetSettingsRequireUniqueChartTypes() {
 	contract := readContract(s.T())
 	components := mustMap(s.T(), contract["components"], "components")

--- a/api/openapi_test.go
+++ b/api/openapi_test.go
@@ -97,6 +97,38 @@ func (s *OpenAPISuite) TestReusableSchemasMatchGoWireTypes() {
 	}
 }
 
+func (s *OpenAPISuite) TestMergeDeclaresNotAcceptableResponse() {
+	contract := readContract(s.T())
+	paths := mustMap(s.T(), contract["paths"], "paths")
+	merge := mustMap(s.T(), mustMap(s.T(), paths["/merge"], "paths./merge")["post"], "paths./merge.post")
+	responses := mustMap(s.T(), merge["responses"], "paths./merge.post.responses")
+	notAcceptable := mustMap(s.T(), responses["406"], "paths./merge.post.responses.406")
+	s.Equal("#/components/responses/NotAcceptableProblem", notAcceptable["$ref"])
+}
+
+func (s *OpenAPISuite) TestDatasetSettingsRequireUniqueChartTypes() {
+	contract := readContract(s.T())
+	components := mustMap(s.T(), contract["components"], "components")
+	schemas := mustMap(s.T(), components["schemas"], "components.schemas")
+	datasetSchema := schemas["Dataset"]
+	dataset := map[string]any{
+		"name": "Bench",
+		"axes": []any{},
+		"settings": []any{
+			map[string]any{"type": "bar"},
+			map[string]any{"type": "line"},
+		},
+		"data": []any{},
+	}
+	s.NoError(validateSchema(contract, datasetSchema, dataset, "dataset"))
+
+	dataset["settings"] = []any{
+		map[string]any{"type": "bar"},
+		map[string]any{"type": "bar", "showLabels": true},
+	}
+	s.ErrorContains(validateSchema(contract, datasetSchema, dataset, "dataset"), "want at most 1")
+}
+
 func TestOpenAPISuite(t *testing.T) {
 	suite.Run(t, new(OpenAPISuite))
 }
@@ -221,6 +253,28 @@ func validateSchema(root map[string]any, rawSchema, value any, location string) 
 		}
 		if matches != 1 {
 			return fmt.Errorf("%s matches %d oneOf schemas, want 1", location, matches)
+		}
+	}
+	if contains, exists := schema["contains"]; exists {
+		array, ok := value.([]any)
+		if !ok {
+			return fmt.Errorf("%s must be an array for contains, got %T", location, value)
+		}
+		matches := 0
+		for i, childValue := range array {
+			if validateSchema(root, contains, childValue, location+"/"+strconv.Itoa(i)) == nil {
+				matches++
+			}
+		}
+		minMatches := 1
+		if min, ok := schema["minContains"].(int); ok {
+			minMatches = min
+		}
+		if matches < minMatches {
+			return fmt.Errorf("%s matches %d items, want at least %d", location, matches, minMatches)
+		}
+		if maxMatches, ok := schema["maxContains"].(int); ok && matches > maxMatches {
+			return fmt.Errorf("%s matches %d items, want at most %d", location, matches, maxMatches)
 		}
 	}
 

--- a/cmd/cli/flagbag.go
+++ b/cmd/cli/flagbag.go
@@ -23,6 +23,7 @@ type FlagBag struct {
 	strs         map[string]*string
 	bools        map[string]*bool
 	floats       map[string]*float64
+	ints         map[string]*int
 	stringSlices map[string]*[]string // backs KindStringSlice, KindStat, and KindStringArray
 }
 
@@ -33,6 +34,7 @@ func NewFlagBag(fl []flags.Flag) *FlagBag {
 		strs:         map[string]*string{},
 		bools:        map[string]*bool{},
 		floats:       map[string]*float64{},
+		ints:         map[string]*int{},
 		stringSlices: map[string]*[]string{},
 	}
 	for _, f := range fl {
@@ -43,6 +45,8 @@ func NewFlagBag(fl []flags.Flag) *FlagBag {
 			b.bools[f.Name] = new(bool)
 		case flags.KindFloat:
 			b.floats[f.Name] = new(float64)
+		case flags.KindInt:
+			b.ints[f.Name] = new(int)
 		case flags.KindStringSlice, flags.KindStat, flags.KindStringArray:
 			b.stringSlices[f.Name] = new([]string)
 		}
@@ -74,6 +78,13 @@ func (b *FlagBag) Bind(fs *pflag.FlagSet) {
 				fs.Float64VarP(b.floats[f.Name], f.Name, f.Shorthand, def, f.Usage)
 			} else {
 				fs.Float64Var(b.floats[f.Name], f.Name, def, f.Usage)
+			}
+		case flags.KindInt:
+			def, _ := f.Default.(int)
+			if f.Shorthand != "" {
+				fs.IntVarP(b.ints[f.Name], f.Name, f.Shorthand, def, f.Usage)
+			} else {
+				fs.IntVar(b.ints[f.Name], f.Name, def, f.Usage)
 			}
 		case flags.KindStringSlice:
 			def, _ := f.Default.([]string)
@@ -149,6 +160,8 @@ func (b *FlagBag) fatalValue(f flags.Flag) string {
 	switch f.Kind {
 	case flags.KindFloat:
 		return strconv.FormatFloat(*b.floats[f.Name], 'g', -1, 64)
+	case flags.KindInt:
+		return strconv.Itoa(*b.ints[f.Name])
 	default:
 		return *b.strs[f.Name]
 	}
@@ -173,6 +186,14 @@ func (b *FlagBag) Bool(name string) bool {
 // Float returns the parsed value of a float flag.
 func (b *FlagBag) Float(name string) float64 {
 	if p := b.floats[name]; p != nil {
+		return *p
+	}
+	return 0
+}
+
+// Int returns the parsed value of an integer flag.
+func (b *FlagBag) Int(name string) int {
+	if p := b.ints[name]; p != nil {
 		return *p
 	}
 	return 0
@@ -223,6 +244,10 @@ func (b *FlagBag) ChartSeed(cmd *cobra.Command) map[string]any {
 			if changed {
 				seed[f.JSONKey] = encodeFlag(f, *b.floats[f.Name])
 			}
+		case flags.KindInt:
+			if changed {
+				seed[f.JSONKey] = encodeFlag(f, *b.ints[f.Name])
+			}
 		default: // KindString
 			if changed || f.Default != nil {
 				seed[f.JSONKey] = encodeFlag(f, *b.strs[f.Name])
@@ -243,6 +268,8 @@ func (b *FlagBag) Reset() {
 			*b.bools[f.Name], _ = f.Default.(bool)
 		case flags.KindFloat:
 			*b.floats[f.Name], _ = f.Default.(float64)
+		case flags.KindInt:
+			*b.ints[f.Name], _ = f.Default.(int)
 		case flags.KindStringSlice, flags.KindStat, flags.KindStringArray:
 			def, _ := f.Default.([]string)
 			*b.stringSlices[f.Name] = def

--- a/cmd/cli/flagbag_test.go
+++ b/cmd/cli/flagbag_test.go
@@ -287,6 +287,7 @@ func (s *FlagBagSuite) TestAccessorsReturnZeroWhenUnset() {
 	s.Equal("", bag.String("missing"))
 	s.False(bag.Bool("missing"))
 	s.Equal(0.0, bag.Float("missing"))
+	s.Equal(0, bag.Int("missing"))
 	s.Nil(bag.StringSlice("missing"))
 }
 
@@ -298,15 +299,21 @@ func (s *FlagBagSuite) TestParseConfigSetsJSONPath() {
 }
 
 func (s *FlagBagSuite) TestResetRestoresDefaults() {
-	fl := append(slices.Clone(DataFlags), internal_charts.SymbolSizeFlag)
+	fl := append(slices.Clone(DataFlags),
+		internal_charts.SymbolSizeFlag,
+		flags.Flag{Name: "port", Default: 8080, Kind: flags.KindInt},
+	)
 	cmd, bag := s.newCmdBag(fl)
 	s.Require().NoError(cmd.Flags().Set("name", "Custom"))
 	s.Require().NoError(cmd.Flags().Set("theme", "vintage"))
 	s.Require().NoError(cmd.Flags().Set("symbol-size", "12"))
+	s.Require().NoError(cmd.Flags().Set("port", "9090"))
+	s.Equal(9090, bag.Int("port"))
 	bag.Reset()
 	s.Equal("Comparisons", bag.String("name"))
 	s.Equal("default", bag.String("theme"))
 	s.Equal(0.0, bag.Float("symbol-size"))
+	s.Equal(8080, bag.Int("port"))
 }
 
 func (s *FlagBagSuite) TestParseConfigRejectsMultiSelectThreeColumnView() {

--- a/cmd/cli/flagbag_test.go
+++ b/cmd/cli/flagbag_test.go
@@ -369,6 +369,22 @@ func (s *FlagBagSuite) TestChartSeedEncodesChangedFloatAndBool() {
 	s.Equal(9.0, seed["symbolSize"])
 }
 
+func (s *FlagBagSuite) TestIntFlagsValidateAndSeed() {
+	fl := []flags.Flag{{
+		Name:    "retries",
+		JSONKey: "retries",
+		Kind:    flags.KindInt,
+		Validate: func(value string) error {
+			s.Equal("3", value)
+			return nil
+		},
+	}}
+	cmd, bag := s.newCmdBag(fl)
+	s.Require().NoError(cmd.Flags().Set("retries", "3"))
+	bag.Validate(cmd)
+	s.Equal(3, bag.ChartSeed(cmd)["retries"])
+}
+
 func TestFlagBagSuite(t *testing.T) {
 	suite.Run(t, new(FlagBagSuite))
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,0 +1,357 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	internalcharts "github.com/goptics/vizb/internal/charts"
+	"github.com/goptics/vizb/pkg/core"
+	"github.com/goptics/vizb/pkg/parser"
+	"github.com/goptics/vizb/shared"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultServeHost = "127.0.0.1"
+	defaultServePort = 8080
+
+	maxRequestBodyBytes = 10 << 20 // 10 MiB
+	readHeaderTimeout   = 5 * time.Second
+	readTimeout         = 15 * time.Second
+	writeTimeout        = 60 * time.Second
+	idleTimeout         = 60 * time.Second
+	shutdownTimeout     = 10 * time.Second
+)
+
+type serveOptions struct {
+	Host string
+	Port int
+}
+
+type serveDependencies struct {
+	newHandler    func() http.Handler
+	listen        func(network, address string) (net.Listener, error)
+	signalContext func(context.Context, ...os.Signal) (context.Context, context.CancelFunc)
+}
+
+var (
+	serveOpts = serveOptions{Host: defaultServeHost, Port: defaultServePort}
+	serveDeps = serveDependencies{
+		newHandler:    newRESTHandler,
+		listen:        net.Listen,
+		signalContext: signal.NotifyContext,
+	}
+)
+
+var serveCmd = newServeCommand(&serveOpts, serveDeps)
+
+func init() {
+	rootCmd.AddCommand(serveCmd)
+}
+
+// restHandlers is the composition point for the REST API. Keeping the three
+// operations as explicit handlers makes the route map testable and lets future
+// transports reuse the request-scoped core without changing server lifecycle
+// code.
+type restHandlers struct {
+	convert http.Handler
+	merge   http.Handler
+	ui      http.Handler
+}
+
+func newRESTHandler() http.Handler {
+	return composeRESTRoutes(restHandlers{
+		convert: http.HandlerFunc(handleConvert),
+		merge:   http.HandlerFunc(handleMerge),
+		ui:      http.HandlerFunc(handleUI),
+	})
+}
+
+func composeRESTRoutes(handlers restHandlers) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("POST /{$}", handlers.convert)
+	mux.Handle("POST /merge", handlers.merge)
+	mux.Handle("POST /ui", handlers.ui)
+	return mux
+}
+
+// newServeCommand wires a configured HTTP server to Cobra. Its dependencies
+// are explicit so command and lifecycle behavior can be exercised without a
+// real listener or operating-system signal.
+func newServeCommand(opts *serveOptions, deps serveDependencies) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "serve",
+		Short:        "Run Vizb's local REST API server",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx, stop := deps.signalContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return runServer(ctx, *opts, deps)
+		},
+	}
+	cmd.Flags().StringVar(&opts.Host, "host", defaultServeHost, "Host interface to listen on")
+	cmd.Flags().IntVarP(&opts.Port, "port", "p", defaultServePort, "TCP port to listen on")
+	return cmd
+}
+
+func runServer(ctx context.Context, opts serveOptions, deps serveDependencies) error {
+	address, err := serveAddress(opts)
+	if err != nil {
+		return err
+	}
+
+	listener, err := deps.listen("tcp", address)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", address, err)
+	}
+
+	server := newHTTPServer(address, deps.newHandler())
+	serveResult := make(chan error, 1)
+	go func() { serveResult <- server.Serve(listener) }()
+
+	select {
+	case err := <-serveResult:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return fmt.Errorf("serve HTTP: %w", err)
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("shutdown HTTP server: %w", err)
+		}
+		if err := <-serveResult; err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("serve HTTP: %w", err)
+		}
+		return nil
+	}
+}
+
+func newHTTPServer(address string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              address,
+		Handler:           http.MaxBytesHandler(handler, maxRequestBodyBytes),
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
+	}
+}
+
+func serveAddress(opts serveOptions) (string, error) {
+	if opts.Host == "" {
+		return "", fmt.Errorf("host must not be empty")
+	}
+	if opts.Port < 1 || opts.Port > 65535 {
+		return "", fmt.Errorf("port must be between 1 and 65535")
+	}
+	return net.JoinHostPort(opts.Host, strconv.Itoa(opts.Port)), nil
+}
+
+type convertRequest struct {
+	Input  json.RawMessage `json:"input"`
+	Parser string          `json:"parser"`
+	Charts struct {
+		Types []string `json:"types"`
+	} `json:"charts"`
+	Output struct {
+		Format string `json:"format"`
+	} `json:"output"`
+}
+
+type mergeRequest struct {
+	Datasets []shared.Dataset `json:"datasets"`
+	TagAxis  string           `json:"tagAxis"`
+}
+
+type uiRequest struct {
+	Datasets json.RawMessage `json:"datasets"`
+	Charts   struct {
+		Types []string `json:"types"`
+	} `json:"charts"`
+}
+
+func handleConvert(w http.ResponseWriter, r *http.Request) {
+	var request convertRequest
+	if !decodeAPIRequest(w, r, &request) {
+		return
+	}
+	if len(request.Input) == 0 || string(request.Input) == "null" {
+		writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", "input is required")
+		return
+	}
+	input, err := inlineInput(request.Input)
+	if err != nil {
+		writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", err.Error())
+		return
+	}
+	types := request.Charts.Types
+	if len(types) == 0 {
+		types = shared.DefaultChartTypes
+	}
+	configs := make([]internalcharts.ChartConfig, 0, len(types))
+	for _, chartType := range types {
+		config, err := internalcharts.Materialise(chartType, nil, nil)
+		if err != nil {
+			writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", err.Error())
+			return
+		}
+		configs = append(configs, config)
+	}
+	result, err := core.Convert(core.ConvertInput{
+		Input: input, Parser: request.Parser, Config: parser.Config{}, Charts: configs,
+	})
+	if err != nil {
+		writeAPIProblem(w, r, http.StatusUnprocessableEntity, "Input processing failed", err.Error())
+		return
+	}
+	if request.Output.Format == "html" {
+		if !accepts(r, "text/html") {
+			writeAPIProblem(w, r, http.StatusNotAcceptable, "Not acceptable", "Accept must allow text/html")
+			return
+		}
+		html, err := core.GenerateUI([]shared.Dataset{*result.Dataset}, types)
+		if err != nil {
+			writeAPIProblem(w, r, http.StatusInternalServerError, "Internal server error", err.Error())
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = io.WriteString(w, html)
+		return
+	}
+	if request.Output.Format != "" && request.Output.Format != "dataset" {
+		writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", "output.format must be dataset or html")
+		return
+	}
+	writeAPIJSON(w, http.StatusOK, result.Dataset)
+}
+
+func handleMerge(w http.ResponseWriter, r *http.Request) {
+	var request mergeRequest
+	if !decodeAPIRequest(w, r, &request) {
+		return
+	}
+	if len(request.Datasets) < 2 {
+		writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", "at least two datasets are required")
+		return
+	}
+	merged, err := core.Merge(request.Datasets, shared.Dimension(request.TagAxis))
+	if err != nil {
+		writeAPIProblem(w, r, http.StatusUnprocessableEntity, "Input processing failed", err.Error())
+		return
+	}
+	writeAPIJSON(w, http.StatusOK, merged)
+}
+
+func handleUI(w http.ResponseWriter, r *http.Request) {
+	var request uiRequest
+	if !decodeAPIRequest(w, r, &request) {
+		return
+	}
+	if !accepts(r, "text/html") {
+		writeAPIProblem(w, r, http.StatusNotAcceptable, "Not acceptable", "Accept must allow text/html")
+		return
+	}
+	datasets, err := decodeDatasets(request.Datasets)
+	if err != nil {
+		writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", err.Error())
+		return
+	}
+	html, err := core.GenerateUI(datasets, request.Charts.Types)
+	if err != nil {
+		writeAPIProblem(w, r, http.StatusUnprocessableEntity, "Input processing failed", err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = io.WriteString(w, html)
+}
+
+func decodeAPIRequest(w http.ResponseWriter, r *http.Request, target any) bool {
+	if contentType := r.Header.Get("Content-Type"); contentType != "" {
+		mediaType, _, err := mime.ParseMediaType(contentType)
+		if err != nil || mediaType != "application/json" {
+			writeAPIProblem(w, r, http.StatusUnsupportedMediaType, "Unsupported media type", "Content-Type must be application/json")
+			return false
+		}
+	}
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", err.Error())
+		return false
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", "request body must contain one JSON value")
+		return false
+	}
+	return true
+}
+
+func inlineInput(raw json.RawMessage) ([]byte, error) {
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return []byte(text), nil
+	}
+	if len(raw) == 0 || (raw[0] != '{' && raw[0] != '[') {
+		return nil, fmt.Errorf("input must be a string, JSON object, or JSON array")
+	}
+	return raw, nil
+}
+
+func decodeDatasets(raw json.RawMessage) ([]shared.Dataset, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("datasets is required")
+	}
+	var datasets []shared.Dataset
+	if raw[0] == '[' {
+		if err := json.Unmarshal(raw, &datasets); err != nil {
+			return nil, err
+		}
+	} else {
+		var dataset shared.Dataset
+		if err := json.Unmarshal(raw, &dataset); err != nil {
+			return nil, err
+		}
+		datasets = []shared.Dataset{dataset}
+	}
+	if len(datasets) == 0 {
+		return nil, fmt.Errorf("at least one dataset is required")
+	}
+	return datasets, nil
+}
+
+func accepts(r *http.Request, mediaType string) bool {
+	accept := r.Header.Get("Accept")
+	return accept == "" || accept == "*/*" || accept == mediaType
+}
+
+func writeAPIJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeAPIProblem(w http.ResponseWriter, r *http.Request, status int, title, detail string) {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"type":     "https://vizb.goptics.org/problems/request",
+		"title":    title,
+		"status":   status,
+		"detail":   detail,
+		"instance": r.URL.Path,
+	})
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -43,6 +43,7 @@ type serveDependencies struct {
 	newHandler    func() http.Handler
 	listen        func(network, address string) (net.Listener, error)
 	signalContext func(context.Context, ...os.Signal) (context.Context, context.CancelFunc)
+	shutdown      func(*http.Server, context.Context) error
 }
 
 var (
@@ -51,6 +52,7 @@ var (
 		newHandler:    newRESTHandler,
 		listen:        net.Listen,
 		signalContext: signal.NotifyContext,
+		shutdown:      (*http.Server).Shutdown,
 	}
 )
 
@@ -130,7 +132,11 @@ func runServer(ctx context.Context, opts serveOptions, deps serveDependencies) e
 	case <-ctx.Done():
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
-		if err := server.Shutdown(shutdownCtx); err != nil {
+		shutdown := deps.shutdown
+		if shutdown == nil {
+			shutdown = (*http.Server).Shutdown
+		}
+		if err := shutdown(server, shutdownCtx); err != nil {
 			return fmt.Errorf("shutdown HTTP server: %w", err)
 		}
 		if err := <-serveResult; err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -185,6 +191,14 @@ type uiRequest struct {
 }
 
 func handleConvert(w http.ResponseWriter, r *http.Request) {
+	handleConvertWithGenerator(w, r, core.GenerateUI)
+}
+
+func handleConvertWithGenerator(
+	w http.ResponseWriter,
+	r *http.Request,
+	generateUI func([]shared.Dataset, []string) (string, error),
+) {
 	var request convertRequest
 	if !decodeAPIRequest(w, r, &request) {
 		return
@@ -223,7 +237,7 @@ func handleConvert(w http.ResponseWriter, r *http.Request) {
 			writeAPIProblem(w, r, http.StatusNotAcceptable, "Not acceptable", "Accept must allow text/html")
 			return
 		}
-		html, err := core.GenerateUI([]shared.Dataset{*result.Dataset}, types)
+		html, err := generateUI([]shared.Dataset{*result.Dataset}, types)
 		if err != nil {
 			writeAPIProblem(w, r, http.StatusInternalServerError, "Internal server error", err.Error())
 			return
@@ -257,6 +271,14 @@ func handleMerge(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleUI(w http.ResponseWriter, r *http.Request) {
+	handleUIWithGenerator(w, r, core.GenerateUI)
+}
+
+func handleUIWithGenerator(
+	w http.ResponseWriter,
+	r *http.Request,
+	generateUI func([]shared.Dataset, []string) (string, error),
+) {
 	var request uiRequest
 	if !decodeAPIRequest(w, r, &request) {
 		return
@@ -270,7 +292,7 @@ func handleUI(w http.ResponseWriter, r *http.Request) {
 		writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", err.Error())
 		return
 	}
-	html, err := core.GenerateUI(datasets, request.Charts.Types)
+	html, err := generateUI(datasets, request.Charts.Types)
 	if err != nil {
 		writeAPIProblem(w, r, http.StatusUnprocessableEntity, "Input processing failed", err.Error())
 		return

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"mime"
 	"net"
 	"net/http"
@@ -16,6 +17,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/goptics/vizb/cmd/cli"
+	"github.com/goptics/vizb/internal/flags"
 	"github.com/goptics/vizb/pkg/core"
 	"github.com/goptics/vizb/shared"
 	"github.com/spf13/cobra"
@@ -46,16 +49,16 @@ type serveDependencies struct {
 }
 
 var (
-	serveOpts = serveOptions{Host: defaultServeHost, Port: defaultServePort}
 	serveDeps = serveDependencies{
 		newHandler:    newRESTHandler,
 		listen:        net.Listen,
 		signalContext: signal.NotifyContext,
 		shutdown:      (*http.Server).Shutdown,
 	}
+	serveBag = cli.NewFlagBag(serveFlags())
 )
 
-var serveCmd = newServeCommand(&serveOpts, serveDeps)
+var serveCmd = newServeCommand(serveBag, serveDeps)
 
 func init() {
 	rootCmd.AddCommand(serveCmd)
@@ -90,7 +93,7 @@ func composeRESTRoutes(handlers restHandlers) *http.ServeMux {
 // newServeCommand wires a configured HTTP server to Cobra. Its dependencies
 // are explicit so command and lifecycle behavior can be exercised without a
 // real listener or operating-system signal.
-func newServeCommand(opts *serveOptions, deps serveDependencies) *cobra.Command {
+func newServeCommand(bag *cli.FlagBag, deps serveDependencies) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "serve",
 		Short:        "Run Vizb's local REST API server",
@@ -99,12 +102,21 @@ func newServeCommand(opts *serveOptions, deps serveDependencies) *cobra.Command 
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx, stop := deps.signalContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 			defer stop()
-			return runServer(ctx, *opts, deps)
+			return runServer(ctx, serveOptions{
+				Host: bag.String("host"),
+				Port: bag.Int("port"),
+			}, deps)
 		},
 	}
-	cmd.Flags().StringVar(&opts.Host, "host", defaultServeHost, "Host interface to listen on")
-	cmd.Flags().IntVarP(&opts.Port, "port", "p", defaultServePort, "TCP port to listen on")
+	bag.Bind(cmd.Flags())
 	return cmd
+}
+
+func serveFlags() []flags.Flag {
+	return []flags.Flag{
+		{Name: "host", Default: defaultServeHost, Usage: "Host interface to listen on", Kind: flags.KindString},
+		{Name: "port", Shorthand: "p", Default: defaultServePort, Usage: "TCP port to listen on", Kind: flags.KindInt},
+	}
 }
 
 func runServer(ctx context.Context, opts serveOptions, deps serveDependencies) error {
@@ -218,7 +230,7 @@ func handleConvertWithGenerator(
 	if format == "html" {
 		html, err := generateUI([]shared.Dataset{*result.Dataset}, types)
 		if err != nil {
-			writeAPIProblem(w, r, http.StatusInternalServerError, "Internal server error", err.Error())
+			writeInternalServerError(w, r, "generate convert HTML", err)
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -231,6 +243,10 @@ func handleConvertWithGenerator(
 func handleMerge(w http.ResponseWriter, r *http.Request) {
 	var request mergeRequest
 	if !decodeAPIRequest(w, r, &request) {
+		return
+	}
+	if !accepts(r, "application/json") {
+		writeAPIProblem(w, r, http.StatusNotAcceptable, "Not acceptable", "Accept must allow application/json")
 		return
 	}
 	if len(request.Datasets) < 2 {
@@ -287,7 +303,7 @@ func handleUIWithGenerator(
 	}
 	html, generationErr := generateUI(datasets, types)
 	if generationErr != nil {
-		writeAPIProblem(w, r, http.StatusInternalServerError, "Internal server error", generationErr.Error())
+		writeInternalServerError(w, r, "generate UI HTML", generationErr)
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -385,6 +401,11 @@ func writeAPIProblem(w http.ResponseWriter, r *http.Request, status int, title, 
 		"detail":   detail,
 		"instance": r.URL.Path,
 	})
+}
+
+func writeInternalServerError(w http.ResponseWriter, r *http.Request, operation string, err error) {
+	log.Printf("serve: %s: %v", operation, err)
+	writeAPIProblem(w, r, http.StatusInternalServerError, "Internal server error", "The server could not generate the response.")
 }
 
 func writeValidationProblem(w http.ResponseWriter, r *http.Request, validationErrors ...apiValidationError) {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -74,6 +74,10 @@ type restHandlers struct {
 	ui      http.Handler
 }
 
+type restRouter struct {
+	routes map[string]http.Handler
+}
+
 func newRESTHandler() http.Handler {
 	return composeRESTRoutes(restHandlers{
 		convert: http.HandlerFunc(handleConvert),
@@ -82,12 +86,26 @@ func newRESTHandler() http.Handler {
 	})
 }
 
-func composeRESTRoutes(handlers restHandlers) *http.ServeMux {
-	mux := http.NewServeMux()
-	mux.Handle("POST /{$}", handlers.convert)
-	mux.Handle("POST /merge", handlers.merge)
-	mux.Handle("POST /ui", handlers.ui)
-	return mux
+func composeRESTRoutes(handlers restHandlers) http.Handler {
+	return restRouter{routes: map[string]http.Handler{
+		"/":      handlers.convert,
+		"/merge": handlers.merge,
+		"/ui":    handlers.ui,
+	}}
+}
+
+func (router restRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	handler, ok := router.routes[r.URL.Path]
+	if !ok {
+		writeAPIProblem(w, r, http.StatusNotFound, "Not found", "The requested operation does not exist.")
+		return
+	}
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeAPIProblem(w, r, http.StatusMethodNotAllowed, "Method not allowed", "This operation only supports POST.")
+		return
+	}
+	handler.ServeHTTP(w, r)
 }
 
 // newServeCommand wires a configured HTTP server to Cobra. Its dependencies
@@ -148,6 +166,9 @@ func runServer(ctx context.Context, opts serveOptions, deps serveDependencies) e
 			shutdown = (*http.Server).Shutdown
 		}
 		if err := shutdown(server, shutdownCtx); err != nil {
+			if closeErr := server.Close(); closeErr != nil && !errors.Is(closeErr, http.ErrServerClosed) {
+				return fmt.Errorf("shutdown HTTP server: %w", errors.Join(err, fmt.Errorf("close HTTP server: %w", closeErr)))
+			}
 			return fmt.Errorf("shutdown HTTP server: %w", err)
 		}
 		if err := <-serveResult; err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -257,10 +278,6 @@ func handleMerge(w http.ResponseWriter, r *http.Request) {
 	if tagAxis == "" {
 		tagAxis = "name"
 	}
-	if tagAxis != "name" && tagAxis != "x" && tagAxis != "y" && tagAxis != "z" {
-		writeValidationProblem(w, r, bodyValidationError("/tagAxis", "invalid_enum", "tagAxis must be one of name, x, y, or z"))
-		return
-	}
 	datasets, validationErr := decodeDatasetArray(request.Datasets, "/datasets")
 	if validationErr != nil {
 		writeValidationProblem(w, r, *validationErr)
@@ -268,7 +285,7 @@ func handleMerge(w http.ResponseWriter, r *http.Request) {
 	}
 	merged, err := core.Merge(datasets, shared.Dimension(tagAxis))
 	if err != nil {
-		writeAPIProblem(w, r, http.StatusUnprocessableEntity, "Input processing failed", err.Error())
+		writeValidationProblem(w, r, bodyValidationError("/tagAxis", "invalid_enum", err.Error()))
 		return
 	}
 	writeAPIJSON(w, http.StatusOK, merged)
@@ -320,14 +337,36 @@ func decodeAPIRequest(w http.ResponseWriter, r *http.Request, target any) bool {
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(target); err != nil {
-		writeValidationProblem(w, r, bodyValidationError("/", "invalid_json", err.Error()))
+		writeRequestDecodeProblem(w, r, err)
 		return false
 	}
-	if decoder.Decode(&struct{}{}) != io.EOF {
-		writeValidationProblem(w, r, bodyValidationError("/", "multiple_values", "request body must contain one JSON value"))
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			writeMalformedJSONProblem(w, r, bodyValidationError("/", "multiple_values", "request body must contain one JSON value"))
+		} else {
+			writeRequestDecodeProblem(w, r, err)
+		}
 		return false
 	}
 	return true
+}
+
+func writeRequestDecodeProblem(w http.ResponseWriter, r *http.Request, err error) {
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		writeAPIProblem(w, r, http.StatusRequestEntityTooLarge, "Content too large", fmt.Sprintf("Request body must not exceed %d bytes.", maxBytesErr.Limit))
+		return
+	}
+	if isMalformedJSON(err) {
+		writeMalformedJSONProblem(w, r, bodyValidationError("/", "invalid_json", err.Error()))
+		return
+	}
+	writeValidationProblem(w, r, bodyValidationError("/", "invalid_json", err.Error()))
+}
+
+func isMalformedJSON(err error) bool {
+	var syntaxErr *json.SyntaxError
+	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.As(err, &syntaxErr)
 }
 
 func inlineInput(raw json.RawMessage) ([]byte, error) {
@@ -410,12 +449,25 @@ func writeInternalServerError(w http.ResponseWriter, r *http.Request, operation 
 
 func writeValidationProblem(w http.ResponseWriter, r *http.Request, validationErrors ...apiValidationError) {
 	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"type":     "https://vizb.goptics.org/problems/validation",
+		"title":    "Unprocessable content",
+		"status":   http.StatusUnprocessableEntity,
+		"detail":   "Request validation failed.",
+		"instance": r.URL.Path,
+		"errors":   validationErrors,
+	})
+}
+
+func writeMalformedJSONProblem(w http.ResponseWriter, r *http.Request, validationErrors ...apiValidationError) {
+	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(http.StatusBadRequest)
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"type":     problemType(http.StatusBadRequest),
-		"title":    "Invalid request",
+		"title":    "Malformed JSON",
 		"status":   http.StatusBadRequest,
-		"detail":   "Request validation failed.",
+		"detail":   "Request body must contain valid JSON.",
 		"instance": r.URL.Path,
 		"errors":   validationErrors,
 	})
@@ -425,9 +477,15 @@ func problemType(status int) string {
 	slug := "internal"
 	switch status {
 	case http.StatusBadRequest:
-		slug = "validation"
+		slug = "malformed-json"
+	case http.StatusNotFound:
+		slug = "not-found"
+	case http.StatusMethodNotAllowed:
+		slug = "method-not-allowed"
 	case http.StatusNotAcceptable:
 		slug = "not-acceptable"
+	case http.StatusRequestEntityTooLarge:
+		slug = "content-too-large"
 	case http.StatusUnsupportedMediaType:
 		slug = "unsupported-media-type"
 	case http.StatusUnprocessableEntity:

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -12,12 +12,11 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
-	internalcharts "github.com/goptics/vizb/internal/charts"
 	"github.com/goptics/vizb/pkg/core"
-	"github.com/goptics/vizb/pkg/parser"
 	"github.com/goptics/vizb/shared"
 	"github.com/spf13/cobra"
 )
@@ -167,29 +166,6 @@ func serveAddress(opts serveOptions) (string, error) {
 	return net.JoinHostPort(opts.Host, strconv.Itoa(opts.Port)), nil
 }
 
-type convertRequest struct {
-	Input  json.RawMessage `json:"input"`
-	Parser string          `json:"parser"`
-	Charts struct {
-		Types []string `json:"types"`
-	} `json:"charts"`
-	Output struct {
-		Format string `json:"format"`
-	} `json:"output"`
-}
-
-type mergeRequest struct {
-	Datasets []shared.Dataset `json:"datasets"`
-	TagAxis  string           `json:"tagAxis"`
-}
-
-type uiRequest struct {
-	Datasets json.RawMessage `json:"datasets"`
-	Charts   struct {
-		Types []string `json:"types"`
-	} `json:"charts"`
-}
-
 func handleConvert(w http.ResponseWriter, r *http.Request) {
 	handleConvertWithGenerator(w, r, core.GenerateUI)
 }
@@ -204,39 +180,42 @@ func handleConvertWithGenerator(
 		return
 	}
 	if len(request.Input) == 0 || string(request.Input) == "null" {
-		writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", "input is required")
+		writeValidationProblem(w, r, bodyValidationError("/input", "required", "input is required"))
 		return
 	}
 	input, err := inlineInput(request.Input)
 	if err != nil {
-		writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", err.Error())
+		writeValidationProblem(w, r, bodyValidationError("/input", "invalid_type", err.Error()))
 		return
 	}
-	types := request.Charts.Types
-	if len(types) == 0 {
-		types = shared.DefaultChartTypes
+	format := request.Output.Format
+	if format == "" {
+		format = "dataset"
 	}
-	configs := make([]internalcharts.ChartConfig, 0, len(types))
-	for _, chartType := range types {
-		config, err := internalcharts.Materialise(chartType, nil, nil)
-		if err != nil {
-			writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", err.Error())
-			return
-		}
-		configs = append(configs, config)
+	if format != "dataset" && format != "html" {
+		writeValidationProblem(w, r, bodyValidationError("/output/format", "invalid_enum", "output.format must be dataset or html"))
+		return
 	}
-	result, err := core.Convert(core.ConvertInput{
-		Input: input, Parser: request.Parser, Config: parser.Config{}, Charts: configs,
-	})
+	responseType := "application/json"
+	if format == "html" {
+		responseType = "text/html"
+	}
+	if !accepts(r, responseType) {
+		writeAPIProblem(w, r, http.StatusNotAcceptable, "Not acceptable", "Accept must allow "+responseType)
+		return
+	}
+
+	convertInput, types, validationErr := buildConvertInput(request, input)
+	if validationErr != nil {
+		writeValidationProblem(w, r, *validationErr)
+		return
+	}
+	result, err := core.Convert(convertInput)
 	if err != nil {
 		writeAPIProblem(w, r, http.StatusUnprocessableEntity, "Input processing failed", err.Error())
 		return
 	}
-	if request.Output.Format == "html" {
-		if !accepts(r, "text/html") {
-			writeAPIProblem(w, r, http.StatusNotAcceptable, "Not acceptable", "Accept must allow text/html")
-			return
-		}
+	if format == "html" {
 		html, err := generateUI([]shared.Dataset{*result.Dataset}, types)
 		if err != nil {
 			writeAPIProblem(w, r, http.StatusInternalServerError, "Internal server error", err.Error())
@@ -244,10 +223,6 @@ func handleConvertWithGenerator(
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, _ = io.WriteString(w, html)
-		return
-	}
-	if request.Output.Format != "" && request.Output.Format != "dataset" {
-		writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", "output.format must be dataset or html")
 		return
 	}
 	writeAPIJSON(w, http.StatusOK, result.Dataset)
@@ -259,10 +234,23 @@ func handleMerge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(request.Datasets) < 2 {
-		writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", "at least two datasets are required")
+		writeValidationProblem(w, r, bodyValidationError("/datasets", "min_items", "at least two datasets are required"))
 		return
 	}
-	merged, err := core.Merge(request.Datasets, shared.Dimension(request.TagAxis))
+	tagAxis := request.TagAxis
+	if tagAxis == "" {
+		tagAxis = "name"
+	}
+	if tagAxis != "name" && tagAxis != "x" && tagAxis != "y" && tagAxis != "z" {
+		writeValidationProblem(w, r, bodyValidationError("/tagAxis", "invalid_enum", "tagAxis must be one of name, x, y, or z"))
+		return
+	}
+	datasets, validationErr := decodeDatasetArray(request.Datasets, "/datasets")
+	if validationErr != nil {
+		writeValidationProblem(w, r, *validationErr)
+		return
+	}
+	merged, err := core.Merge(datasets, shared.Dimension(tagAxis))
 	if err != nil {
 		writeAPIProblem(w, r, http.StatusUnprocessableEntity, "Input processing failed", err.Error())
 		return
@@ -289,12 +277,17 @@ func handleUIWithGenerator(
 	}
 	datasets, err := decodeDatasets(request.Datasets)
 	if err != nil {
-		writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", err.Error())
+		writeValidationProblem(w, r, *err)
 		return
 	}
-	html, err := generateUI(datasets, request.Charts.Types)
-	if err != nil {
-		writeAPIProblem(w, r, http.StatusUnprocessableEntity, "Input processing failed", err.Error())
+	datasets, types, validationErr := applyUIOptions(datasets, request.Charts, request.Statistics)
+	if validationErr != nil {
+		writeValidationProblem(w, r, *validationErr)
+		return
+	}
+	html, generationErr := generateUI(datasets, types)
+	if generationErr != nil {
+		writeAPIProblem(w, r, http.StatusInternalServerError, "Internal server error", generationErr.Error())
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -302,21 +295,20 @@ func handleUIWithGenerator(
 }
 
 func decodeAPIRequest(w http.ResponseWriter, r *http.Request, target any) bool {
-	if contentType := r.Header.Get("Content-Type"); contentType != "" {
-		mediaType, _, err := mime.ParseMediaType(contentType)
-		if err != nil || mediaType != "application/json" {
-			writeAPIProblem(w, r, http.StatusUnsupportedMediaType, "Unsupported media type", "Content-Type must be application/json")
-			return false
-		}
+	contentType := r.Header.Get("Content-Type")
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if contentType == "" || err != nil || mediaType != "application/json" {
+		writeAPIProblem(w, r, http.StatusUnsupportedMediaType, "Unsupported media type", "Content-Type must be application/json")
+		return false
 	}
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(target); err != nil {
-		writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", err.Error())
+		writeValidationProblem(w, r, bodyValidationError("/", "invalid_json", err.Error()))
 		return false
 	}
 	if decoder.Decode(&struct{}{}) != io.EOF {
-		writeAPIProblem(w, r, http.StatusBadRequest, "Invalid request", "request body must contain one JSON value")
+		writeValidationProblem(w, r, bodyValidationError("/", "multiple_values", "request body must contain one JSON value"))
 		return false
 	}
 	return true
@@ -333,31 +325,48 @@ func inlineInput(raw json.RawMessage) ([]byte, error) {
 	return raw, nil
 }
 
-func decodeDatasets(raw json.RawMessage) ([]shared.Dataset, error) {
-	if len(raw) == 0 {
-		return nil, fmt.Errorf("datasets is required")
-	}
-	var datasets []shared.Dataset
-	if raw[0] == '[' {
-		if err := json.Unmarshal(raw, &datasets); err != nil {
-			return nil, err
-		}
-	} else {
-		var dataset shared.Dataset
-		if err := json.Unmarshal(raw, &dataset); err != nil {
-			return nil, err
-		}
-		datasets = []shared.Dataset{dataset}
-	}
-	if len(datasets) == 0 {
-		return nil, fmt.Errorf("at least one dataset is required")
-	}
-	return datasets, nil
-}
-
 func accepts(r *http.Request, mediaType string) bool {
-	accept := r.Header.Get("Accept")
-	return accept == "" || accept == "*/*" || accept == mediaType
+	values := r.Header.Values("Accept")
+	if len(values) == 0 {
+		return true
+	}
+	targetType, targetSubtype, ok := strings.Cut(mediaType, "/")
+	if !ok {
+		return false
+	}
+	bestSpecificity, bestQuality := -1, -1.0
+	for _, value := range values {
+		for _, mediaRange := range strings.Split(value, ",") {
+			acceptedType, params, err := mime.ParseMediaType(strings.TrimSpace(mediaRange))
+			if err != nil {
+				continue
+			}
+			quality := 1.0
+			if rawQuality, exists := params["q"]; exists {
+				quality, err = strconv.ParseFloat(rawQuality, 64)
+				if err != nil || quality < 0 || quality > 1 {
+					continue
+				}
+			}
+			rangeType, rangeSubtype, ok := strings.Cut(acceptedType, "/")
+			if !ok {
+				continue
+			}
+			specificity := -1
+			switch {
+			case rangeType == targetType && rangeSubtype == targetSubtype:
+				specificity = 2
+			case rangeType == targetType && rangeSubtype == "*":
+				specificity = 1
+			case rangeType == "*" && rangeSubtype == "*":
+				specificity = 0
+			}
+			if specificity > bestSpecificity || (specificity == bestSpecificity && quality > bestQuality) {
+				bestSpecificity, bestQuality = specificity, quality
+			}
+		}
+	}
+	return bestSpecificity >= 0 && bestQuality > 0
 }
 
 func writeAPIJSON(w http.ResponseWriter, status int, value any) {
@@ -370,10 +379,38 @@ func writeAPIProblem(w http.ResponseWriter, r *http.Request, status int, title, 
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(map[string]any{
-		"type":     "https://vizb.goptics.org/problems/request",
+		"type":     problemType(status),
 		"title":    title,
 		"status":   status,
 		"detail":   detail,
 		"instance": r.URL.Path,
 	})
+}
+
+func writeValidationProblem(w http.ResponseWriter, r *http.Request, validationErrors ...apiValidationError) {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"type":     problemType(http.StatusBadRequest),
+		"title":    "Invalid request",
+		"status":   http.StatusBadRequest,
+		"detail":   "Request validation failed.",
+		"instance": r.URL.Path,
+		"errors":   validationErrors,
+	})
+}
+
+func problemType(status int) string {
+	slug := "internal"
+	switch status {
+	case http.StatusBadRequest:
+		slug = "validation"
+	case http.StatusNotAcceptable:
+		slug = "not-acceptable"
+	case http.StatusUnsupportedMediaType:
+		slug = "unsupported-media-type"
+	case http.StatusUnprocessableEntity:
+		slug = "processing"
+	}
+	return "https://vizb.goptics.org/problems/" + slug
 }

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -478,10 +478,7 @@ func applyUIOptions(datasets []shared.Dataset, selection chartSelection, statist
 					validationErr := bodyValidationError("/datasets", "invalid_dataset", err.Error())
 					return nil, nil, &validationErr
 				}
-				if err := json.Unmarshal(raw, &seed); err != nil {
-					validationErr := bodyValidationError("/datasets", "invalid_dataset", err.Error())
-					return nil, nil, &validationErr
-				}
+				_ = json.Unmarshal(raw, &seed) // json.Marshal always produces valid JSON.
 			}
 			if stat != nil {
 				seed["stat"] = stat

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -1,0 +1,679 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"slices"
+	"strings"
+
+	internalcharts "github.com/goptics/vizb/internal/charts"
+	"github.com/goptics/vizb/pkg/core"
+	"github.com/goptics/vizb/pkg/parser"
+	"github.com/goptics/vizb/shared"
+)
+
+type groupingOptions struct {
+	Pattern string   `json:"pattern"`
+	Regex   string   `json:"regex"`
+	Columns []string `json:"columns"`
+	Filter  string   `json:"filter"`
+}
+
+type unitOptions struct {
+	Memory string `json:"memory"`
+	Time   string `json:"time"`
+	Number string `json:"number"`
+}
+
+type metadataOptions struct {
+	ID          string       `json:"id"`
+	Name        string       `json:"name"`
+	Theme       string       `json:"theme"`
+	Description string       `json:"description"`
+	Tag         string       `json:"tag"`
+	Timestamp   string       `json:"timestamp"`
+	Meta        *shared.Meta `json:"meta"`
+}
+
+type chartSelection struct {
+	Types   []string          `json:"types"`
+	Configs []json.RawMessage `json:"configs"`
+}
+
+type statisticsOptions struct {
+	Enabled *bool    `json:"enabled"`
+	Math    []string `json:"math"`
+}
+
+type convertRequest struct {
+	Input    json.RawMessage  `json:"input"`
+	Parser   string           `json:"parser"`
+	Metadata *metadataOptions `json:"metadata"`
+	Grouping *groupingOptions `json:"grouping"`
+	Units    *unitOptions     `json:"units"`
+	Select   []string         `json:"select"`
+	JSONPath string           `json:"jsonPath"`
+	Charts   chartSelection   `json:"charts"`
+	Output   struct {
+		Format string `json:"format"`
+	} `json:"output"`
+}
+
+type mergeRequest struct {
+	Datasets []json.RawMessage `json:"datasets"`
+	TagAxis  string            `json:"tagAxis"`
+}
+
+type uiRequest struct {
+	Datasets   json.RawMessage   `json:"datasets"`
+	Charts     chartSelection    `json:"charts"`
+	Statistics *statisticsOptions `json:"statistics"`
+}
+
+type apiValidationError struct {
+	Location string `json:"location"`
+	Path     string `json:"path"`
+	Code     string `json:"code"`
+	Message  string `json:"message"`
+}
+
+func bodyValidationError(path, code, message string) apiValidationError {
+	return apiValidationError{Location: "body", Path: path, Code: code, Message: message}
+}
+
+func buildConvertInput(request convertRequest, input []byte) (core.ConvertInput, []string, *apiValidationError) {
+	key := strings.TrimSpace(request.Parser)
+	if key == "" {
+		key = "auto"
+	}
+	if !slices.Contains([]string{"auto", "csv", "json", "go", "javascript", "rust"}, key) {
+		err := bodyValidationError("/parser", "invalid_enum", "parser must be one of auto, csv, json, go, javascript, or rust")
+		return core.ConvertInput{}, nil, &err
+	}
+
+	cfg, validationErr := buildParserConfig(request, key)
+	if validationErr != nil {
+		return core.ConvertInput{}, nil, validationErr
+	}
+	configs, types, validationErr := materialiseConversionCharts(request.Charts)
+	if validationErr != nil {
+		return core.ConvertInput{}, nil, validationErr
+	}
+
+	metadata := core.Metadata{Name: "Comparisons", Theme: "default"}
+	if request.Metadata != nil {
+		if request.Metadata.Theme != "" {
+			if err := validateTheme(request.Metadata.Theme); err != nil {
+				validationErr := bodyValidationError("/metadata/theme", "invalid_value", err.Error())
+				return core.ConvertInput{}, nil, &validationErr
+			}
+		}
+		metadata = core.Metadata{
+			ID:          request.Metadata.ID,
+			Name:        request.Metadata.Name,
+			Theme:       request.Metadata.Theme,
+			Description: request.Metadata.Description,
+			Tag:         request.Metadata.Tag,
+			Timestamp:   request.Metadata.Timestamp,
+			System:      request.Metadata.Meta,
+		}
+		if metadata.Name == "" {
+			metadata.Name = "Comparisons"
+		}
+		if metadata.Theme == "" {
+			metadata.Theme = "default"
+		}
+	}
+
+	return core.ConvertInput{
+		Input: input, Parser: key, Config: cfg, Metadata: metadata, Charts: configs,
+	}, types, nil
+}
+
+func buildParserConfig(request convertRequest, key string) (parser.Config, *apiValidationError) {
+	cfg := parser.Config{GroupPattern: "x", MemUnit: "B", TimeUnit: "ns", JSONPath: request.JSONPath}
+	if request.Grouping != nil {
+		cfg.GroupPattern = request.Grouping.Pattern
+		if cfg.GroupPattern == "" {
+			cfg.GroupPattern = "x"
+		}
+		cfg.GroupRegex = request.Grouping.Regex
+		cfg.Group = slices.Clone(request.Grouping.Columns)
+		cfg.Filter = request.Grouping.Filter
+	}
+	if err := parser.ValidateGroupPattern(cfg.GroupPattern); err != nil {
+		validationErr := bodyValidationError("/grouping/pattern", "invalid_value", err.Error())
+		return cfg, &validationErr
+	}
+	for i, column := range cfg.Group {
+		if strings.TrimSpace(column) == "" {
+			validationErr := bodyValidationError(fmt.Sprintf("/grouping/columns/%d", i), "min_length", "grouping columns must not be empty")
+			return cfg, &validationErr
+		}
+	}
+	if cfg.GroupRegex != "" {
+		if _, err := regexp.Compile(cfg.GroupRegex); err != nil {
+			validationErr := bodyValidationError("/grouping/regex", "invalid_regex", err.Error())
+			return cfg, &validationErr
+		}
+	}
+	if cfg.Filter != "" {
+		if _, err := regexp.Compile(cfg.Filter); err != nil {
+			validationErr := bodyValidationError("/grouping/filter", "invalid_regex", err.Error())
+			return cfg, &validationErr
+		}
+	}
+
+	if request.Units != nil {
+		if request.Units.Memory != "" && !slices.Contains([]string{"b", "B", "KB", "MB", "GB"}, request.Units.Memory) {
+			validationErr := bodyValidationError("/units/memory", "invalid_enum", "memory unit must be one of b, B, KB, MB, or GB")
+			return cfg, &validationErr
+		}
+		if request.Units.Time != "" && !slices.Contains([]string{"ns", "us", "ms", "s"}, request.Units.Time) {
+			validationErr := bodyValidationError("/units/time", "invalid_enum", "time unit must be one of ns, us, ms, or s")
+			return cfg, &validationErr
+		}
+		if request.Units.Number != "" && !slices.Contains([]string{"K", "M", "B", "T"}, request.Units.Number) {
+			validationErr := bodyValidationError("/units/number", "invalid_enum", "number unit must be one of K, M, B, or T")
+			return cfg, &validationErr
+		}
+		if request.Units.Memory != "" {
+			cfg.MemUnit = request.Units.Memory
+		}
+		if request.Units.Time != "" {
+			cfg.TimeUnit = request.Units.Time
+		}
+		cfg.NumberUnit = request.Units.Number
+	}
+
+	if cfg.JSONPath != "" && key != "auto" && key != "json" {
+		validationErr := bodyValidationError("/jsonPath", "inapplicable_option", "jsonPath is only supported by the json parser")
+		return cfg, &validationErr
+	}
+	if len(request.Select) > 0 && slices.Contains([]string{"go", "javascript", "rust"}, key) {
+		validationErr := bodyValidationError("/select", "inapplicable_option", "select is only supported by csv and json input")
+		return cfg, &validationErr
+	}
+
+	var err error
+	cfg, err = parser.ResolveGroupConfig(cfg)
+	if err != nil {
+		validationErr := bodyValidationError("/grouping", "invalid_grouping", err.Error())
+		return cfg, &validationErr
+	}
+	if validationErr := applySelectOptions(&cfg, request.Select); validationErr != nil {
+		return cfg, validationErr
+	}
+	cfg.Mode = parser.ResolveMode(cfg)
+	return cfg, nil
+}
+
+func applySelectOptions(cfg *parser.Config, rawSelect []string) *apiValidationError {
+	if len(rawSelect) == 0 {
+		return nil
+	}
+	if parser.IsExplicitGrouping(*cfg) {
+		seen := map[string]bool{}
+		for i, raw := range rawSelect {
+			if strings.TrimSpace(raw) == "" {
+				err := bodyValidationError(fmt.Sprintf("/select/%d", i), "min_length", "select expressions must not be empty")
+				return &err
+			}
+			selected, parseErr := parser.ParseSelectFlag(raw)
+			if parseErr != nil {
+				err := bodyValidationError(fmt.Sprintf("/select/%d", i), "invalid_select", parseErr.Error())
+				return &err
+			}
+			for _, column := range selected {
+				if seen[column.Source] {
+					err := bodyValidationError(fmt.Sprintf("/select/%d", i), "duplicate_value", "duplicate selected column "+column.Source)
+					return &err
+				}
+				seen[column.Source] = true
+				cfg.Select = append(cfg.Select, column)
+			}
+		}
+		groupSet := map[string]bool{}
+		for _, column := range parser.EffectiveGroupColumns(*cfg) {
+			groupSet[column] = true
+		}
+		for _, column := range cfg.Select {
+			if groupSet[column.Source] {
+				err := bodyValidationError("/select", "conflicting_option", "column "+column.Source+" cannot be in both select and grouping.columns")
+				return &err
+			}
+		}
+		return nil
+	}
+
+	for i, raw := range rawSelect {
+		if strings.TrimSpace(raw) == "" {
+			err := bodyValidationError(fmt.Sprintf("/select/%d", i), "min_length", "select expressions must not be empty")
+			return &err
+		}
+		view, parseErr := parser.ParseSelectViewFlag(raw)
+		if parseErr != nil {
+			err := bodyValidationError(fmt.Sprintf("/select/%d", i), "invalid_select", parseErr.Error())
+			return &err
+		}
+		cfg.SelectViews = append(cfg.SelectViews, view)
+	}
+	if len(cfg.SelectViews) > 1 {
+		if err := parser.ValidateMultiSelectStatViews(cfg.SelectViews); err != nil {
+			validationErr := bodyValidationError("/select", "invalid_select", err.Error())
+			return &validationErr
+		}
+	}
+	return nil
+}
+
+func materialiseConversionCharts(selection chartSelection) ([]internalcharts.ChartConfig, []string, *apiValidationError) {
+	types, validationErr := validateChartTypes(selection.Types, true)
+	if validationErr != nil {
+		return nil, nil, validationErr
+	}
+	overrides, _, validationErr := decodeChartOverrides(selection.Configs, types)
+	if validationErr != nil {
+		return nil, nil, validationErr
+	}
+	configs := make([]internalcharts.ChartConfig, 0, len(types))
+	for _, chartType := range types {
+		config, err := internalcharts.Materialise(chartType, nil, overrides[chartType])
+		if err != nil {
+			validationErr := bodyValidationError("/charts/configs", "invalid_chart_config", err.Error())
+			return nil, nil, &validationErr
+		}
+		configs = append(configs, config)
+	}
+	return configs, types, nil
+}
+
+func validateChartTypes(input []string, conversionDefaults bool) ([]string, *apiValidationError) {
+	if input != nil && len(input) == 0 {
+		err := bodyValidationError("/charts/types", "min_items", "charts.types must contain at least one chart type")
+		return nil, &err
+	}
+	types := slices.Clone(input)
+	if types == nil && conversionDefaults {
+		types = slices.Clone(shared.DefaultChartTypes)
+	}
+	seen := map[string]bool{}
+	for i, chartType := range types {
+		if _, ok := internalcharts.Get(chartType); !ok {
+			err := bodyValidationError(fmt.Sprintf("/charts/types/%d", i), "invalid_enum", "unknown chart type "+chartType)
+			return nil, &err
+		}
+		if seen[chartType] {
+			err := bodyValidationError(fmt.Sprintf("/charts/types/%d", i), "duplicate_value", "chart types must be unique")
+			return nil, &err
+		}
+		seen[chartType] = true
+	}
+	return types, nil
+}
+
+func decodeChartOverrides(rawConfigs []json.RawMessage, selected []string) (map[string]internalcharts.ChartConfig, []string, *apiValidationError) {
+	overrides := map[string]internalcharts.ChartConfig{}
+	order := make([]string, 0, len(rawConfigs))
+	for i, raw := range rawConfigs {
+		config, validationErr := decodeChartConfig(raw, fmt.Sprintf("/charts/configs/%d", i))
+		if validationErr != nil {
+			return nil, nil, validationErr
+		}
+		chartType := config.ChartType()
+		if _, exists := overrides[chartType]; exists {
+			err := bodyValidationError(fmt.Sprintf("/charts/configs/%d/type", i), "duplicate_value", "only one config is allowed per chart type")
+			return nil, nil, &err
+		}
+		if selected != nil && !slices.Contains(selected, chartType) {
+			err := bodyValidationError(fmt.Sprintf("/charts/configs/%d/type", i), "inapplicable_option", "chart config type must also appear in charts.types")
+			return nil, nil, &err
+		}
+		overrides[chartType] = config
+		order = append(order, chartType)
+	}
+	return overrides, order, nil
+}
+
+func decodeChartConfig(raw json.RawMessage, path string) (internalcharts.ChartConfig, *apiValidationError) {
+	var discriminator struct {
+		Type string `json:"type"`
+	}
+	if err := strictDecode(raw, &discriminator); err != nil {
+		validationErr := bodyValidationError(path, "invalid_chart_config", err.Error())
+		return nil, &validationErr
+	}
+	if discriminator.Type == "" {
+		validationErr := bodyValidationError(path+"/type", "required", "chart config type is required")
+		return nil, &validationErr
+	}
+	config, err := internalcharts.New(discriminator.Type)
+	if err != nil {
+		validationErr := bodyValidationError(path+"/type", "invalid_enum", err.Error())
+		return nil, &validationErr
+	}
+	if err := strictDecode(raw, config); err != nil {
+		validationErr := bodyValidationError(path, "invalid_chart_config", err.Error())
+		return nil, &validationErr
+	}
+	if validationErr := validateChartConfigValues(raw, path); validationErr != nil {
+		return nil, validationErr
+	}
+	return config, nil
+}
+
+func validateChartConfigValues(raw json.RawMessage, path string) *apiValidationError {
+	var values map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &values); err != nil {
+		validationErr := bodyValidationError(path, "invalid_chart_config", err.Error())
+		return &validationErr
+	}
+	if scaleRaw, ok := values["scale"]; ok {
+		var scale string
+		if err := json.Unmarshal(scaleRaw, &scale); err != nil || (scale != "linear" && scale != "log") {
+			validationErr := bodyValidationError(path+"/scale", "invalid_enum", "scale must be linear or log")
+			return &validationErr
+		}
+	}
+	if sizeRaw, ok := values["symbolSize"]; ok {
+		var size float64
+		if err := json.Unmarshal(sizeRaw, &size); err != nil || size <= 0 {
+			validationErr := bodyValidationError(path+"/symbolSize", "exclusive_minimum", "symbolSize must be greater than zero")
+			return &validationErr
+		}
+	}
+	if sortRaw, ok := values["sort"]; ok {
+		var sortFields map[string]json.RawMessage
+		if err := json.Unmarshal(sortRaw, &sortFields); err != nil {
+			validationErr := bodyValidationError(path+"/sort", "invalid_value", "sort must be an object")
+			return &validationErr
+		}
+		if _, ok := sortFields["enabled"]; !ok {
+			validationErr := bodyValidationError(path+"/sort/enabled", "required", "sort.enabled is required")
+			return &validationErr
+		}
+		orderRaw, ok := sortFields["order"]
+		if !ok {
+			validationErr := bodyValidationError(path+"/sort/order", "required", "sort.order is required")
+			return &validationErr
+		}
+		var order string
+		if err := json.Unmarshal(orderRaw, &order); err != nil || (order != "asc" && order != "desc") {
+			validationErr := bodyValidationError(path+"/sort/order", "invalid_enum", "sort.order must be asc or desc")
+			return &validationErr
+		}
+	}
+	if statRaw, ok := values["stat"]; ok {
+		var statFields map[string]json.RawMessage
+		if err := json.Unmarshal(statRaw, &statFields); err != nil {
+			validationErr := bodyValidationError(path+"/stat", "invalid_value", "stat must be an object")
+			return &validationErr
+		}
+		if _, ok := statFields["enabled"]; !ok {
+			validationErr := bodyValidationError(path+"/stat/enabled", "required", "stat.enabled is required")
+			return &validationErr
+		}
+		if _, ok := statFields["math"]; !ok {
+			validationErr := bodyValidationError(path+"/stat/math", "required", "stat.math is required")
+			return &validationErr
+		}
+		var stat shared.StatConfig
+		if err := json.Unmarshal(statRaw, &stat); err != nil {
+			validationErr := bodyValidationError(path+"/stat", "invalid_value", err.Error())
+			return &validationErr
+		}
+		if validationErr := validateStatMath(stat.Math, path+"/stat/math"); validationErr != nil {
+			return validationErr
+		}
+	}
+	return nil
+}
+
+func validateStatMath(math []string, path string) *apiValidationError {
+	seen := map[string]bool{}
+	for i, value := range math {
+		if !slices.Contains(shared.ValidStatMath, value) {
+			err := bodyValidationError(fmt.Sprintf("%s/%d", path, i), "invalid_enum", "unknown statistics category "+value)
+			return &err
+		}
+		if seen[value] {
+			err := bodyValidationError(fmt.Sprintf("%s/%d", path, i), "duplicate_value", "statistics categories must be unique")
+			return &err
+		}
+		seen[value] = true
+	}
+	return nil
+}
+
+func applyUIOptions(datasets []shared.Dataset, selection chartSelection, statistics *statisticsOptions) ([]shared.Dataset, []string, *apiValidationError) {
+	types, validationErr := validateChartTypes(selection.Types, false)
+	if validationErr != nil {
+		return nil, nil, validationErr
+	}
+	overrides, overrideOrder, validationErr := decodeChartOverrides(selection.Configs, types)
+	if validationErr != nil {
+		return nil, nil, validationErr
+	}
+	var stat *shared.StatConfig
+	if statistics != nil {
+		if validationErr := validateStatMath(statistics.Math, "/statistics/math"); validationErr != nil {
+			return nil, nil, validationErr
+		}
+		enabled := true
+		if statistics.Enabled != nil {
+			enabled = *statistics.Enabled
+		}
+		stat = &shared.StatConfig{Enabled: enabled, Math: slices.Clone(statistics.Math)}
+	}
+
+	result := slices.Clone(datasets)
+	for i := range result {
+		existing := map[string]internalcharts.ChartConfig{}
+		existingOrder := make([]string, 0, len(result[i].Settings))
+		for _, config := range result[i].Settings {
+			existing[config.ChartType()] = config
+			existingOrder = append(existingOrder, config.ChartType())
+		}
+		targetTypes := types
+		if targetTypes == nil {
+			targetTypes = slices.Clone(existingOrder)
+			for _, chartType := range overrideOrder {
+				if !slices.Contains(targetTypes, chartType) {
+					targetTypes = append(targetTypes, chartType)
+				}
+			}
+		}
+		configs := make([]internalcharts.ChartConfig, 0, len(targetTypes))
+		for _, chartType := range targetTypes {
+			base, hasBase := existing[chartType]
+			override, hasOverride := overrides[chartType]
+			if !hasBase && !hasOverride {
+				continue
+			}
+			seed := map[string]any{}
+			if hasBase {
+				raw, err := json.Marshal(base)
+				if err != nil {
+					validationErr := bodyValidationError("/datasets", "invalid_dataset", err.Error())
+					return nil, nil, &validationErr
+				}
+				if err := json.Unmarshal(raw, &seed); err != nil {
+					validationErr := bodyValidationError("/datasets", "invalid_dataset", err.Error())
+					return nil, nil, &validationErr
+				}
+			}
+			if stat != nil {
+				seed["stat"] = stat
+			}
+			config, err := internalcharts.Materialise(chartType, seed, override)
+			if err != nil {
+				validationErr := bodyValidationError("/charts/configs", "invalid_chart_config", err.Error())
+				return nil, nil, &validationErr
+			}
+			configs = append(configs, config)
+		}
+		result[i].Settings = configs
+	}
+	return result, types, nil
+}
+
+type datasetWire struct {
+	ID           string            `json:"id"`
+	Tag          string            `json:"tag"`
+	Timestamp    string            `json:"timestamp"`
+	Name         *string           `json:"name"`
+	Theme        string            `json:"theme"`
+	History      []historyWire     `json:"history"`
+	Description  string            `json:"description"`
+	Meta         *shared.Meta      `json:"meta"`
+	Axes         *[]axisWire       `json:"axes"`
+	Settings     *[]json.RawMessage `json:"settings"`
+	Data         *[]shared.DataPoint `json:"data"`
+	PreserveRows bool              `json:"preserveRows"`
+}
+
+type historyWire struct {
+	Tag       *string      `json:"tag"`
+	Timestamp *string      `json:"timestamp"`
+	Meta      *shared.Meta `json:"meta"`
+}
+
+type axisWire struct {
+	Key   *string `json:"key"`
+	Label string  `json:"label"`
+	Type  string  `json:"type"`
+}
+
+func decodeStrictDataset(raw json.RawMessage, path string) (shared.Dataset, *apiValidationError) {
+	var wire datasetWire
+	if err := strictDecode(raw, &wire); err != nil {
+		validationErr := bodyValidationError(path, "invalid_dataset", err.Error())
+		return shared.Dataset{}, &validationErr
+	}
+	switch {
+	case wire.Name == nil:
+		validationErr := bodyValidationError(path+"/name", "required", "dataset name is required")
+		return shared.Dataset{}, &validationErr
+	case wire.Axes == nil:
+		validationErr := bodyValidationError(path+"/axes", "required", "dataset axes are required")
+		return shared.Dataset{}, &validationErr
+	case wire.Settings == nil:
+		validationErr := bodyValidationError(path+"/settings", "required", "dataset settings are required")
+		return shared.Dataset{}, &validationErr
+	case wire.Data == nil:
+		validationErr := bodyValidationError(path+"/data", "required", "dataset data is required")
+		return shared.Dataset{}, &validationErr
+	}
+
+	axes := make([]shared.Axis, 0, len(*wire.Axes))
+	for i, axis := range *wire.Axes {
+		axisPath := fmt.Sprintf("%s/axes/%d", path, i)
+		if axis.Key == nil {
+			validationErr := bodyValidationError(axisPath+"/key", "required", "axis key is required")
+			return shared.Dataset{}, &validationErr
+		}
+		if !slices.Contains([]string{"name", "x", "y", "z"}, *axis.Key) {
+			validationErr := bodyValidationError(axisPath+"/key", "invalid_enum", "axis key must be one of name, x, y, or z")
+			return shared.Dataset{}, &validationErr
+		}
+		if axis.Type != "" && axis.Type != "value" {
+			validationErr := bodyValidationError(axisPath+"/type", "invalid_enum", "axis type must be empty or value")
+			return shared.Dataset{}, &validationErr
+		}
+		axes = append(axes, shared.Axis{Key: *axis.Key, Label: axis.Label, Type: axis.Type})
+	}
+
+	settings := make([]internalcharts.ChartConfig, 0, len(*wire.Settings))
+	for i, rawConfig := range *wire.Settings {
+		config, validationErr := decodeChartConfig(rawConfig, fmt.Sprintf("%s/settings/%d", path, i))
+		if validationErr != nil {
+			return shared.Dataset{}, validationErr
+		}
+		settings = append(settings, config)
+	}
+
+	history := make([]shared.HistoryEntry, 0, len(wire.History))
+	for i, entry := range wire.History {
+		entryPath := fmt.Sprintf("%s/history/%d", path, i)
+		if entry.Tag == nil {
+			validationErr := bodyValidationError(entryPath+"/tag", "required", "history tag is required")
+			return shared.Dataset{}, &validationErr
+		}
+		if entry.Timestamp == nil {
+			validationErr := bodyValidationError(entryPath+"/timestamp", "required", "history timestamp is required")
+			return shared.Dataset{}, &validationErr
+		}
+		history = append(history, shared.HistoryEntry{Tag: *entry.Tag, Timestamp: *entry.Timestamp, Meta: entry.Meta})
+	}
+
+	return shared.Dataset{
+		ID:           wire.ID,
+		Tag:          wire.Tag,
+		Timestamp:    wire.Timestamp,
+		Name:         *wire.Name,
+		Theme:        wire.Theme,
+		History:      history,
+		Description:  wire.Description,
+		Meta:         wire.Meta,
+		Axes:         axes,
+		Settings:     settings,
+		Data:         slices.Clone(*wire.Data),
+		PreserveRows: wire.PreserveRows,
+	}, nil
+}
+
+func decodeDatasetArray(rawDatasets []json.RawMessage, path string) ([]shared.Dataset, *apiValidationError) {
+	datasets := make([]shared.Dataset, 0, len(rawDatasets))
+	for i, raw := range rawDatasets {
+		dataset, validationErr := decodeStrictDataset(raw, fmt.Sprintf("%s/%d", path, i))
+		if validationErr != nil {
+			return nil, validationErr
+		}
+		datasets = append(datasets, dataset)
+	}
+	return datasets, nil
+}
+
+func decodeDatasets(raw json.RawMessage) ([]shared.Dataset, *apiValidationError) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		validationErr := bodyValidationError("/datasets", "required", "datasets is required")
+		return nil, &validationErr
+	}
+	if trimmed[0] == '[' {
+		var rawDatasets []json.RawMessage
+		if err := strictDecode(trimmed, &rawDatasets); err != nil {
+			validationErr := bodyValidationError("/datasets", "invalid_dataset", err.Error())
+			return nil, &validationErr
+		}
+		if len(rawDatasets) == 0 {
+			validationErr := bodyValidationError("/datasets", "min_items", "at least one dataset is required")
+			return nil, &validationErr
+		}
+		return decodeDatasetArray(rawDatasets, "/datasets")
+	}
+	if trimmed[0] != '{' {
+		validationErr := bodyValidationError("/datasets", "invalid_type", "datasets must be a Dataset object or array")
+		return nil, &validationErr
+	}
+	dataset, validationErr := decodeStrictDataset(trimmed, "/datasets")
+	if validationErr != nil {
+		return nil, validationErr
+	}
+	return []shared.Dataset{dataset}, nil
+}
+
+func strictDecode(raw []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("must contain one JSON value")
+	}
+	return nil
+}

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -28,16 +28,6 @@ type unitOptions struct {
 	Number string `json:"number"`
 }
 
-type metadataOptions struct {
-	ID          string       `json:"id"`
-	Name        string       `json:"name"`
-	Theme       string       `json:"theme"`
-	Description string       `json:"description"`
-	Tag         string       `json:"tag"`
-	Timestamp   string       `json:"timestamp"`
-	Meta        *shared.Meta `json:"meta"`
-}
-
 type chartSelection struct {
 	Types   []string          `json:"types"`
 	Configs []json.RawMessage `json:"configs"`
@@ -51,7 +41,6 @@ type statisticsOptions struct {
 type convertRequest struct {
 	Input    json.RawMessage  `json:"input"`
 	Parser   string           `json:"parser"`
-	Metadata *metadataOptions `json:"metadata"`
 	Grouping *groupingOptions `json:"grouping"`
 	Units    *unitOptions     `json:"units"`
 	Select   []string         `json:"select"`
@@ -68,8 +57,8 @@ type mergeRequest struct {
 }
 
 type uiRequest struct {
-	Datasets   json.RawMessage   `json:"datasets"`
-	Charts     chartSelection    `json:"charts"`
+	Datasets   json.RawMessage    `json:"datasets"`
+	Charts     chartSelection     `json:"charts"`
 	Statistics *statisticsOptions `json:"statistics"`
 }
 
@@ -78,6 +67,10 @@ type apiValidationError struct {
 	Path     string `json:"path"`
 	Code     string `json:"code"`
 	Message  string `json:"message"`
+}
+
+func (e apiValidationError) Error() string {
+	return e.Message
 }
 
 func bodyValidationError(path, code, message string) apiValidationError {
@@ -103,33 +96,15 @@ func buildConvertInput(request convertRequest, input []byte) (core.ConvertInput,
 		return core.ConvertInput{}, nil, validationErr
 	}
 
-	metadata := core.Metadata{Name: "Comparisons", Theme: "default"}
-	if request.Metadata != nil {
-		if request.Metadata.Theme != "" {
-			if err := validateTheme(request.Metadata.Theme); err != nil {
-				validationErr := bodyValidationError("/metadata/theme", "invalid_value", err.Error())
-				return core.ConvertInput{}, nil, &validationErr
-			}
-		}
-		metadata = core.Metadata{
-			ID:          request.Metadata.ID,
-			Name:        request.Metadata.Name,
-			Theme:       request.Metadata.Theme,
-			Description: request.Metadata.Description,
-			Tag:         request.Metadata.Tag,
-			Timestamp:   request.Metadata.Timestamp,
-			System:      request.Metadata.Meta,
-		}
-		if metadata.Name == "" {
-			metadata.Name = "Comparisons"
-		}
-		if metadata.Theme == "" {
-			metadata.Theme = "default"
-		}
-	}
-
 	return core.ConvertInput{
-		Input: input, Parser: key, Config: cfg, Metadata: metadata, Charts: configs,
+		Input:  input,
+		Parser: key,
+		Config: cfg,
+		Metadata: core.Metadata{
+			Name:  "Comparisons",
+			Theme: "default",
+		},
+		Charts: configs,
 	}, types, nil
 }
 
@@ -203,6 +178,12 @@ func buildParserConfig(request convertRequest, key string) (parser.Config, *apiV
 	if err != nil {
 		validationErr := bodyValidationError("/grouping", "invalid_grouping", err.Error())
 		return cfg, &validationErr
+	}
+	if (key == "csv" || key == "json") && len(cfg.Group) > 0 {
+		if err := parser.ValidateTabularGroupAlignment(cfg); err != nil {
+			validationErr := bodyValidationError("/grouping", "invalid_grouping", err.Error())
+			return cfg, &validationErr
+		}
 	}
 	if validationErr := applySelectOptions(&cfg, request.Select); validationErr != nil {
 		return cfg, validationErr
@@ -342,7 +323,7 @@ func decodeChartConfig(raw json.RawMessage, path string) (internalcharts.ChartCo
 	var discriminator struct {
 		Type string `json:"type"`
 	}
-	if err := strictDecode(raw, &discriminator); err != nil {
+	if err := json.Unmarshal(raw, &discriminator); err != nil {
 		validationErr := bodyValidationError(path, "invalid_chart_config", err.Error())
 		return nil, &validationErr
 	}
@@ -521,18 +502,18 @@ func applyUIOptions(datasets []shared.Dataset, selection chartSelection, statist
 }
 
 type datasetWire struct {
-	ID           string            `json:"id"`
-	Tag          string            `json:"tag"`
-	Timestamp    string            `json:"timestamp"`
-	Name         *string           `json:"name"`
-	Theme        string            `json:"theme"`
-	History      []historyWire     `json:"history"`
-	Description  string            `json:"description"`
-	Meta         *shared.Meta      `json:"meta"`
-	Axes         *[]axisWire       `json:"axes"`
-	Settings     *[]json.RawMessage `json:"settings"`
+	ID           string              `json:"id"`
+	Tag          string              `json:"tag"`
+	Timestamp    string              `json:"timestamp"`
+	Name         *string             `json:"name"`
+	Theme        string              `json:"theme"`
+	History      []historyWire       `json:"history"`
+	Description  string              `json:"description"`
+	Meta         *shared.Meta        `json:"meta"`
+	Axes         *[]axisWire         `json:"axes"`
+	Settings     *[]json.RawMessage  `json:"settings"`
 	Data         *[]shared.DataPoint `json:"data"`
-	PreserveRows bool              `json:"preserveRows"`
+	PreserveRows bool                `json:"preserveRows"`
 }
 
 type historyWire struct {

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -262,11 +262,8 @@ func materialiseConversionCharts(selection chartSelection) ([]internalcharts.Cha
 	}
 	configs := make([]internalcharts.ChartConfig, 0, len(types))
 	for _, chartType := range types {
-		config, err := internalcharts.Materialise(chartType, nil, overrides[chartType])
-		if err != nil {
-			validationErr := bodyValidationError("/charts/configs", "invalid_chart_config", err.Error())
-			return nil, nil, &validationErr
-		}
+		// chartType and overrides are validated above, so Materialise cannot fail.
+		config, _ := internalcharts.Materialise(chartType, nil, overrides[chartType])
 		configs = append(configs, config)
 	}
 	return configs, types, nil
@@ -483,11 +480,8 @@ func applyUIOptions(datasets []shared.Dataset, selection chartSelection, statist
 			if stat != nil {
 				seed["stat"] = stat
 			}
-			config, err := internalcharts.Materialise(chartType, seed, override)
-			if err != nil {
-				validationErr := bodyValidationError("/charts/configs", "invalid_chart_config", err.Error())
-				return nil, nil, &validationErr
-			}
+			// chartType and override were validated before assembling the seed.
+			config, _ := internalcharts.Materialise(chartType, seed, override)
 			configs = append(configs, config)
 		}
 		result[i].Settings = configs

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -470,10 +470,7 @@ func applyUIOptions(datasets []shared.Dataset, selection chartSelection, statist
 		configs := make([]internalcharts.ChartConfig, 0, len(targetTypes))
 		for _, chartType := range targetTypes {
 			base, hasBase := existing[chartType]
-			override, hasOverride := overrides[chartType]
-			if !hasBase && !hasOverride {
-				continue
-			}
+			override := overrides[chartType]
 			seed := map[string]any{}
 			if hasBase {
 				raw, err := json.Marshal(base)
@@ -568,11 +565,18 @@ func decodeStrictDataset(raw json.RawMessage, path string) (shared.Dataset, *api
 	}
 
 	settings := make([]internalcharts.ChartConfig, 0, len(*wire.Settings))
+	settingTypes := make(map[string]bool, len(*wire.Settings))
 	for i, rawConfig := range *wire.Settings {
-		config, validationErr := decodeChartConfig(rawConfig, fmt.Sprintf("%s/settings/%d", path, i))
+		configPath := fmt.Sprintf("%s/settings/%d", path, i)
+		config, validationErr := decodeChartConfig(rawConfig, configPath)
 		if validationErr != nil {
 			return shared.Dataset{}, validationErr
 		}
+		if settingTypes[config.ChartType()] {
+			validationErr := bodyValidationError(configPath+"/type", "duplicate_value", "dataset setting types must be unique")
+			return shared.Dataset{}, &validationErr
+		}
+		settingTypes[config.ChartType()] = true
 		settings = append(settings, config)
 	}
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/goptics/vizb/cmd/cli"
 	"github.com/goptics/vizb/shared"
 	"github.com/stretchr/testify/suite"
 )
@@ -33,8 +34,8 @@ func (s *ServeSuite) SetupTest() {
 }
 
 func (s *ServeSuite) TestDefaultsAndHTTPPolicy() {
-	s.Equal(defaultServeHost, serveOpts.Host)
-	s.Equal(defaultServePort, serveOpts.Port)
+	s.Equal(defaultServeHost, serveBag.String("host"))
+	s.Equal(defaultServePort, serveBag.Int("port"))
 	s.NotNil(serveCmd.Flags().Lookup("host"))
 	s.NotNil(serveCmd.Flags().Lookup("port"))
 
@@ -92,9 +93,9 @@ func (s *ServeSuite) TestRoutesRegisterOnlyTheThreePOSTOperations() {
 }
 
 func (s *ServeSuite) TestInvalidConfigurationReturnsCommandError() {
-	options := serveOptions{Host: defaultServeHost, Port: defaultServePort}
+	bag := cli.NewFlagBag(serveFlags())
 	var listened atomic.Bool
-	command := newServeCommand(&options, serveDependencies{
+	command := newServeCommand(bag, serveDependencies{
 		newHandler: http.NotFoundHandler,
 		listen: func(string, string) (net.Listener, error) {
 			listened.Store(true)
@@ -406,6 +407,8 @@ func (s *ServeSuite) TestConvertEndpointReportsUIGenerationFailure() {
 	recorder := s.apiRequest(handler, "/", body, "application/json", "text/html")
 	s.Equal(http.StatusInternalServerError, recorder.Code)
 	s.Equal(float64(http.StatusInternalServerError), s.problemStatus(recorder))
+	s.NotContains(recorder.Body.String(), "template failed")
+	s.Contains(recorder.Body.String(), "could not generate the response")
 }
 
 func (s *ServeSuite) TestMergeEndpoint() {
@@ -430,6 +433,9 @@ func (s *ServeSuite) TestMergeEndpoint() {
 
 	recorder = s.apiRequest(handler, "/merge", `{"datasets":[`+firstMergeJSON[:len(firstMergeJSON)-1]+`,"extra":true},`+secondMergeJSON+`]}`, "application/json", "")
 	s.Equal(http.StatusBadRequest, recorder.Code)
+
+	recorder = s.apiRequest(handler, "/merge", `{"datasets":[`+firstMergeJSON+`,`+secondMergeJSON+`]}`, "application/json", "text/html")
+	s.Equal(http.StatusNotAcceptable, recorder.Code)
 }
 
 func (s *ServeSuite) TestUIEndpoint() {
@@ -478,6 +484,26 @@ func (s *ServeSuite) TestUIEndpointAcceptsConfigsStatisticsAndMediaRanges() {
 	s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
 }
 
+func (s *ServeSuite) TestUIEndpointMaterialisesDefaultsForSelectedChartTypes() {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleUIWithGenerator(w, r, func(datasets []shared.Dataset, charts []string) (string, error) {
+			s.Equal([]string{"line"}, charts)
+			s.Require().Len(datasets, 1)
+			s.Require().Len(datasets[0].Settings, 1)
+			s.Equal("line", datasets[0].Settings[0].ChartType())
+			raw, err := json.Marshal(datasets[0].Settings[0])
+			s.Require().NoError(err)
+			var config map[string]any
+			s.Require().NoError(json.Unmarshal(raw, &config))
+			s.Equal("linear", config["scale"])
+			return "<html>ok</html>", nil
+		})
+	})
+	body := `{"datasets":` + validDatasetJSON + `,"charts":{"types":["line"]}}`
+	recorder := s.apiRequest(handler, "/ui", body, "application/json", "text/html")
+	s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+}
+
 func (s *ServeSuite) TestUIEndpointValidatesDatasetsAndStatistics() {
 	handler := newRESTHandler()
 	tests := []struct {
@@ -493,6 +519,7 @@ func (s *ServeSuite) TestUIEndpointValidatesDatasetsAndStatistics() {
 		{name: "invalid axis key", datasets: `{"name":"Bench","axes":[{"key":"metric"}],"settings":[],"data":[]}`},
 		{name: "invalid axis type", datasets: `{"name":"Bench","axes":[{"key":"x","type":"category"}],"settings":[],"data":[]}`},
 		{name: "invalid setting", datasets: `{"name":"Bench","axes":[],"settings":[{"type":"unknown"}],"data":[]}`},
+		{name: "duplicate setting types", datasets: `{"name":"Bench","axes":[],"settings":[{"type":"bar"},{"type":"bar"}],"data":[]}`},
 		{name: "history missing tag", datasets: `{"name":"Bench","history":[{"timestamp":"now"}],"axes":[],"settings":[],"data":[]}`},
 		{name: "history missing timestamp", datasets: `{"name":"Bench","history":[{"tag":"v1"}],"axes":[],"settings":[],"data":[]}`},
 		{name: "invalid statistics", datasets: validDatasetJSON, suffix: `,"statistics":{"math":["bogus"]}`},
@@ -517,6 +544,8 @@ func (s *ServeSuite) TestUIEndpointReportsGenerationFailure() {
 	recorder := s.apiRequest(handler, "/ui", body, "application/json", "text/html")
 	s.Equal(http.StatusInternalServerError, recorder.Code)
 	s.Equal(float64(http.StatusInternalServerError), s.problemStatus(recorder))
+	s.NotContains(recorder.Body.String(), "template failed")
+	s.Contains(recorder.Body.String(), "could not generate the response")
 }
 
 func (s *ServeSuite) TestRequestHelpers() {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1,0 +1,164 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ServeSuite struct {
+	suite.Suite
+}
+
+func (s *ServeSuite) SetupTest() {
+	ResetTestState()
+}
+
+func (s *ServeSuite) TestDefaultsAndHTTPPolicy() {
+	s.Equal(defaultServeHost, serveOpts.Host)
+	s.Equal(defaultServePort, serveOpts.Port)
+	s.NotNil(serveCmd.Flags().Lookup("host"))
+	s.NotNil(serveCmd.Flags().Lookup("port"))
+
+	server := newHTTPServer("127.0.0.1:8080", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.ReadAll(r.Body)
+		s.Error(err)
+		var maxErr *http.MaxBytesError
+		s.True(errors.As(err, &maxErr))
+	}))
+	s.Equal(readHeaderTimeout, server.ReadHeaderTimeout)
+	s.Equal(readTimeout, server.ReadTimeout)
+	s.Equal(writeTimeout, server.WriteTimeout)
+	s.Equal(idleTimeout, server.IdleTimeout)
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(make([]byte, maxRequestBodyBytes+1)))
+	server.Handler.ServeHTTP(httptest.NewRecorder(), req)
+}
+
+func (s *ServeSuite) TestRoutesRegisterOnlyTheThreePOSTOperations() {
+	called := make(map[string]bool)
+	routes := composeRESTRoutes(restHandlers{
+		convert: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called["convert"] = true
+			w.WriteHeader(http.StatusNoContent)
+		}),
+		merge: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called["merge"] = true
+			w.WriteHeader(http.StatusNoContent)
+		}),
+		ui: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called["ui"] = true; w.WriteHeader(http.StatusNoContent) }),
+	})
+
+	for _, test := range []struct {
+		path string
+		name string
+	}{
+		{path: "/", name: "convert"},
+		{path: "/merge", name: "merge"},
+		{path: "/ui", name: "ui"},
+	} {
+		recorder := httptest.NewRecorder()
+		routes.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, test.path, nil))
+		s.Equal(http.StatusNoContent, recorder.Code, test.path)
+		s.True(called[test.name])
+	}
+
+	for _, request := range []*http.Request{
+		httptest.NewRequest(http.MethodGet, "/", nil),
+		httptest.NewRequest(http.MethodPost, "/unknown", nil),
+	} {
+		recorder := httptest.NewRecorder()
+		routes.ServeHTTP(recorder, request)
+		s.Contains([]int{http.StatusMethodNotAllowed, http.StatusNotFound}, recorder.Code)
+	}
+}
+
+func (s *ServeSuite) TestInvalidConfigurationReturnsCommandError() {
+	options := serveOptions{Host: defaultServeHost, Port: defaultServePort}
+	var listened atomic.Bool
+	command := newServeCommand(&options, serveDependencies{
+		newHandler: http.NotFoundHandler,
+		listen: func(string, string) (net.Listener, error) {
+			listened.Store(true)
+			return nil, errors.New("must not listen")
+		},
+		signalContext: directSignalContext,
+	})
+	command.SetArgs([]string{"--port", "0"})
+	err := command.Execute()
+	s.EqualError(err, "port must be between 1 and 65535")
+	s.False(listened.Load())
+}
+
+func (s *ServeSuite) TestListenerFailureReturnsCommandError() {
+	err := runServer(context.Background(), serveOptions{Host: defaultServeHost, Port: defaultServePort}, serveDependencies{
+		newHandler: http.NotFoundHandler,
+		listen: func(string, string) (net.Listener, error) {
+			return nil, errors.New("address already in use")
+		},
+	})
+	s.EqualError(err, "listen on 127.0.0.1:8080: address already in use")
+}
+
+func (s *ServeSuite) TestCancellationTriggersGracefulShutdown() {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	s.Require().NoError(err)
+	defer listener.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		result <- runServer(ctx, serveOptions{Host: defaultServeHost, Port: defaultServePort}, serveDependencies{
+			newHandler: http.NotFoundHandler,
+			listen:     func(string, string) (net.Listener, error) { return listener, nil },
+		})
+	}()
+
+	s.Eventually(func() bool {
+		connection, err := net.DialTimeout("tcp", listener.Addr().String(), time.Second)
+		if err != nil {
+			return false
+		}
+		_ = connection.Close()
+		return true
+	}, time.Second, 10*time.Millisecond)
+	cancel()
+	s.Require().NoError(<-result)
+}
+
+func (s *ServeSuite) TestServeAddress() {
+	for _, test := range []struct {
+		options serveOptions
+		want    string
+	}{
+		{options: serveOptions{Host: "", Port: 8080}, want: "host must not be empty"},
+		{options: serveOptions{Host: "127.0.0.1", Port: -1}, want: "port must be between 1 and 65535"},
+		{options: serveOptions{Host: "127.0.0.1", Port: 65536}, want: "port must be between 1 and 65535"},
+	} {
+		s.Run(test.want, func() {
+			_, err := serveAddress(test.options)
+			s.EqualError(err, test.want)
+		})
+	}
+	address, err := serveAddress(serveOptions{Host: "::1", Port: 8080})
+	s.Require().NoError(err)
+	s.Equal("[::1]:8080", address)
+}
+
+func directSignalContext(ctx context.Context, _ ...os.Signal) (context.Context, context.CancelFunc) {
+	return context.WithCancel(ctx)
+}
+
+func TestServeSuite(t *testing.T) {
+	suite.Run(t, new(ServeSuite))
+}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3,12 +3,14 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -110,6 +112,33 @@ func (s *ServeSuite) TestListenerFailureReturnsCommandError() {
 	s.EqualError(err, "listen on 127.0.0.1:8080: address already in use")
 }
 
+func (s *ServeSuite) TestServeFailureIsReturned() {
+	err := runServer(context.Background(), serveOptions{Host: defaultServeHost, Port: defaultServePort}, serveDependencies{
+		newHandler: http.NotFoundHandler,
+		listen: func(string, string) (net.Listener, error) {
+			return errorListener{err: errors.New("accept failed")}, nil
+		},
+	})
+	s.EqualError(err, "serve HTTP: accept failed")
+}
+
+func (s *ServeSuite) TestCancellationShutsDownInMemoryListener() {
+	listener := newBlockingListener()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- runServer(ctx, serveOptions{Host: defaultServeHost, Port: defaultServePort}, serveDependencies{
+			newHandler: http.NotFoundHandler,
+			listen:     func(string, string) (net.Listener, error) { return listener, nil },
+		})
+	}()
+	<-listener.acceptStarted
+	cancel()
+	s.Require().NoError(<-result)
+}
+
 func (s *ServeSuite) TestCancellationTriggersGracefulShutdown() {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	s.Require().NoError(err)
@@ -154,6 +183,179 @@ func (s *ServeSuite) TestServeAddress() {
 	s.Require().NoError(err)
 	s.Equal("[::1]:8080", address)
 }
+
+func (s *ServeSuite) TestConvertEndpoint() {
+	handler := newRESTHandler()
+	request := `{"input":"region,value\nwest,12\n","parser":"csv","charts":{"types":["bar"]}}`
+	recorder := s.apiRequest(handler, "/", request, "application/json", "application/json")
+	s.Equal(http.StatusOK, recorder.Code)
+	s.Contains(recorder.Header().Get("Content-Type"), "application/json")
+	var dataset map[string]any
+	s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &dataset))
+	s.Len(dataset["data"], 1)
+
+	recorder = s.apiRequest(handler, "/", request[:len(request)-1]+`,"output":{"format":"html"}}`, "application/json", "text/html")
+	s.Equal(http.StatusOK, recorder.Code)
+	s.Contains(recorder.Header().Get("Content-Type"), "text/html")
+	s.Contains(recorder.Body.String(), "VIZB_DATA")
+}
+
+func (s *ServeSuite) TestConvertEndpointRejectsInvalidRequests() {
+	handler := newRESTHandler()
+	for _, test := range []struct {
+		name        string
+		body        string
+		contentType string
+		accept      string
+		wantStatus  int
+	}{
+		{name: "missing input", body: `{}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
+		{name: "invalid input kind", body: `{"input":42}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
+		{name: "unknown chart", body: `{"input":"x,y\na,1\n","charts":{"types":["unknown"]}}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
+		{name: "unsupported parser", body: `{"input":"x,y\na,1\n","parser":"go"}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity},
+		{name: "html not accepted", body: `{"input":"x,y\na,1\n","output":{"format":"html"}}`, contentType: "application/json", accept: "application/json", wantStatus: http.StatusNotAcceptable},
+		{name: "invalid output format", body: `{"input":"x,y\na,1\n","output":{"format":"csv"}}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
+		{name: "unknown field", body: `{"input":"x,y\na,1\n","extra":true}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
+		{name: "wrong content type", body: `{}`, contentType: "text/plain", wantStatus: http.StatusUnsupportedMediaType},
+		{name: "multiple JSON values", body: `{} {}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
+	} {
+		s.Run(test.name, func() {
+			recorder := s.apiRequest(handler, "/", test.body, test.contentType, test.accept)
+			s.Equal(test.wantStatus, recorder.Code)
+			s.Contains(recorder.Header().Get("Content-Type"), "application/problem+json")
+			s.Equal(float64(test.wantStatus), s.problemStatus(recorder))
+		})
+	}
+}
+
+func (s *ServeSuite) TestMergeEndpoint() {
+	handler := newRESTHandler()
+	recorder := s.apiRequest(handler, "/merge", `{"datasets":[{"name":"one"}]}`, "application/json", "")
+	s.Equal(http.StatusBadRequest, recorder.Code)
+
+	recorder = s.apiRequest(handler, "/merge", `{"datasets":[{"name":"Bench","tag":"v1","data":[{"name":"case","yAxis":"1"}]},{"name":"Bench","tag":"v2","data":[{"name":"case","yAxis":"2"}]}],"tagAxis":"x"}`, "application/json", "")
+	s.Equal(http.StatusOK, recorder.Code)
+	var merged []map[string]any
+	s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &merged))
+	s.Len(merged, 1)
+
+	recorder = s.apiRequest(handler, "/merge", `{"datasets":[{"name":"one"},{"name":"two"}],"tagAxis":"invalid"}`, "application/json", "")
+	s.Equal(http.StatusUnprocessableEntity, recorder.Code)
+}
+
+func (s *ServeSuite) TestUIEndpoint() {
+	handler := newRESTHandler()
+	valid := `{"datasets":{"name":"Bench","data":[{"name":"case","yAxis":"1"}]}}`
+	recorder := s.apiRequest(handler, "/ui", valid, "application/json", "text/html")
+	s.Equal(http.StatusOK, recorder.Code)
+	s.Contains(recorder.Header().Get("Content-Type"), "text/html")
+	s.Contains(recorder.Body.String(), "VIZB_DATA")
+
+	for _, test := range []struct {
+		name       string
+		body       string
+		accept     string
+		wantStatus int
+	}{
+		{name: "not accepted", body: valid, accept: "application/json", wantStatus: http.StatusNotAcceptable},
+		{name: "missing datasets", body: `{}`, accept: "text/html", wantStatus: http.StatusBadRequest},
+		{name: "empty datasets", body: `{"datasets":[]}`, accept: "text/html", wantStatus: http.StatusBadRequest},
+		{name: "invalid datasets", body: `{"datasets":true}`, accept: "text/html", wantStatus: http.StatusBadRequest},
+	} {
+		s.Run(test.name, func() {
+			recorder := s.apiRequest(handler, "/ui", test.body, "application/json", test.accept)
+			s.Equal(test.wantStatus, recorder.Code)
+		})
+	}
+}
+
+func (s *ServeSuite) TestRequestHelpers() {
+	s.Equal([]byte("text"), s.inlineInput(`"text"`))
+	s.Equal([]byte(`{"value":1}`), s.inlineInput(`{"value":1}`))
+	_, err := inlineInput(json.RawMessage(`42`))
+	s.ErrorContains(err, "input must be")
+	_, err = inlineInput(nil)
+	s.ErrorContains(err, "input must be")
+
+	datasets, err := decodeDatasets(json.RawMessage(`{"name":"Bench"}`))
+	s.Require().NoError(err)
+	s.Len(datasets, 1)
+	_, err = decodeDatasets(nil)
+	s.ErrorContains(err, "datasets is required")
+
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	s.True(accepts(request, "text/html"))
+	request.Header.Set("Accept", "*/*")
+	s.True(accepts(request, "text/html"))
+	request.Header.Set("Accept", "application/json")
+	s.False(accepts(request, "text/html"))
+}
+
+func (s *ServeSuite) apiRequest(handler http.Handler, path, body, contentType, accept string) *httptest.ResponseRecorder {
+	s.T().Helper()
+	request := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(body))
+	if contentType != "" {
+		request.Header.Set("Content-Type", contentType)
+	}
+	if accept != "" {
+		request.Header.Set("Accept", accept)
+	}
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+	return recorder
+}
+
+func (s *ServeSuite) problemStatus(recorder *httptest.ResponseRecorder) float64 {
+	s.T().Helper()
+	var problem map[string]any
+	s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &problem))
+	return problem["status"].(float64)
+}
+
+func (s *ServeSuite) inlineInput(raw string) []byte {
+	s.T().Helper()
+	input, err := inlineInput(json.RawMessage(raw))
+	s.Require().NoError(err)
+	return input
+}
+
+type testAddr string
+
+func (a testAddr) Network() string { return "tcp" }
+func (a testAddr) String() string  { return string(a) }
+
+type errorListener struct{ err error }
+
+func (l errorListener) Accept() (net.Conn, error) { return nil, l.err }
+func (l errorListener) Close() error              { return nil }
+func (l errorListener) Addr() net.Addr            { return testAddr("in-memory") }
+
+type blockingListener struct {
+	acceptStarted chan struct{}
+	closed        chan struct{}
+	once          sync.Once
+}
+
+func newBlockingListener() *blockingListener {
+	return &blockingListener{acceptStarted: make(chan struct{}), closed: make(chan struct{})}
+}
+
+func (l *blockingListener) Accept() (net.Conn, error) {
+	select {
+	case <-l.acceptStarted:
+	default:
+		close(l.acceptStarted)
+	}
+	<-l.closed
+	return nil, net.ErrClosed
+}
+
+func (l *blockingListener) Close() error {
+	l.once.Do(func() { close(l.closed) })
+	return nil
+}
+
+func (l *blockingListener) Addr() net.Addr { return testAddr("in-memory") }
 
 func directSignalContext(ctx context.Context, _ ...os.Signal) (context.Context, context.CancelFunc) {
 	return context.WithCancel(ctx)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
+	"github.com/goptics/vizb/shared"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -122,6 +122,16 @@ func (s *ServeSuite) TestServeFailureIsReturned() {
 	s.EqualError(err, "serve HTTP: accept failed")
 }
 
+func (s *ServeSuite) TestServerClosedIsASuccessfulServeResult() {
+	err := runServer(context.Background(), serveOptions{Host: defaultServeHost, Port: defaultServePort}, serveDependencies{
+		newHandler: http.NotFoundHandler,
+		listen: func(string, string) (net.Listener, error) {
+			return errorListener{err: http.ErrServerClosed}, nil
+		},
+	})
+	s.NoError(err)
+}
+
 func (s *ServeSuite) TestCancellationShutsDownInMemoryListener() {
 	listener := newBlockingListener()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -140,29 +150,69 @@ func (s *ServeSuite) TestCancellationShutsDownInMemoryListener() {
 }
 
 func (s *ServeSuite) TestCancellationTriggersGracefulShutdown() {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	s.Require().NoError(err)
-	defer listener.Close()
-
+	listener := newBlockingListener()
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var shutdownCalled atomic.Bool
 	result := make(chan error, 1)
 	go func() {
 		result <- runServer(ctx, serveOptions{Host: defaultServeHost, Port: defaultServePort}, serveDependencies{
 			newHandler: http.NotFoundHandler,
 			listen:     func(string, string) (net.Listener, error) { return listener, nil },
+			shutdown: func(server *http.Server, ctx context.Context) error {
+				shutdownCalled.Store(true)
+				return server.Shutdown(ctx)
+			},
 		})
 	}()
 
-	s.Eventually(func() bool {
-		connection, err := net.DialTimeout("tcp", listener.Addr().String(), time.Second)
-		if err != nil {
-			return false
-		}
-		_ = connection.Close()
-		return true
-	}, time.Second, 10*time.Millisecond)
+	<-listener.acceptStarted
 	cancel()
 	s.Require().NoError(<-result)
+	s.True(shutdownCalled.Load())
+}
+
+func (s *ServeSuite) TestShutdownFailureIsReturned() {
+	listener := newBlockingListener()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- runServer(ctx, serveOptions{Host: defaultServeHost, Port: defaultServePort}, serveDependencies{
+			newHandler: http.NotFoundHandler,
+			listen:     func(string, string) (net.Listener, error) { return listener, nil },
+			shutdown: func(server *http.Server, _ context.Context) error {
+				_ = server.Close()
+				return errors.New("drain failed")
+			},
+		})
+	}()
+
+	<-listener.acceptStarted
+	cancel()
+	s.EqualError(<-result, "shutdown HTTP server: drain failed")
+}
+
+func (s *ServeSuite) TestServeFailureDuringShutdownIsReturned() {
+	listener := newBlockingErrorListener(errors.New("accept failed during shutdown"))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- runServer(ctx, serveOptions{Host: defaultServeHost, Port: defaultServePort}, serveDependencies{
+			newHandler: http.NotFoundHandler,
+			listen:     func(string, string) (net.Listener, error) { return listener, nil },
+			shutdown: func(*http.Server, context.Context) error {
+				return listener.Close()
+			},
+		})
+	}()
+
+	<-listener.acceptStarted
+	cancel()
+	s.EqualError(<-result, "serve HTTP: accept failed during shutdown")
 }
 
 func (s *ServeSuite) TestServeAddress() {
@@ -198,6 +248,12 @@ func (s *ServeSuite) TestConvertEndpoint() {
 	s.Equal(http.StatusOK, recorder.Code)
 	s.Contains(recorder.Header().Get("Content-Type"), "text/html")
 	s.Contains(recorder.Body.String(), "VIZB_DATA")
+
+	recorder = s.apiRequest(handler, "/", request[:len(request)-1]+`,"output":{"format":"dataset"}}`, "application/json", "application/json")
+	s.Equal(http.StatusOK, recorder.Code)
+
+	recorder = s.apiRequest(handler, "/", `{"input":[{"region":"west","value":12}],"charts":{"types":["bar"]}}`, "application/json", "")
+	s.Equal(http.StatusOK, recorder.Code)
 }
 
 func (s *ServeSuite) TestConvertEndpointRejectsInvalidRequests() {
@@ -210,6 +266,7 @@ func (s *ServeSuite) TestConvertEndpointRejectsInvalidRequests() {
 		wantStatus  int
 	}{
 		{name: "missing input", body: `{}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
+		{name: "null input", body: `{"input":null}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
 		{name: "invalid input kind", body: `{"input":42}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
 		{name: "unknown chart", body: `{"input":"x,y\na,1\n","charts":{"types":["unknown"]}}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
 		{name: "unsupported parser", body: `{"input":"x,y\na,1\n","parser":"go"}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity},
@@ -217,6 +274,7 @@ func (s *ServeSuite) TestConvertEndpointRejectsInvalidRequests() {
 		{name: "invalid output format", body: `{"input":"x,y\na,1\n","output":{"format":"csv"}}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
 		{name: "unknown field", body: `{"input":"x,y\na,1\n","extra":true}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
 		{name: "wrong content type", body: `{}`, contentType: "text/plain", wantStatus: http.StatusUnsupportedMediaType},
+		{name: "malformed content type", body: `{}`, contentType: `application/json; charset="`, wantStatus: http.StatusUnsupportedMediaType},
 		{name: "multiple JSON values", body: `{} {}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
 	} {
 		s.Run(test.name, func() {
@@ -228,9 +286,24 @@ func (s *ServeSuite) TestConvertEndpointRejectsInvalidRequests() {
 	}
 }
 
+func (s *ServeSuite) TestConvertEndpointReportsUIGenerationFailure() {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleConvertWithGenerator(w, r, func([]shared.Dataset, []string) (string, error) {
+			return "", errors.New("template failed")
+		})
+	})
+	body := `{"input":"region,value\nwest,12\n","parser":"csv","charts":{"types":["bar"]},"output":{"format":"html"}}`
+	recorder := s.apiRequest(handler, "/", body, "application/json", "text/html")
+	s.Equal(http.StatusInternalServerError, recorder.Code)
+	s.Equal(float64(http.StatusInternalServerError), s.problemStatus(recorder))
+}
+
 func (s *ServeSuite) TestMergeEndpoint() {
 	handler := newRESTHandler()
-	recorder := s.apiRequest(handler, "/merge", `{"datasets":[{"name":"one"}]}`, "application/json", "")
+	recorder := s.apiRequest(handler, "/merge", `{`, "application/json", "")
+	s.Equal(http.StatusBadRequest, recorder.Code)
+
+	recorder = s.apiRequest(handler, "/merge", `{"datasets":[{"name":"one"}]}`, "application/json", "")
 	s.Equal(http.StatusBadRequest, recorder.Code)
 
 	recorder = s.apiRequest(handler, "/merge", `{"datasets":[{"name":"Bench","tag":"v1","data":[{"name":"case","yAxis":"1"}]},{"name":"Bench","tag":"v2","data":[{"name":"case","yAxis":"2"}]}],"tagAxis":"x"}`, "application/json", "")
@@ -257,6 +330,7 @@ func (s *ServeSuite) TestUIEndpoint() {
 		accept     string
 		wantStatus int
 	}{
+		{name: "invalid request", body: `{`, accept: "text/html", wantStatus: http.StatusBadRequest},
 		{name: "not accepted", body: valid, accept: "application/json", wantStatus: http.StatusNotAcceptable},
 		{name: "missing datasets", body: `{}`, accept: "text/html", wantStatus: http.StatusBadRequest},
 		{name: "empty datasets", body: `{"datasets":[]}`, accept: "text/html", wantStatus: http.StatusBadRequest},
@@ -269,9 +343,22 @@ func (s *ServeSuite) TestUIEndpoint() {
 	}
 }
 
+func (s *ServeSuite) TestUIEndpointReportsGenerationFailure() {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleUIWithGenerator(w, r, func([]shared.Dataset, []string) (string, error) {
+			return "", errors.New("template failed")
+		})
+	})
+	body := `{"datasets":{"name":"Bench","data":[{"name":"case","yAxis":"1"}]}}`
+	recorder := s.apiRequest(handler, "/ui", body, "application/json", "text/html")
+	s.Equal(http.StatusUnprocessableEntity, recorder.Code)
+	s.Equal(float64(http.StatusUnprocessableEntity), s.problemStatus(recorder))
+}
+
 func (s *ServeSuite) TestRequestHelpers() {
 	s.Equal([]byte("text"), s.inlineInput(`"text"`))
 	s.Equal([]byte(`{"value":1}`), s.inlineInput(`{"value":1}`))
+	s.Equal([]byte(`[{"value":1}]`), s.inlineInput(`[{"value":1}]`))
 	_, err := inlineInput(json.RawMessage(`42`))
 	s.ErrorContains(err, "input must be")
 	_, err = inlineInput(nil)
@@ -280,6 +367,11 @@ func (s *ServeSuite) TestRequestHelpers() {
 	datasets, err := decodeDatasets(json.RawMessage(`{"name":"Bench"}`))
 	s.Require().NoError(err)
 	s.Len(datasets, 1)
+	datasets, err = decodeDatasets(json.RawMessage(`[{"name":"One"},{"name":"Two"}]`))
+	s.Require().NoError(err)
+	s.Len(datasets, 2)
+	_, err = decodeDatasets(json.RawMessage(`[invalid]`))
+	s.Error(err)
 	_, err = decodeDatasets(nil)
 	s.ErrorContains(err, "datasets is required")
 
@@ -334,10 +426,19 @@ type blockingListener struct {
 	acceptStarted chan struct{}
 	closed        chan struct{}
 	once          sync.Once
+	acceptErr     error
 }
 
 func newBlockingListener() *blockingListener {
-	return &blockingListener{acceptStarted: make(chan struct{}), closed: make(chan struct{})}
+	return newBlockingErrorListener(net.ErrClosed)
+}
+
+func newBlockingErrorListener(err error) *blockingListener {
+	return &blockingListener{
+		acceptStarted: make(chan struct{}),
+		closed:        make(chan struct{}),
+		acceptErr:     err,
+	}
 }
 
 func (l *blockingListener) Accept() (net.Conn, error) {
@@ -347,7 +448,7 @@ func (l *blockingListener) Accept() (net.Conn, error) {
 		close(l.acceptStarted)
 	}
 	<-l.closed
-	return nil, net.ErrClosed
+	return nil, l.acceptErr
 }
 
 func (l *blockingListener) Close() error {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -22,6 +22,12 @@ type ServeSuite struct {
 	suite.Suite
 }
 
+const (
+	validDatasetJSON = `{"name":"Bench","axes":[{"key":"name"},{"key":"y"}],"settings":[{"type":"bar"}],"data":[{"name":"case","yAxis":"1"}]}`
+	firstMergeJSON   = `{"name":"Bench","tag":"v1","axes":[{"key":"name"},{"key":"y"}],"settings":[{"type":"bar"}],"data":[{"name":"case","yAxis":"1"}]}`
+	secondMergeJSON  = `{"name":"Bench","tag":"v2","axes":[{"key":"name"},{"key":"y"}],"settings":[{"type":"bar"}],"data":[{"name":"case","yAxis":"2"}]}`
+)
+
 func (s *ServeSuite) SetupTest() {
 	ResetTestState()
 }
@@ -254,6 +260,45 @@ func (s *ServeSuite) TestConvertEndpoint() {
 
 	recorder = s.apiRequest(handler, "/", `{"input":[{"region":"west","value":12}],"charts":{"types":["bar"]}}`, "application/json", "")
 	s.Equal(http.StatusOK, recorder.Code)
+
+	documented := `{
+		"input":{"data":[{"region":"west","latency":12},{"region":"east","latency":18}]},
+		"parser":"auto",
+		"grouping":{"pattern":"x","columns":["region"]},
+		"units":{"memory":"KB","time":"ms","number":"K"},
+		"select":["latency"],
+		"jsonPath":".data",
+		"charts":{"types":["bar"],"configs":[{"type":"bar","showLabels":true}]},
+		"output":{"format":"dataset"}
+	}`
+	recorder = s.apiRequest(handler, "/", documented, "application/json", "application/json")
+	s.Equal(http.StatusOK, recorder.Code)
+	s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &dataset))
+	s.Equal("Comparisons", dataset["name"])
+}
+
+func (s *ServeSuite) TestConvertEndpointSupportsBenchmarkFamilies() {
+	handler := newRESTHandler()
+	for _, test := range []struct {
+		name   string
+		parser string
+		input  string
+	}{
+		{name: "go", parser: "go", input: "BenchmarkFoo-8 100 123 ns/op\n"},
+		{name: "javascript", parser: "javascript", input: " · foo 1234 0.1 0.2 0.3 0.4 0.5 0.6 0.7 ±1.5% 100\n"},
+		{name: "rust", parser: "rust", input: "foo time: [21.234 ns 21.456 ns 21.678 ns]\n"},
+	} {
+		s.Run(test.name, func() {
+			body, err := json.Marshal(map[string]any{
+				"input":  test.input,
+				"parser": test.parser,
+				"charts": map[string]any{"types": []string{"bar"}},
+			})
+			s.Require().NoError(err)
+			recorder := s.apiRequest(handler, "/", string(body), "application/json", "application/json")
+			s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+		})
+	}
 }
 
 func (s *ServeSuite) TestConvertEndpointRejectsInvalidRequests() {
@@ -271,8 +316,11 @@ func (s *ServeSuite) TestConvertEndpointRejectsInvalidRequests() {
 		{name: "unknown chart", body: `{"input":"x,y\na,1\n","charts":{"types":["unknown"]}}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
 		{name: "unsupported parser", body: `{"input":"x,y\na,1\n","parser":"go"}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity},
 		{name: "html not accepted", body: `{"input":"x,y\na,1\n","output":{"format":"html"}}`, contentType: "application/json", accept: "application/json", wantStatus: http.StatusNotAcceptable},
+		{name: "dataset not accepted", body: `{"input":"x,y\na,1\n"}`, contentType: "application/json", accept: "text/html", wantStatus: http.StatusNotAcceptable},
 		{name: "invalid output format", body: `{"input":"x,y\na,1\n","output":{"format":"csv"}}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
+		{name: "metadata is not supported", body: `{"input":"x,y\na,1\n","metadata":{"name":"example"}}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
 		{name: "unknown field", body: `{"input":"x,y\na,1\n","extra":true}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
+		{name: "missing content type", body: `{}`, wantStatus: http.StatusUnsupportedMediaType},
 		{name: "wrong content type", body: `{}`, contentType: "text/plain", wantStatus: http.StatusUnsupportedMediaType},
 		{name: "malformed content type", body: `{}`, contentType: `application/json; charset="`, wantStatus: http.StatusUnsupportedMediaType},
 		{name: "multiple JSON values", body: `{} {}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
@@ -282,6 +330,68 @@ func (s *ServeSuite) TestConvertEndpointRejectsInvalidRequests() {
 			s.Equal(test.wantStatus, recorder.Code)
 			s.Contains(recorder.Header().Get("Content-Type"), "application/problem+json")
 			s.Equal(float64(test.wantStatus), s.problemStatus(recorder))
+			if test.wantStatus == http.StatusBadRequest {
+				var problem struct {
+					Errors []apiValidationError `json:"errors"`
+				}
+				s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &problem))
+				s.NotEmpty(problem.Errors)
+			}
+		})
+	}
+}
+
+func (s *ServeSuite) TestConvertEndpointValidatesStructuredOptions() {
+	handler := newRESTHandler()
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "invalid parser", body: `{"input":"x,y\na,1\n","parser":"xml"}`},
+		{name: "invalid group pattern", body: `{"input":"x,y\na,1\n","parser":"csv","grouping":{"pattern":"["}}`},
+		{name: "empty group column", body: `{"input":"x,y\na,1\n","parser":"csv","grouping":{"pattern":"x","columns":[""]}}`},
+		{name: "invalid group regex", body: `{"input":"x,y\na,1\n","grouping":{"regex":"["}}`},
+		{name: "invalid filter regex", body: `{"input":"x,y\na,1\n","grouping":{"filter":"["}}`},
+		{name: "misaligned grouping", body: `{"input":"a,b,c\nx,y,1\n","parser":"csv","grouping":{"pattern":"x/y","columns":["a","b"]}}`},
+		{name: "invalid memory unit", body: `{"input":"x,y\na,1\n","units":{"memory":"TB"}}`},
+		{name: "invalid time unit", body: `{"input":"x,y\na,1\n","units":{"time":"minute"}}`},
+		{name: "invalid number unit", body: `{"input":"x,y\na,1\n","units":{"number":"Q"}}`},
+		{name: "json path with csv", body: `{"input":"x,y\na,1\n","parser":"csv","jsonPath":".data"}`},
+		{name: "select with benchmark", body: `{"input":"BenchmarkFoo 100 1 ns/op\n","parser":"go","select":["x,y"]}`},
+		{name: "empty select", body: `{"input":"x,y\na,1\n","select":[""]}`},
+		{name: "invalid solo select", body: `{"input":"x,y\na,1\n","select":["x"]}`},
+		{name: "invalid repeatable select", body: `{"input":"a,b,c\n1,2,3\n","select":["a,b,c","a,b"]}`},
+		{name: "duplicate grouped select", body: `{"input":"region,value\nwest,1\n","parser":"csv","grouping":{"pattern":"x","columns":["region"]},"select":["value","value"]}`},
+		{name: "group select conflict", body: `{"input":"region,value\nwest,1\n","parser":"csv","grouping":{"pattern":"x","columns":["region"]},"select":["region"]}`},
+		{name: "empty chart types", body: `{"input":"x,y\na,1\n","charts":{"types":[]}}`},
+		{name: "duplicate chart types", body: `{"input":"x,y\na,1\n","charts":{"types":["bar","bar"]}}`},
+		{name: "missing config type", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"showLabels":true}]}}`},
+		{name: "unknown config type", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"unknown"}]}}`},
+		{name: "duplicate configs", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar"},{"type":"bar"}]}}`},
+		{name: "unselected config", body: `{"input":"x,y\na,1\n","charts":{"types":["bar"],"configs":[{"type":"line"}]}}`},
+		{name: "unknown config field", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","bogus":true}]}}`},
+		{name: "invalid scale", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","scale":"square"}]}}`},
+		{name: "invalid symbol size", body: `{"input":"x,y\na,1\n","charts":{"types":["line"],"configs":[{"type":"line","symbolSize":0}]}}`},
+		{name: "sort not object", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","sort":true}]}}`},
+		{name: "sort missing enabled", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","sort":{"order":"asc"}}]}}`},
+		{name: "sort missing order", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","sort":{"enabled":true}}]}}`},
+		{name: "sort invalid order", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","sort":{"enabled":true,"order":"sideways"}}]}}`},
+		{name: "stat not object", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","stat":true}]}}`},
+		{name: "stat missing enabled", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","stat":{"math":[]}}]}}`},
+		{name: "stat missing math", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","stat":{"enabled":true}}]}}`},
+		{name: "stat invalid math", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","stat":{"enabled":true,"math":["bogus"]}}]}}`},
+		{name: "stat duplicate math", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","stat":{"enabled":true,"math":["counts","counts"]}}]}}`},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			recorder := s.apiRequest(handler, "/", test.body, "application/json", "application/json")
+			s.Equal(http.StatusBadRequest, recorder.Code, recorder.Body.String())
+			var problem struct {
+				Errors []apiValidationError `json:"errors"`
+			}
+			s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &problem))
+			s.NotEmpty(problem.Errors)
 		})
 	}
 }
@@ -306,19 +416,25 @@ func (s *ServeSuite) TestMergeEndpoint() {
 	recorder = s.apiRequest(handler, "/merge", `{"datasets":[{"name":"one"}]}`, "application/json", "")
 	s.Equal(http.StatusBadRequest, recorder.Code)
 
-	recorder = s.apiRequest(handler, "/merge", `{"datasets":[{"name":"Bench","tag":"v1","data":[{"name":"case","yAxis":"1"}]},{"name":"Bench","tag":"v2","data":[{"name":"case","yAxis":"2"}]}],"tagAxis":"x"}`, "application/json", "")
+	recorder = s.apiRequest(handler, "/merge", `{"datasets":[`+firstMergeJSON+`,`+secondMergeJSON+`],"tagAxis":"x"}`, "application/json", "")
 	s.Equal(http.StatusOK, recorder.Code)
 	var merged []map[string]any
 	s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &merged))
 	s.Len(merged, 1)
 
-	recorder = s.apiRequest(handler, "/merge", `{"datasets":[{"name":"one"},{"name":"two"}],"tagAxis":"invalid"}`, "application/json", "")
-	s.Equal(http.StatusUnprocessableEntity, recorder.Code)
+	recorder = s.apiRequest(handler, "/merge", `{"datasets":[`+firstMergeJSON+`,`+secondMergeJSON+`],"tagAxis":"invalid"}`, "application/json", "")
+	s.Equal(http.StatusBadRequest, recorder.Code)
+
+	recorder = s.apiRequest(handler, "/merge", `{"datasets":[{"name":"one"},{"name":"two"}]}`, "application/json", "")
+	s.Equal(http.StatusBadRequest, recorder.Code)
+
+	recorder = s.apiRequest(handler, "/merge", `{"datasets":[`+firstMergeJSON[:len(firstMergeJSON)-1]+`,"extra":true},`+secondMergeJSON+`]}`, "application/json", "")
+	s.Equal(http.StatusBadRequest, recorder.Code)
 }
 
 func (s *ServeSuite) TestUIEndpoint() {
 	handler := newRESTHandler()
-	valid := `{"datasets":{"name":"Bench","data":[{"name":"case","yAxis":"1"}]}}`
+	valid := `{"datasets":` + validDatasetJSON + `}`
 	recorder := s.apiRequest(handler, "/ui", valid, "application/json", "text/html")
 	s.Equal(http.StatusOK, recorder.Code)
 	s.Contains(recorder.Header().Get("Content-Type"), "text/html")
@@ -335,10 +451,58 @@ func (s *ServeSuite) TestUIEndpoint() {
 		{name: "missing datasets", body: `{}`, accept: "text/html", wantStatus: http.StatusBadRequest},
 		{name: "empty datasets", body: `{"datasets":[]}`, accept: "text/html", wantStatus: http.StatusBadRequest},
 		{name: "invalid datasets", body: `{"datasets":true}`, accept: "text/html", wantStatus: http.StatusBadRequest},
+		{name: "incomplete dataset", body: `{"datasets":{"name":"Bench"}}`, accept: "text/html", wantStatus: http.StatusBadRequest},
+		{name: "unknown nested field", body: `{"datasets":` + validDatasetJSON[:len(validDatasetJSON)-1] + `,"extra":true}}`, accept: "text/html", wantStatus: http.StatusBadRequest},
+		{name: "invalid chart type", body: `{"datasets":` + validDatasetJSON + `,"charts":{"types":["unknown"]}}`, accept: "text/html", wantStatus: http.StatusBadRequest},
 	} {
 		s.Run(test.name, func() {
 			recorder := s.apiRequest(handler, "/ui", test.body, "application/json", test.accept)
 			s.Equal(test.wantStatus, recorder.Code)
+		})
+	}
+}
+
+func (s *ServeSuite) TestUIEndpointAcceptsConfigsStatisticsAndMediaRanges() {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleUIWithGenerator(w, r, func(datasets []shared.Dataset, charts []string) (string, error) {
+			s.Equal([]string{"bar"}, charts)
+			s.Require().Len(datasets, 1)
+			s.Require().Len(datasets[0].Settings, 1)
+			s.True(datasets[0].Settings[0].StatEnabled())
+			s.Equal([]string{"counts"}, datasets[0].Settings[0].StatMath())
+			return "<html>ok</html>", nil
+		})
+	})
+	body := `{"datasets":` + validDatasetJSON + `,"charts":{"types":["bar"],"configs":[{"type":"bar","showLabels":true}]},"statistics":{"enabled":true,"math":["counts"]}}`
+	recorder := s.apiRequest(handler, "/ui", body, "application/json", "text/html;q=0.9,application/xhtml+xml")
+	s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+}
+
+func (s *ServeSuite) TestUIEndpointValidatesDatasetsAndStatistics() {
+	handler := newRESTHandler()
+	tests := []struct {
+		name     string
+		datasets string
+		suffix   string
+	}{
+		{name: "missing name", datasets: `{"axes":[],"settings":[],"data":[]}`},
+		{name: "missing axes", datasets: `{"name":"Bench","settings":[],"data":[]}`},
+		{name: "missing settings", datasets: `{"name":"Bench","axes":[],"data":[]}`},
+		{name: "missing data", datasets: `{"name":"Bench","axes":[],"settings":[]}`},
+		{name: "axis missing key", datasets: `{"name":"Bench","axes":[{}],"settings":[],"data":[]}`},
+		{name: "invalid axis key", datasets: `{"name":"Bench","axes":[{"key":"metric"}],"settings":[],"data":[]}`},
+		{name: "invalid axis type", datasets: `{"name":"Bench","axes":[{"key":"x","type":"category"}],"settings":[],"data":[]}`},
+		{name: "invalid setting", datasets: `{"name":"Bench","axes":[],"settings":[{"type":"unknown"}],"data":[]}`},
+		{name: "history missing tag", datasets: `{"name":"Bench","history":[{"timestamp":"now"}],"axes":[],"settings":[],"data":[]}`},
+		{name: "history missing timestamp", datasets: `{"name":"Bench","history":[{"tag":"v1"}],"axes":[],"settings":[],"data":[]}`},
+		{name: "invalid statistics", datasets: validDatasetJSON, suffix: `,"statistics":{"math":["bogus"]}`},
+		{name: "duplicate statistics", datasets: validDatasetJSON, suffix: `,"statistics":{"math":["counts","counts"]}`},
+	}
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			body := `{"datasets":` + test.datasets + test.suffix + `}`
+			recorder := s.apiRequest(handler, "/ui", body, "application/json", "text/html")
+			s.Equal(http.StatusBadRequest, recorder.Code, recorder.Body.String())
 		})
 	}
 }
@@ -349,10 +513,10 @@ func (s *ServeSuite) TestUIEndpointReportsGenerationFailure() {
 			return "", errors.New("template failed")
 		})
 	})
-	body := `{"datasets":{"name":"Bench","data":[{"name":"case","yAxis":"1"}]}}`
+	body := `{"datasets":` + validDatasetJSON + `}`
 	recorder := s.apiRequest(handler, "/ui", body, "application/json", "text/html")
-	s.Equal(http.StatusUnprocessableEntity, recorder.Code)
-	s.Equal(float64(http.StatusUnprocessableEntity), s.problemStatus(recorder))
+	s.Equal(http.StatusInternalServerError, recorder.Code)
+	s.Equal(float64(http.StatusInternalServerError), s.problemStatus(recorder))
 }
 
 func (s *ServeSuite) TestRequestHelpers() {
@@ -364,16 +528,16 @@ func (s *ServeSuite) TestRequestHelpers() {
 	_, err = inlineInput(nil)
 	s.ErrorContains(err, "input must be")
 
-	datasets, err := decodeDatasets(json.RawMessage(`{"name":"Bench"}`))
-	s.Require().NoError(err)
+	datasets, validationErr := decodeDatasets(json.RawMessage(validDatasetJSON))
+	s.Nil(validationErr)
 	s.Len(datasets, 1)
-	datasets, err = decodeDatasets(json.RawMessage(`[{"name":"One"},{"name":"Two"}]`))
-	s.Require().NoError(err)
+	datasets, validationErr = decodeDatasets(json.RawMessage(`[` + validDatasetJSON + `,` + validDatasetJSON + `]`))
+	s.Nil(validationErr)
 	s.Len(datasets, 2)
-	_, err = decodeDatasets(json.RawMessage(`[invalid]`))
-	s.Error(err)
-	_, err = decodeDatasets(nil)
-	s.ErrorContains(err, "datasets is required")
+	_, validationErr = decodeDatasets(json.RawMessage(`[invalid]`))
+	s.NotNil(validationErr)
+	_, validationErr = decodeDatasets(nil)
+	s.ErrorContains(validationErr, "datasets is required")
 
 	request := httptest.NewRequest(http.MethodPost, "/", nil)
 	s.True(accepts(request, "text/html"))
@@ -381,6 +545,22 @@ func (s *ServeSuite) TestRequestHelpers() {
 	s.True(accepts(request, "text/html"))
 	request.Header.Set("Accept", "application/json")
 	s.False(accepts(request, "text/html"))
+	request.Header.Set("Accept", "text/html,application/xhtml+xml")
+	s.True(accepts(request, "text/html"))
+	request.Header.Set("Accept", "text/*;q=0.8")
+	s.True(accepts(request, "text/html"))
+	request.Header.Set("Accept", "text/html;q=0,*/*;q=1")
+	s.False(accepts(request, "text/html"))
+	request.Header.Set("Accept", "text/html;q=bogus")
+	s.False(accepts(request, "text/html"))
+	request.Header.Set("Accept", "text/html;q=2")
+	s.False(accepts(request, "text/html"))
+	request.Header.Set("Accept", "not a media range")
+	s.False(accepts(request, "text/html"))
+	s.False(accepts(request, "invalid"))
+
+	var target map[string]any
+	s.Error(strictDecode([]byte(`{} {}`), &target))
 }
 
 func (s *ServeSuite) apiRequest(handler http.Handler, path, body, contentType, accept string) *httptest.ResponseRecorder {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -10,11 +10,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/goptics/vizb/cmd/cli"
+	internalcharts "github.com/goptics/vizb/internal/charts"
+	"github.com/goptics/vizb/pkg/parser"
 	"github.com/goptics/vizb/shared"
 	"github.com/stretchr/testify/suite"
 )
@@ -39,19 +43,35 @@ func (s *ServeSuite) TestDefaultsAndHTTPPolicy() {
 	s.NotNil(serveCmd.Flags().Lookup("host"))
 	s.NotNil(serveCmd.Flags().Lookup("port"))
 
+	var applicationCalled atomic.Bool
 	server := newHTTPServer("127.0.0.1:8080", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := io.ReadAll(r.Body)
-		s.Error(err)
-		var maxErr *http.MaxBytesError
-		s.True(errors.As(err, &maxErr))
+		var request convertRequest
+		if !decodeAPIRequest(w, r, &request) {
+			return
+		}
+		applicationCalled.Store(true)
 	}))
 	s.Equal(readHeaderTimeout, server.ReadHeaderTimeout)
 	s.Equal(readTimeout, server.ReadTimeout)
 	s.Equal(writeTimeout, server.WriteTimeout)
 	s.Equal(idleTimeout, server.IdleTimeout)
 
-	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(make([]byte, maxRequestBodyBytes+1)))
-	server.Handler.ServeHTTP(httptest.NewRecorder(), req)
+	body := append([]byte(`{"input":"`), bytes.Repeat([]byte("a"), maxRequestBodyBytes)...)
+	body = append(body, '"', '}')
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	server.Handler.ServeHTTP(recorder, req)
+	s.Equal(http.StatusRequestEntityTooLarge, recorder.Code)
+	s.Equal("application/problem+json", recorder.Header().Get("Content-Type"))
+	s.JSONEq(`{
+		"type":"https://vizb.goptics.org/problems/content-too-large",
+		"title":"Content too large",
+		"status":413,
+		"detail":"Request body must not exceed 10485760 bytes.",
+		"instance":"/"
+	}`, recorder.Body.String())
+	s.False(applicationCalled.Load())
 }
 
 func (s *ServeSuite) TestRoutesRegisterOnlyTheThreePOSTOperations() {
@@ -82,13 +102,47 @@ func (s *ServeSuite) TestRoutesRegisterOnlyTheThreePOSTOperations() {
 		s.True(called[test.name])
 	}
 
-	for _, request := range []*http.Request{
-		httptest.NewRequest(http.MethodGet, "/", nil),
-		httptest.NewRequest(http.MethodPost, "/unknown", nil),
+	for _, test := range []struct {
+		name    string
+		request *http.Request
+		status  int
+		allow   string
+		body    string
+	}{
+		{
+			name:    "wrong method",
+			request: httptest.NewRequest(http.MethodGet, "/", nil),
+			status:  http.StatusMethodNotAllowed,
+			allow:   http.MethodPost,
+			body: `{
+				"type":"https://vizb.goptics.org/problems/method-not-allowed",
+				"title":"Method not allowed",
+				"status":405,
+				"detail":"This operation only supports POST.",
+				"instance":"/"
+			}`,
+		},
+		{
+			name:    "unknown path",
+			request: httptest.NewRequest(http.MethodPost, "/unknown", nil),
+			status:  http.StatusNotFound,
+			body: `{
+				"type":"https://vizb.goptics.org/problems/not-found",
+				"title":"Not found",
+				"status":404,
+				"detail":"The requested operation does not exist.",
+				"instance":"/unknown"
+			}`,
+		},
 	} {
-		recorder := httptest.NewRecorder()
-		routes.ServeHTTP(recorder, request)
-		s.Contains([]int{http.StatusMethodNotAllowed, http.StatusNotFound}, recorder.Code)
+		s.Run(test.name, func() {
+			recorder := httptest.NewRecorder()
+			routes.ServeHTTP(recorder, test.request)
+			s.Equal(test.status, recorder.Code)
+			s.Equal("application/problem+json", recorder.Header().Get("Content-Type"))
+			s.Equal(test.allow, recorder.Header().Get("Allow"))
+			s.JSONEq(test.body, recorder.Body.String())
+		})
 	}
 }
 
@@ -201,6 +255,95 @@ func (s *ServeSuite) TestShutdownFailureIsReturned() {
 	s.EqualError(<-result, "shutdown HTTP server: drain failed")
 }
 
+func (s *ServeSuite) TestShutdownFailurePreservesCloseFailure() {
+	listener := closeErrorListener{
+		blockingListener: newBlockingListener(),
+		err:              errors.New("close failed"),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	drainErr := errors.New("drain failed")
+	result := make(chan error, 1)
+	go func() {
+		result <- runServer(ctx, serveOptions{Host: defaultServeHost, Port: defaultServePort}, serveDependencies{
+			newHandler: http.NotFoundHandler,
+			listen:     func(string, string) (net.Listener, error) { return listener, nil },
+			shutdown:   func(*http.Server, context.Context) error { return drainErr },
+		})
+	}()
+
+	<-listener.acceptStarted
+	cancel()
+	err := <-result
+	s.ErrorIs(err, drainErr)
+	s.ErrorContains(err, "close HTTP server: close failed")
+}
+
+func (s *ServeSuite) TestShutdownDeadlineForceClosesActiveConnections() {
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+	listener := newSingleConnectionListener(serverConn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	handlerFinished := make(chan struct{})
+	result := make(chan error, 1)
+	go func() {
+		result <- runServer(ctx, serveOptions{Host: defaultServeHost, Port: defaultServePort}, serveDependencies{
+			newHandler: func() http.Handler {
+				return http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+					defer close(handlerFinished)
+					close(requestStarted)
+					<-releaseRequest
+				})
+			},
+			listen: func(string, string) (net.Listener, error) { return listener, nil },
+			shutdown: func(server *http.Server, parent context.Context) error {
+				deadline, cancel := context.WithTimeout(parent, 20*time.Millisecond)
+				defer cancel()
+				return server.Shutdown(deadline)
+			},
+		})
+	}()
+
+	clientResult := make(chan struct {
+		response []byte
+		err      error
+	}, 1)
+	go func() {
+		_, err := io.WriteString(clientConn, "POST / HTTP/1.1\r\nHost: vizb\r\nContent-Length: 2\r\n\r\n{}")
+		if err != nil {
+			clientResult <- struct {
+				response []byte
+				err      error
+			}{err: err}
+			return
+		}
+		response, err := io.ReadAll(clientConn)
+		clientResult <- struct {
+			response []byte
+			err      error
+		}{response: response, err: err}
+	}()
+	<-requestStarted
+	cancel()
+	s.EqualError(<-result, "shutdown HTTP server: context deadline exceeded")
+	select {
+	case client := <-clientResult:
+		s.NoError(client.err)
+		s.Empty(client.response)
+	case <-time.After(time.Second):
+		s.Fail("active client connection was not force-closed")
+	}
+	close(releaseRequest)
+	select {
+	case <-handlerFinished:
+	case <-time.After(time.Second):
+		s.Fail("active request handler did not finish")
+	}
+}
+
 func (s *ServeSuite) TestServeFailureDuringShutdownIsReturned() {
 	listener := newBlockingErrorListener(errors.New("accept failed during shutdown"))
 	ctx, cancel := context.WithCancel(context.Background())
@@ -310,28 +453,29 @@ func (s *ServeSuite) TestConvertEndpointRejectsInvalidRequests() {
 		contentType string
 		accept      string
 		wantStatus  int
+		wantErrors  bool
 	}{
-		{name: "missing input", body: `{}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
-		{name: "null input", body: `{"input":null}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
-		{name: "invalid input kind", body: `{"input":42}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
-		{name: "unknown chart", body: `{"input":"x,y\na,1\n","charts":{"types":["unknown"]}}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
+		{name: "missing input", body: `{}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true},
+		{name: "null input", body: `{"input":null}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true},
+		{name: "invalid input kind", body: `{"input":42}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true},
+		{name: "unknown chart", body: `{"input":"x,y\na,1\n","charts":{"types":["unknown"]}}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true},
 		{name: "unsupported parser", body: `{"input":"x,y\na,1\n","parser":"go"}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity},
 		{name: "html not accepted", body: `{"input":"x,y\na,1\n","output":{"format":"html"}}`, contentType: "application/json", accept: "application/json", wantStatus: http.StatusNotAcceptable},
 		{name: "dataset not accepted", body: `{"input":"x,y\na,1\n"}`, contentType: "application/json", accept: "text/html", wantStatus: http.StatusNotAcceptable},
-		{name: "invalid output format", body: `{"input":"x,y\na,1\n","output":{"format":"csv"}}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
-		{name: "metadata is not supported", body: `{"input":"x,y\na,1\n","metadata":{"name":"example"}}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
-		{name: "unknown field", body: `{"input":"x,y\na,1\n","extra":true}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
+		{name: "invalid output format", body: `{"input":"x,y\na,1\n","output":{"format":"csv"}}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true},
+		{name: "metadata is not supported", body: `{"input":"x,y\na,1\n","metadata":{"name":"example"}}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true},
+		{name: "unknown field", body: `{"input":"x,y\na,1\n","extra":true}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true},
 		{name: "missing content type", body: `{}`, wantStatus: http.StatusUnsupportedMediaType},
 		{name: "wrong content type", body: `{}`, contentType: "text/plain", wantStatus: http.StatusUnsupportedMediaType},
 		{name: "malformed content type", body: `{}`, contentType: `application/json; charset="`, wantStatus: http.StatusUnsupportedMediaType},
-		{name: "multiple JSON values", body: `{} {}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
+		{name: "multiple JSON values", body: `{} {}`, contentType: "application/json", wantStatus: http.StatusBadRequest, wantErrors: true},
 	} {
 		s.Run(test.name, func() {
 			recorder := s.apiRequest(handler, "/", test.body, test.contentType, test.accept)
 			s.Equal(test.wantStatus, recorder.Code)
 			s.Contains(recorder.Header().Get("Content-Type"), "application/problem+json")
 			s.Equal(float64(test.wantStatus), s.problemStatus(recorder))
-			if test.wantStatus == http.StatusBadRequest {
+			if test.wantErrors {
 				var problem struct {
 					Errors []apiValidationError `json:"errors"`
 				}
@@ -387,7 +531,7 @@ func (s *ServeSuite) TestConvertEndpointValidatesStructuredOptions() {
 	for _, test := range tests {
 		s.Run(test.name, func() {
 			recorder := s.apiRequest(handler, "/", test.body, "application/json", "application/json")
-			s.Equal(http.StatusBadRequest, recorder.Code, recorder.Body.String())
+			s.Equal(http.StatusUnprocessableEntity, recorder.Code, recorder.Body.String())
 			var problem struct {
 				Errors []apiValidationError `json:"errors"`
 			}
@@ -417,7 +561,7 @@ func (s *ServeSuite) TestMergeEndpoint() {
 	s.Equal(http.StatusBadRequest, recorder.Code)
 
 	recorder = s.apiRequest(handler, "/merge", `{"datasets":[{"name":"one"}]}`, "application/json", "")
-	s.Equal(http.StatusBadRequest, recorder.Code)
+	s.Equal(http.StatusUnprocessableEntity, recorder.Code)
 
 	recorder = s.apiRequest(handler, "/merge", `{"datasets":[`+firstMergeJSON+`,`+secondMergeJSON+`],"tagAxis":"x"}`, "application/json", "")
 	s.Equal(http.StatusOK, recorder.Code)
@@ -426,13 +570,13 @@ func (s *ServeSuite) TestMergeEndpoint() {
 	s.Len(merged, 1)
 
 	recorder = s.apiRequest(handler, "/merge", `{"datasets":[`+firstMergeJSON+`,`+secondMergeJSON+`],"tagAxis":"invalid"}`, "application/json", "")
-	s.Equal(http.StatusBadRequest, recorder.Code)
+	s.Equal(http.StatusUnprocessableEntity, recorder.Code)
 
 	recorder = s.apiRequest(handler, "/merge", `{"datasets":[{"name":"one"},{"name":"two"}]}`, "application/json", "")
-	s.Equal(http.StatusBadRequest, recorder.Code)
+	s.Equal(http.StatusUnprocessableEntity, recorder.Code)
 
 	recorder = s.apiRequest(handler, "/merge", `{"datasets":[`+firstMergeJSON[:len(firstMergeJSON)-1]+`,"extra":true},`+secondMergeJSON+`]}`, "application/json", "")
-	s.Equal(http.StatusBadRequest, recorder.Code)
+	s.Equal(http.StatusUnprocessableEntity, recorder.Code)
 
 	recorder = s.apiRequest(handler, "/merge", `{"datasets":[`+firstMergeJSON+`,`+secondMergeJSON+`]}`, "application/json", "text/html")
 	s.Equal(http.StatusNotAcceptable, recorder.Code)
@@ -454,12 +598,12 @@ func (s *ServeSuite) TestUIEndpoint() {
 	}{
 		{name: "invalid request", body: `{`, accept: "text/html", wantStatus: http.StatusBadRequest},
 		{name: "not accepted", body: valid, accept: "application/json", wantStatus: http.StatusNotAcceptable},
-		{name: "missing datasets", body: `{}`, accept: "text/html", wantStatus: http.StatusBadRequest},
-		{name: "empty datasets", body: `{"datasets":[]}`, accept: "text/html", wantStatus: http.StatusBadRequest},
-		{name: "invalid datasets", body: `{"datasets":true}`, accept: "text/html", wantStatus: http.StatusBadRequest},
-		{name: "incomplete dataset", body: `{"datasets":{"name":"Bench"}}`, accept: "text/html", wantStatus: http.StatusBadRequest},
-		{name: "unknown nested field", body: `{"datasets":` + validDatasetJSON[:len(validDatasetJSON)-1] + `,"extra":true}}`, accept: "text/html", wantStatus: http.StatusBadRequest},
-		{name: "invalid chart type", body: `{"datasets":` + validDatasetJSON + `,"charts":{"types":["unknown"]}}`, accept: "text/html", wantStatus: http.StatusBadRequest},
+		{name: "missing datasets", body: `{}`, accept: "text/html", wantStatus: http.StatusUnprocessableEntity},
+		{name: "empty datasets", body: `{"datasets":[]}`, accept: "text/html", wantStatus: http.StatusUnprocessableEntity},
+		{name: "invalid datasets", body: `{"datasets":true}`, accept: "text/html", wantStatus: http.StatusUnprocessableEntity},
+		{name: "incomplete dataset", body: `{"datasets":{"name":"Bench"}}`, accept: "text/html", wantStatus: http.StatusUnprocessableEntity},
+		{name: "unknown nested field", body: `{"datasets":` + validDatasetJSON[:len(validDatasetJSON)-1] + `,"extra":true}}`, accept: "text/html", wantStatus: http.StatusUnprocessableEntity},
+		{name: "invalid chart type", body: `{"datasets":` + validDatasetJSON + `,"charts":{"types":["unknown"]}}`, accept: "text/html", wantStatus: http.StatusUnprocessableEntity},
 	} {
 		s.Run(test.name, func() {
 			recorder := s.apiRequest(handler, "/ui", test.body, "application/json", test.accept)
@@ -529,7 +673,7 @@ func (s *ServeSuite) TestUIEndpointValidatesDatasetsAndStatistics() {
 		s.Run(test.name, func() {
 			body := `{"datasets":` + test.datasets + test.suffix + `}`
 			recorder := s.apiRequest(handler, "/ui", body, "application/json", "text/html")
-			s.Equal(http.StatusBadRequest, recorder.Code, recorder.Body.String())
+			s.Equal(http.StatusUnprocessableEntity, recorder.Code, recorder.Body.String())
 		})
 	}
 }
@@ -586,10 +730,68 @@ func (s *ServeSuite) TestRequestHelpers() {
 	s.False(accepts(request, "text/html"))
 	request.Header.Set("Accept", "not a media range")
 	s.False(accepts(request, "text/html"))
+	request.Header.Set("Accept", "text")
+	s.False(accepts(request, "text/html"))
 	s.False(accepts(request, "invalid"))
 
 	var target map[string]any
 	s.Error(strictDecode([]byte(`{} {}`), &target))
+
+	request = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"input":"x,y\\na,1\\n"} trailing`))
+	request.Header.Set("Content-Type", "application/json")
+	s.False(decodeAPIRequest(httptest.NewRecorder(), request, &convertRequest{}))
+
+	_, validationErr = decodeChartConfig(json.RawMessage(`{`), "/charts/configs/0")
+	s.NotNil(validationErr)
+	validationErr = validateChartConfigValues(json.RawMessage(`{"stat":"invalid"}`), "/charts/configs/0")
+	s.NotNil(validationErr)
+
+	cfg := parser.Config{Group: []string{"region"}, GroupPattern: "x"}
+	validationErr = applySelectOptions(&cfg, []string{""})
+	s.NotNil(validationErr)
+	validationErr = applySelectOptions(&cfg, []string{"region{"})
+	s.NotNil(validationErr)
+	cfg = parser.Config{}
+	validationErr = applySelectOptions(&cfg, []string{"region,value,extra", "region,value"})
+	s.NotNil(validationErr)
+	cfg = parser.Config{}
+	validationErr = applySelectOptions(&cfg, []string{"region,value"})
+	s.Nil(validationErr)
+
+	validationErr = validateChartConfigValues(json.RawMessage(`[]`), "/charts/configs/0")
+	s.NotNil(validationErr)
+	validationErr = validateChartConfigValues(json.RawMessage(`{"sort":true}`), "/charts/configs/0")
+	s.NotNil(validationErr)
+	validationErr = validateChartConfigValues(json.RawMessage(`{"stat":{"enabled":true,"math":"invalid"}}`), "/charts/configs/0")
+	s.NotNil(validationErr)
+	_, _, validationErr = applyUIOptions(nil, chartSelection{Configs: []json.RawMessage{json.RawMessage(`{`)}}, nil)
+	s.NotNil(validationErr)
+
+	datasets, validationErr = decodeDatasets(json.RawMessage(validDatasetJSON))
+	s.Nil(validationErr)
+	var result []shared.Dataset
+	var types []string
+	result, types, validationErr = applyUIOptions(datasets, chartSelection{Configs: []json.RawMessage{json.RawMessage(`{"type":"line"}`)}}, nil)
+	s.Nil(validationErr)
+	s.Nil(types)
+	s.Len(result[0].Settings, 2)
+
+	for _, test := range []struct {
+		name   string
+		config malformedChartConfig
+	}{
+		{name: "marshal existing config", config: malformedChartConfig{chartType: "bar", marshalErr: errors.New("marshal failed")}},
+		{name: "decode existing config", config: malformedChartConfig{chartType: "bar", raw: []byte(`{`)}},
+	} {
+		s.Run(test.name, func() {
+			invalidDataset := shared.Dataset{Settings: []internalcharts.ChartConfig{test.config}}
+			_, _, validationErr := applyUIOptions([]shared.Dataset{invalidDataset}, chartSelection{Types: []string{"bar"}}, nil)
+			s.NotNil(validationErr)
+		})
+	}
+
+	_, validationErr = decodeStrictDataset(json.RawMessage(`{"name":"Bench","history":[{"tag":"v1","timestamp":"now"}],"axes":[],"settings":[],"data":[]}`), "/datasets/0")
+	s.Nil(validationErr)
 }
 
 func (s *ServeSuite) apiRequest(handler http.Handler, path, body, contentType, accept string) *httptest.ResponseRecorder {
@@ -624,6 +826,18 @@ type testAddr string
 
 func (a testAddr) Network() string { return "tcp" }
 func (a testAddr) String() string  { return string(a) }
+
+type malformedChartConfig struct {
+	chartType  string
+	raw        []byte
+	marshalErr error
+}
+
+func (c malformedChartConfig) MarshalJSON() ([]byte, error) { return c.raw, c.marshalErr }
+func (c malformedChartConfig) ChartType() string            { return c.chartType }
+func (malformedChartConfig) StatEnabled() bool              { return false }
+func (malformedChartConfig) StatMath() []string             { return nil }
+func (malformedChartConfig) SwapString() string             { return "" }
 
 type errorListener struct{ err error }
 
@@ -666,6 +880,52 @@ func (l *blockingListener) Close() error {
 }
 
 func (l *blockingListener) Addr() net.Addr { return testAddr("in-memory") }
+
+type closeErrorListener struct {
+	*blockingListener
+	err error
+}
+
+func (l closeErrorListener) Close() error {
+	_ = l.blockingListener.Close()
+	return l.err
+}
+
+type singleConnectionListener struct {
+	conn          net.Conn
+	acceptStarted chan struct{}
+	closed        chan struct{}
+	acceptOnce    sync.Once
+	closeOnce     sync.Once
+}
+
+func newSingleConnectionListener(conn net.Conn) *singleConnectionListener {
+	return &singleConnectionListener{
+		conn:          conn,
+		acceptStarted: make(chan struct{}),
+		closed:        make(chan struct{}),
+	}
+}
+
+func (l *singleConnectionListener) Accept() (net.Conn, error) {
+	accepted := false
+	l.acceptOnce.Do(func() {
+		accepted = true
+		close(l.acceptStarted)
+	})
+	if accepted {
+		return l.conn, nil
+	}
+	<-l.closed
+	return nil, net.ErrClosed
+}
+
+func (l *singleConnectionListener) Close() error {
+	l.closeOnce.Do(func() { close(l.closed) })
+	return nil
+}
+
+func (l *singleConnectionListener) Addr() net.Addr { return testAddr("in-memory") }
 
 func directSignalContext(ctx context.Context, _ ...os.Signal) (context.Context, context.CancelFunc) {
 	return context.WithCancel(ctx)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -757,6 +757,10 @@ func (s *ServeSuite) TestRequestHelpers() {
 	cfg = parser.Config{}
 	validationErr = applySelectOptions(&cfg, []string{"region,value"})
 	s.Nil(validationErr)
+	_, validationErr = buildParserConfig(convertRequest{
+		Grouping: &groupingOptions{Pattern: "x,y", Columns: []string{"region/value"}},
+	}, "csv")
+	s.NotNil(validationErr)
 
 	validationErr = validateChartConfigValues(json.RawMessage(`[]`), "/charts/configs/0")
 	s.NotNil(validationErr)

--- a/cmd/testing.go
+++ b/cmd/testing.go
@@ -26,9 +26,13 @@ func ResetTestState() {
 	mergeOpts.OutputFile = ""
 	mergeOpts.TagAxis = "n"
 
+	serveOpts.Host = defaultServeHost
+	serveOpts.Port = defaultServePort
+
 	resetChanged(rootCmd.Flags())
 	resetChanged(uiCmd.Flags())
 	resetChanged(mergeCmd.Flags())
+	resetChanged(serveCmd.Flags())
 }
 
 // resetChanged clears the Changed flag on every flag in fs so

--- a/cmd/testing.go
+++ b/cmd/testing.go
@@ -26,8 +26,7 @@ func ResetTestState() {
 	mergeOpts.OutputFile = ""
 	mergeOpts.TagAxis = "n"
 
-	serveOpts.Host = defaultServeHost
-	serveOpts.Port = defaultServePort
+	serveBag.Reset()
 
 	resetChanged(rootCmd.Flags())
 	resetChanged(uiCmd.Flags())

--- a/docs/src/content/docs/commands/serve.mdx
+++ b/docs/src/content/docs/commands/serve.mdx
@@ -119,15 +119,16 @@ not depend on this server remaining available.
 ## Errors
 
 All errors are `application/problem+json`. Every response has a stable `type`,
-`title`, `status`, and `detail`; validation errors additionally include `errors`.
+`title`, `status`, and `detail`; malformed JSON and semantic validation errors
+additionally include `errors`.
 Each entry identifies the input location, a JSON Pointer-like `path`, a stable
 `code`, and a human-readable `message`.
 
 ```json
 {
   "type": "https://vizb.goptics.org/problems/validation",
-  "title": "Invalid request",
-  "status": 400,
+  "title": "Unprocessable content",
+  "status": 422,
   "detail": "Request validation failed.",
   "instance": "/merge",
   "errors": [
@@ -143,8 +144,11 @@ Each entry identifies the input location, a JSON Pointer-like `path`, a stable
 
 | Status | Meaning |
 | --- | --- |
-| `400` | Invalid JSON, unknown field, or invalid/inapplicable option |
+| `400` | The body is malformed JSON or contains multiple JSON values |
+| `404` | The requested API operation does not exist |
+| `405` | The operation does not support the HTTP method; `Allow: POST` is returned |
 | `406` | The requested `Accept` type cannot represent the selected output |
+| `413` | The request body exceeds the 10 MiB limit |
 | `415` | The request is not `application/json` |
-| `422` | Valid request structure, but the input could not be processed |
+| `422` | Valid JSON violates request schema or semantic rules, or the input could not be processed |
 | `500` | Unexpected server or template failure |

--- a/docs/src/content/docs/commands/serve.mdx
+++ b/docs/src/content/docs/commands/serve.mdx
@@ -57,7 +57,6 @@ curl -sS http://127.0.0.1:8080/ \
   --data '{
     "input": "region,latency\\nwest,12\\neast,18\\n",
     "parser": "csv",
-    "metadata": { "name": "API latency" },
     "select": ["region", "latency"],
     "charts": { "types": ["bar", "line"] },
     "output": { "format": "dataset" }

--- a/docs/src/content/docs/commands/serve.mdx
+++ b/docs/src/content/docs/commands/serve.mdx
@@ -23,6 +23,11 @@ vizb serve --host 0.0.0.0 --port 8080
 The host and port make up the API base URL. The default binding is loopback so
 that the server is not exposed to a network unintentionally.
 
+Each request body is limited to 10 MiB. The server uses a 5-second header read
+timeout, a 15-second request read timeout, and 60-second write and idle
+timeouts. On `SIGINT` or `SIGTERM`, it stops accepting requests and allows up
+to 10 seconds for in-flight work to finish.
+
 Browse the generated [API reference](/api/) for the complete OpenAPI contract,
 including request and response schemas and generated code snippets.
 

--- a/internal/flags/flag.go
+++ b/internal/flags/flag.go
@@ -25,6 +25,7 @@ const (
 	KindString      Kind = iota // string
 	KindBool                    // bool
 	KindFloat                   // float64
+	KindInt                     // int
 	KindStringSlice             // []string (comma-separated), e.g. --group, --charts
 	KindStringArray             // []string (repeatable flag), e.g. --select, --chart
 	KindStat                    // optional-value string slice, e.g. --stat

--- a/shared/chart_selection_test.go
+++ b/shared/chart_selection_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	internal_charts "github.com/goptics/vizb/internal/charts"
+	"github.com/goptics/vizb/internal/flags"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -85,6 +86,15 @@ func (s *ChartSelectionSuite) TestDatasetNeeds3D() {
 			s.Equal(c.want, DatasetNeeds3D(c.ds))
 		})
 	}
+}
+
+func (s *ChartSelectionSuite) TestConvertFlagValueValidatesIntegers() {
+	flag := flags.Flag{Name: "depth", Kind: flags.KindInt}
+	value, err := convertFlagValue(flag, "3", true, nil)
+	s.NoError(err)
+	s.Equal(3, value)
+	_, err = convertFlagValue(flag, "not-a-number", true, nil)
+	s.ErrorContains(err, "must be an integer")
 }
 
 var _ internal_charts.ChartConfig = stubChartConfig{}

--- a/shared/chart_spec.go
+++ b/shared/chart_spec.go
@@ -235,7 +235,7 @@ func convertFlagValue(f flags.Flag, val string, hasEq bool, axes []Axis) (any, e
 		}
 		return map[string]any{"enabled": true, "math": math}, nil
 
-	default: // KindString, KindFloat
+	default: // KindString, KindFloat, KindInt
 		if !hasEq {
 			return nil, fmt.Errorf("--chart: key %q requires a value (e.g. %s=<value>)", f.Name, f.Name)
 		}
@@ -250,6 +250,13 @@ func convertFlagValue(f flags.Flag, val string, hasEq bool, axes []Axis) (any, e
 		}
 		if f.Kind == flags.KindFloat {
 			n, _ := strconv.ParseFloat(val, 64) // Validate already ensured it parses
+			return encode(f, n), nil
+		}
+		if f.Kind == flags.KindInt {
+			n, err := strconv.Atoi(val)
+			if err != nil {
+				return nil, fmt.Errorf("--chart: key %q value %q must be an integer", f.Name, val)
+			}
 			return encode(f, n), nil
 		}
 		return encode(f, val), nil


### PR DESCRIPTION
## Related issues
Resolve #213 

## Changes
- Added vizb serve with --host/--port defaults, limits, timeouts, listener
  errors, and bounded SIGINT/SIGTERM shutdown in cmd/serve.go.

- Registered testable POST route composition for /, /merge, and /ui.
- Added lifecycle/configuration/limit tests in cmd/serve_test.go.
- Documented limits and lifecycle defaults in docs/src/content/docs/commands/
- Included the local #212 server-safe core prerequisite commits.

## Test Steps

```bash
go test ./...
task test:cli
task format:check:cli
go vet ./...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `vizb serve` command for local HTTP conversion (`/`), merging (`/merge`), and HTML UI generation (`/ui`).
  * Added configurable server host/port, timeouts, and a 10 MiB request body limit with strict JSON validation.
  * Added standardized `application/problem+json` error responses and improved `Accept` negotiation behavior.
  * Enforced dataset `settings` so each chart type can appear at most once; added support for integer-typed CLI/chart flags.

* **Documentation**
  * Updated `serve` and API docs with request limits, lifecycle/shutdown behavior, and refined error/status meanings.

* **Tests**
  * Added comprehensive server and endpoint tests, plus OpenAPI contract and integer-flag validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->