### PR TITLE
chore(release): draft CHANGELOG.md with git-cliff

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -50,6 +50,14 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin \
   && task --version
 
+# git-cliff — not in Debian apt; same idea as alpine's `apk add git-cliff`.
+# Host/dev: `brew install git-cliff` (task cliff:install).
+ARG GIT_CLIFF_VERSION=2.13.1
+RUN arch=$(uname -m | sed 's/aarch64/aarch64/;s/arm64/aarch64/;s/x86_64/x86_64/') \
+  && curl -fsSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-${arch}-unknown-linux-gnu.tar.gz" \
+    | tar -xz --strip-components=1 -C /usr/local/bin "git-cliff-${GIT_CLIFF_VERSION}/git-cliff" \
+  && git-cliff --version
+
 USER vizber
 WORKDIR /home/vizber
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in this repository.
+* @fahimfaisaal

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,6 +15,7 @@ tasks:
       - cd docs; pnpm install; cd -
       - task: build:ui
       - task: act:install
+      - task: cliff:install
       - go run github.com/evilmartians/lefthook@latest install
 
   dev:docs:
@@ -143,12 +144,29 @@ tasks:
     cmds:
       - goreleaser release --snapshot --clean
 
+  # CHANGELOG helpers: scripts/release-changelog.sh; install via Homebrew (or see Dockerfile).
+  cliff:install:
+    desc: Install git-cliff for CHANGELOG drafts (Homebrew)
+    cmds:
+      - (which git-cliff && echo "git-cliff already installed") || brew install git-cliff
+
+  release:changelog:
+    desc: "Draft CHANGELOG.md (git-cliff). Usage: task release:changelog -- vX.Y.Z"
+    cmds:
+      - ./scripts/release-changelog.sh draft {{.CLI_ARGS}}
+
+  release:changelog:commit:
+    desc: "Commit CHANGELOG.md only. Usage: task release:changelog:commit -- vX.Y.Z"
+    cmds:
+      - ./scripts/release-changelog.sh commit {{.CLI_ARGS}}
+
   release:
-    desc: Create and push a new tag to trigger release
+    desc: "Tag and push a release. Usage: task release -- vX.Y.Z"
     prompt: This will create and push a new release tag. Continue?
     vars:
       VERSION: "{{.CLI_ARGS}}"
     cmds:
+      - ./scripts/release-changelog.sh preflight {{.VERSION}}
       - task: release:check
       - task: release:snapshot
       - echo "Creating tag {{.VERSION}}..."

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,77 @@
+# git-cliff config for Vizb CHANGELOG.md drafts.
+# Used by: task release:changelog -- vX.Y.Z
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+# Header is only used for full regenerations. release:changelog uses --prepend
+# so the existing CHANGELOG.md intro is left intact.
+header = """
+# Changelog
+
+Notable changes to Vizb documented here.
+
+Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+"""
+# Match existing Vizb style: "# [v0.15.1] - YYYY-MM-DD" + ### Added/Fixed/Changed
+# Whitespace: one blank after the version heading and after each ### group title;
+# one blank between groups; no blank between list items.
+body = """
+{% if version -%}
+# [{{ version }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+# [Unreleased]
+{% endif %}
+{% for group, commits in commits | group_by(attribute="group") -%}
+### {{ group | striptags | trim }}
+
+{% for commit in commits -%}
+- {% if commit.scope %}**{{ commit.scope }}** — {% endif %}\
+{% if commit.breaking %}**BREAKING** {% endif %}\
+{{ commit.message | split(pat="\n") | first | trim | upper_first }}
+{% endfor %}
+{% endfor -%}
+"""
+trim = true
+render_always = false
+postprocessors = [
+  # Turn (#123) into a GitHub PR link.
+  { pattern = '\(#([0-9]+)\)', replace = "([#${1}](https://github.com/goptics/vizb/pull/${1}))" },
+]
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+require_conventional = false
+split_commits = false
+protect_breaking_commits = true
+filter_commits = false
+fail_on_unmatched_commit = false
+topo_order = false
+topo_order_commits = true
+sort_commits = "newest"
+use_branch_tags = false
+recurse_submodules = false
+
+commit_preprocessors = []
+
+# HTML comment prefixes force group order (striptags removes them in the body).
+commit_parsers = [
+  { message = "^feat", group = "<!-- 0 -->Added" },
+  { message = "^fix", group = "<!-- 1 -->Fixed" },
+  { message = "^perf", group = "<!-- 2 -->Changed" },
+  { message = "^refactor", group = "<!-- 2 -->Changed" },
+  { message = "^docs\\(changelog\\)", skip = true },
+  { message = "^chore: updated changelog", skip = true },
+  { message = "^chore: update changelog", skip = true },
+  { message = "^docs", skip = true },
+  { message = "^test", skip = true },
+  { message = "^ci", skip = true },
+  { message = "^style", skip = true },
+  { message = "^build", skip = true },
+  { message = "^chore\\(deps", skip = true },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^chore", skip = true },
+  { message = "^revert", group = "<!-- 3 -->Changed" },
+  { body = ".*security", group = "<!-- 1 -->Fixed" },
+]

--- a/scripts/release-changelog.sh
+++ b/scripts/release-changelog.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Maintainer helpers for CHANGELOG.md drafts and release preflight.
+# Usage:
+#   ./scripts/release-changelog.sh draft   vX.Y.Z
+#   ./scripts/release-changelog.sh commit  vX.Y.Z
+#   ./scripts/release-changelog.sh preflight vX.Y.Z
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+usage() {
+  echo "Usage: $0 {draft|commit|preflight} vX.Y.Z" >&2
+  exit 1
+}
+
+require_version() {
+  local version="${1:-}"
+  if [[ -z "$version" ]]; then
+    echo "Usage: $0 $cmd vX.Y.Z" >&2
+    exit 1
+  fi
+  if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "VERSION must look like vX.Y.Z (got: $version)" >&2
+    exit 1
+  fi
+}
+
+has_section() {
+  grep -qE "^# \\[${1}\\]" CHANGELOG.md
+}
+
+cmd="${1:-}"
+version="${2:-}"
+[[ -n "$cmd" ]] || usage
+
+case "$cmd" in
+  draft)
+    require_version "$version"
+    command -v git-cliff >/dev/null 2>&1 || {
+      echo "git-cliff not found. Install: brew install git-cliff  (or: task cliff:install)" >&2
+      exit 1
+    }
+    [[ -f cliff.toml ]] || {
+      echo "cliff.toml not found in repo root" >&2
+      exit 1
+    }
+    if has_section "$version"; then
+      echo "CHANGELOG.md already has a section for ${version}; refusing to prepend again." >&2
+      exit 1
+    fi
+    git-cliff --config cliff.toml --unreleased --tag "$version" --prepend CHANGELOG.md
+    cat <<EOF
+
+Draft prepended for ${version}.
+Next:
+  1. Polish CHANGELOG.md if needed
+  2. task release:changelog:commit -- ${version}
+  3. task release -- ${version}
+EOF
+    ;;
+
+  commit)
+    require_version "$version"
+    if ! has_section "$version"; then
+      echo "CHANGELOG.md has no section for ${version}. Run: task release:changelog -- ${version}" >&2
+      exit 1
+    fi
+    if git diff --quiet -- CHANGELOG.md && git diff --cached --quiet -- CHANGELOG.md; then
+      echo "No CHANGELOG.md changes to commit." >&2
+      exit 1
+    fi
+    git add CHANGELOG.md
+    git commit -m "docs(changelog): add ${version} release notes"
+    echo "Committed CHANGELOG.md for ${version}. Push, then: task release -- ${version}"
+    ;;
+
+  preflight)
+    require_version "$version"
+    if ! has_section "$version"; then
+      echo "CHANGELOG.md has no section for ${version}." >&2
+      echo "Run: task release:changelog -- ${version}, polish, commit, then retry." >&2
+      exit 1
+    fi
+    if ! git diff --quiet -- CHANGELOG.md || ! git diff --cached --quiet -- CHANGELOG.md; then
+      echo "CHANGELOG.md has uncommitted changes. Commit first:" >&2
+      echo "  task release:changelog:commit -- ${version}" >&2
+      exit 1
+    fi
+    ;;
+
+  *)
+    usage
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Draft `CHANGELOG.md` from conventional commits with git-cliff before tagging
- Add `task release:changelog` / `release:changelog:commit` and release preflight
- Install git-cliff via Homebrew on host (`task cliff:install` / `task init`) and pin it in the Dev Container

## Test plan
- [ ] `task cliff:install` (or brew) then `task release:changelog -- v0.99.0` (dry draft; restore file)
- [ ] Confirm guards: missing version, existing section, dirty CHANGELOG on `task release`
- [ ] Rebuild Dev Container and run `git-cliff --version`