### PR TITLE
fix(core): make Go benchmark metadata request-scoped

### DIFF
--- a/cmd/cli/pipeline.go
+++ b/cmd/cli/pipeline.go
@@ -78,8 +78,8 @@ func RunLinear(cmd *cobra.Command, args []string, meta RunMeta, cfg parser.Confi
 		if meta.Parser == "json" && cfg.JSONPath != "" {
 			target = applyJSONPath(target, cfg.JSONPath)
 		}
-		results, effectiveCfg := prepareData(target, meta.Parser, cfg)
-		datasets = []*shared.Dataset{assembleDataset(results, meta, configs, effectiveCfg)}
+		results, effectiveCfg, system := prepareData(target, meta.Parser, cfg)
+		datasets = []*shared.Dataset{assembleDataset(results, meta, configs, effectiveCfg, system)}
 		// Validate swap only for chart subcommands (applyOnPassthrough true).
 		// The root command stores swap as-is, trusting the UI to handle it.
 		if applyOnPassthrough {
@@ -246,7 +246,7 @@ func applyJSONPath(filePath, path string) string {
 // prepareData parses input into data points, aggregating grouped csv/json rows.
 // The returned Config is the parser's effective config (auto-group/auto-value
 // mutations included) for aggregation and dataset assembly.
-func prepareData(filePath, parserKey string, cfg parser.Config) ([]shared.DataPoint, parser.Config) {
+func prepareData(filePath, parserKey string, cfg parser.Config) ([]shared.DataPoint, parser.Config, *shared.Meta) {
 	parseFn, err := parser.GetParser(parserKey)
 	if err != nil {
 		shared.ExitWithError(err.Error(), nil)
@@ -271,7 +271,7 @@ func prepareData(filePath, parserKey string, cfg parser.Config) ([]shared.DataPo
 	}
 	defer input.Close()
 
-	data, effectiveCfg, err := parseFn(input, cfg)
+	data, effectiveCfg, system, err := parseFn(input, cfg)
 	if err != nil {
 		shared.ExitWithError(err.Error(), nil)
 	}
@@ -297,7 +297,7 @@ func prepareData(filePath, parserKey string, cfg parser.Config) ([]shared.DataPo
 		shared.ExitWithError("No dataset found", nil)
 	}
 
-	return data, effectiveCfg
+	return data, effectiveCfg, system
 }
 
 // applyColAxis expands multi-stat points onto cfg.ColAxis when the flag is set.
@@ -403,15 +403,7 @@ func formatAggregationGroup(cfg parser.Config) string {
 
 // assembleDataset builds the output Dataset from parsed results plus the
 // command's metadata and the resolved per-chart configs.
-func assembleDataset(results []shared.DataPoint, m RunMeta, configs []internal_charts.ChartConfig, cfg parser.Config) *shared.Dataset {
-	meta := shared.Meta{OS: shared.OS, Arch: shared.Arch, Pkg: shared.Pkg}
-	if cpuName := strings.TrimSpace(shared.CPU); cpuName != "" || shared.CPUCount != 0 {
-		meta.CPU = &shared.CPUInfo{Name: cpuName, Cores: shared.CPUCount}
-	}
-	var system *shared.Meta
-	if meta != (shared.Meta{}) {
-		system = &meta
-	}
+func assembleDataset(results []shared.DataPoint, m RunMeta, configs []internal_charts.ChartConfig, cfg parser.Config, system *shared.Meta) *shared.Dataset {
 	return core.Assemble(core.AssembleInput{
 		Points: results,
 		Parser: m.Parser,

--- a/cmd/cli/pipeline_test.go
+++ b/cmd/cli/pipeline_test.go
@@ -49,7 +49,7 @@ func (s *PipelineSuite) TestApplyJSONPathEnvelope() {
 	s.FileExists(extracted)
 
 	cfg := parser.Config{GroupPattern: "x", Group: []string{"impl"}, JSONPath: ".data"}
-	results, _ := prepareData(extracted, "json", cfg)
+	results, _, _ := prepareData(extracted, "json", cfg)
 	s.Len(results, 2)
 	s.ElementsMatch([]string{"a", "b"}, []string{results[0].XAxis, results[1].XAxis})
 }
@@ -59,7 +59,7 @@ func (s *PipelineSuite) TestPrepareDataReadsGoJSONEventsDirectly() {
 {"Action":"output","Output":"BenchmarkExample-8 100 1234 ns/op\n"}
 {"Action":"pass","Test":"BenchmarkExample"}`)
 
-	results, _ := prepareData(input, "go", parser.Config{
+	results, _, _ := prepareData(input, "go", parser.Config{
 		GroupPattern: "y",
 		TimeUnit:     "ns",
 	})
@@ -68,12 +68,41 @@ func (s *PipelineSuite) TestPrepareDataReadsGoJSONEventsDirectly() {
 	s.Equal("Example", results[0].YAxis)
 }
 
+func (s *PipelineSuite) TestGoBenchmarkMetadataPreservesDatasetWireFormat() {
+	input := s.writeFile("bench.txt", strings.Join([]string{
+		"goos: linux",
+		"goarch: amd64",
+		"pkg: example.com/cli",
+		"cpu: CLI CPU",
+		"BenchmarkExample-8 100 1234 ns/op",
+	}, "\n"))
+
+	results, cfg, system := prepareData(input, "go", parser.Config{
+		GroupPattern: "y",
+		TimeUnit:     "ns",
+	})
+	dataset := assembleDataset(results, RunMeta{Name: "CLI", Parser: "go"}, nil, cfg, system)
+	encoded, err := json.Marshal(dataset)
+
+	s.Require().NoError(err)
+	var wire struct {
+		Meta json.RawMessage `json:"meta"`
+	}
+	s.Require().NoError(json.Unmarshal(encoded, &wire))
+	s.JSONEq(`{
+		"cpu": {"name": "CLI CPU", "cores": 8},
+		"os": "linux",
+		"arch": "amd64",
+		"pkg": "example.com/cli"
+	}`, string(wire.Meta))
+}
+
 func (s *PipelineSuite) TestPrepareDataWarnsJSONPathIgnoredForNonJSONParser() {
 	benchFile := s.writeFile("valid.txt", `BenchmarkExample-8    1000000    1234 ns/op`)
 	cfg := parser.Config{GroupPattern: "y", TimeUnit: "ns", MemUnit: "B", JSONPath: ".data"}
 
 	errOut := testutil.CaptureStderr(func() {
-		results, _ := prepareData(benchFile, "go", cfg)
+		results, _, _ := prepareData(benchFile, "go", cfg)
 		s.NotEmpty(results)
 	})
 	s.Contains(errOut, "--json-path is only supported for the json parser")
@@ -89,7 +118,7 @@ func (s *PipelineSuite) TestPrepareDataWarnsSelectIgnoredForGoParser() {
 	}
 
 	errOut := testutil.CaptureStderr(func() {
-		results, _ := prepareData(benchFile, "go", cfg)
+		results, _, _ := prepareData(benchFile, "go", cfg)
 		s.NotEmpty(results)
 	})
 	s.Contains(errOut, "--select is only supported for csv/json parsers")
@@ -102,7 +131,7 @@ func (s *PipelineSuite) TestPrepareData() {
 		benchFile := s.writeFile("valid.txt", `BenchmarkExample-8    1000000    1234 ns/op    1000 B/op    10 allocs/op
 BenchmarkAnother-8    2000000    2345 ns/op    2000 B/op    20 allocs/op`)
 
-		results, _ := prepareData(benchFile, "go", cfg)
+		results, _, _ := prepareData(benchFile, "go", cfg)
 		s.NotEmpty(results)
 	})
 
@@ -409,7 +438,7 @@ func (s *PipelineSuite) TestPrepareDataAutoValuePreservesMetric() {
 	csvFile := s.writeFile("grid.csv", "x,y,z,value\n0,0,0,4\n0,0,1,3.22\n0,1,0,3.28\n")
 	cfg := parser.Config{AutoGroup: true, ChartTypes: []string{"scatter"}}
 
-	results, effectiveCfg := prepareData(csvFile, "csv", cfg)
+	results, effectiveCfg, _ := prepareData(csvFile, "csv", cfg)
 	s.Equal("value", effectiveCfg.MetricColumn)
 	s.Require().Len(results, 3)
 	s.Equal("4", results[0].Metric)
@@ -422,7 +451,7 @@ func (s *PipelineSuite) TestPrepareDataAutoGroupSkipsCollapseLogWhenAllUnique() 
 	cfg := parser.Config{AutoGroup: true, GroupPattern: "x", ChartTypes: []string{"bar"}}
 
 	out := testutil.CaptureStdout(func() {
-		results, effectiveCfg := prepareData(csvFile, "csv", cfg)
+		results, effectiveCfg, _ := prepareData(csvFile, "csv", cfg)
 		s.Equal([]string{"region"}, effectiveCfg.Group)
 		s.Len(results, 3)
 	})
@@ -486,7 +515,7 @@ func (s *PipelineSuite) TestPrepareDataAutoGroupAggregatesCSV() {
 	os.Stdout = w
 	defer func() { os.Stdout = oldStdout }()
 
-	results, effectiveCfg := prepareData(csvFile, "csv", cfg)
+	results, effectiveCfg, _ := prepareData(csvFile, "csv", cfg)
 	w.Close()
 
 	output, err := io.ReadAll(r)
@@ -514,7 +543,7 @@ func (s *PipelineSuite) TestPrepareDataAggregatesCSV() {
 	os.Stdout = w
 	defer func() { os.Stdout = oldStdout }()
 
-	results, _ := prepareData(csvFile, "csv", cfg)
+	results, _, _ := prepareData(csvFile, "csv", cfg)
 	w.Close()
 
 	output, err := io.ReadAll(r)
@@ -535,7 +564,7 @@ func (s *PipelineSuite) TestPrepareDataAxesRejectsNonTabularParser() {
 func (s *PipelineSuite) TestAssembleDatasetSetsID() {
 	results := []shared.DataPoint{{Name: "A", Stats: []shared.Stat{{Type: "time", Value: shared.F64(1)}}}}
 	cfg := parser.Config{AutoGroup: true}
-	ds := assembleDataset(results, RunMeta{Name: "T", ID: "bench-v1", Parser: "go"}, nil, cfg)
+	ds := assembleDataset(results, RunMeta{Name: "T", ID: "bench-v1", Parser: "go"}, nil, cfg, nil)
 	s.Equal("bench-v1", ds.ID)
 }
 
@@ -550,7 +579,7 @@ func (s *PipelineSuite) TestAssembleDatasetUsesAutoValueAxesFromData() {
 			{Source: "z", AxisKey: "z"},
 		},
 	}
-	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, cfg)
+	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, cfg, nil)
 
 	s.Len(ds.Axes, 3)
 	for _, ax := range ds.Axes {
@@ -565,7 +594,7 @@ func (s *PipelineSuite) TestAssembleDatasetUsesCategoryAxesFromData() {
 	// Auto-group path: Stats populated → category-type x axis (-p x)
 	results := []shared.DataPoint{{XAxis: "US", Stats: []shared.Stat{{Type: "sells", Value: shared.F64(10)}}}}
 	cfg := parser.Config{AutoGroup: true, Group: []string{"region"}, GroupPattern: "x"}
-	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, cfg)
+	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, cfg, nil)
 
 	s.Require().Len(ds.Axes, 1)
 	s.Equal("x", ds.Axes[0].Key)
@@ -588,7 +617,7 @@ func (s *PipelineSuite) TestAssembleDatasetAutoEnablesVisualMapForValueMetric() 
 	configs := []internal_charts.ChartConfig{
 		&scatterchart.Config{Type: "scatter"},
 	}
-	ds := assembleDataset(results, RunMeta{Name: "Noise", Parser: "csv"}, configs, cfg)
+	ds := assembleDataset(results, RunMeta{Name: "Noise", Parser: "csv"}, configs, cfg, nil)
 
 	s.Require().Len(ds.Settings, 1)
 	sc := ds.Settings[0].(*scatterchart.Config)
@@ -617,7 +646,7 @@ func (s *PipelineSuite) TestAssembleDatasetAutoEnables3DForBarAndLine() {
 		&barchart.Config{Type: "bar"},
 		&linechart.Config{Type: "line"},
 	}
-	ds := assembleDataset(results, RunMeta{Name: "Grid", Parser: "csv"}, configs, cfg)
+	ds := assembleDataset(results, RunMeta{Name: "Grid", Parser: "csv"}, configs, cfg, nil)
 
 	s.Require().Len(ds.Settings, 2)
 	bc := ds.Settings[0].(*barchart.Config)
@@ -642,7 +671,7 @@ func (s *PipelineSuite) TestAssembleDatasetAppendMetricAxisFromConfig() {
 			{Source: "z", AxisKey: "z"},
 		},
 	}
-	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, cfg)
+	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, cfg, nil)
 
 	s.Require().Len(ds.Axes, 4)
 	s.Equal("metric", ds.Axes[3].Key)
@@ -657,7 +686,7 @@ func (s *PipelineSuite) TestAssembleDatasetSelectViewMixedAxes() {
 			{Columns: []parser.ColumnSpec{{Source: "region", AxisKey: "x", AxisType: "category"}, {Source: "latency", AxisKey: "y", AxisType: "value"}}},
 		},
 	}
-	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, cfg)
+	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, cfg, nil)
 
 	s.Require().Len(ds.Axes, 2)
 	s.Equal("x", ds.Axes[0].Key)
@@ -685,11 +714,11 @@ func (s *PipelineSuite) TestParseCSVToAssembleDatasetMixedSelect() {
 	input, err := os.Open(csvFile)
 	s.Require().NoError(err)
 	defer input.Close()
-	results, effectiveCfg, err := parser.Parsers["csv"](input, cfg)
+	results, effectiveCfg, _, err := parser.Parsers["csv"](input, cfg)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(results)
 
-	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, effectiveCfg)
+	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, effectiveCfg, nil)
 	s.Require().Len(ds.Axes, 2)
 	s.Equal("x", ds.Axes[0].Key)
 	s.Equal("", ds.Axes[0].Type, "mixed x axis must be category (empty Type)")
@@ -706,7 +735,7 @@ func (s *PipelineSuite) TestAssembleDatasetGroupedAxesFromConfig() {
 			{Source: "latency", AxisKey: "y", AxisType: "value"},
 		},
 	}
-	ds := assembleDataset(results, RunMeta{Parser: "csv"}, nil, cfg)
+	ds := assembleDataset(results, RunMeta{Parser: "csv"}, nil, cfg, nil)
 	s.Require().Len(ds.Axes, 2)
 	s.Equal("", ds.Axes[0].Type)
 	s.Equal("value", ds.Axes[1].Type)
@@ -720,7 +749,7 @@ func (s *PipelineSuite) TestAssembleDatasetSelectAxis() {
 			{Columns: []parser.ColumnSpec{{Source: "x", AxisKey: "x"}, {Source: "y", AxisKey: "y"}}},
 		},
 	}
-	ds := assembleDataset(results, RunMeta{Parser: "csv"}, nil, cfg)
+	ds := assembleDataset(results, RunMeta{Parser: "csv"}, nil, cfg, nil)
 	s.Require().Len(ds.Axes, 2)
 	s.Equal("value", ds.Axes[0].Type)
 	s.Equal("value", ds.Axes[1].Type)
@@ -734,7 +763,7 @@ func (s *PipelineSuite) TestAssembleDatasetPreservesTheme() {
 			{Columns: []parser.ColumnSpec{{Source: "x", AxisKey: "x", AxisType: "value"}, {Source: "y", AxisKey: "y", AxisType: "value"}}},
 		},
 	}
-	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv", Theme: "walden"}, nil, cfg)
+	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv", Theme: "walden"}, nil, cfg, nil)
 	s.Equal("walden", ds.Theme)
 }
 
@@ -750,7 +779,7 @@ func (s *PipelineSuite) TestAssembleDatasetInfersAxesWithoutAxisType() {
 			{Columns: append([]parser.ColumnSpec(nil), view...)},
 		},
 	}
-	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, cfg)
+	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, cfg, nil)
 	s.Require().Len(ds.Axes, 2)
 	s.Equal("", ds.Axes[0].Type)
 	s.Equal("value", ds.Axes[1].Type)
@@ -798,7 +827,7 @@ func (s *PipelineSuite) TestAssembleDatasetSelectViewValueAxesEnables3D() {
 		},
 	}
 	configs := []internal_charts.ChartConfig{&scatterchart.Config{Type: "scatter"}}
-	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, configs, cfg)
+	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, configs, cfg, nil)
 
 	s.Require().Len(ds.Axes, 3)
 	for _, ax := range ds.Axes {
@@ -817,7 +846,7 @@ func (s *PipelineSuite) TestAssembleDatasetCategoryAxesSkipAuto3D() {
 	configs := []internal_charts.ChartConfig{
 		&scatterchart.Config{Type: "scatter"},
 	}
-	ds := assembleDataset(results, RunMeta{Name: "Grouped", Parser: "csv"}, configs, cfg)
+	ds := assembleDataset(results, RunMeta{Name: "Grouped", Parser: "csv"}, configs, cfg, nil)
 
 	sc := ds.Settings[0].(*scatterchart.Config)
 	s.Nil(sc.ThreeD)
@@ -959,7 +988,7 @@ func (s *PipelineSuite) TestPrepareDataMultiSelectStatMode() {
 		},
 	}
 
-	data, _ := prepareData(csvFile, "csv", cfg)
+	data, _, _ := prepareData(csvFile, "csv", cfg)
 	s.Len(data, 4) // 2 rows × 2 views (different dim columns → not merged)
 	s.Equal("Asia", data[0].XAxis)
 	s.Require().Len(data[0].Stats, 1)
@@ -979,7 +1008,7 @@ func (s *PipelineSuite) TestPrepareDataCollapsesSharedDimMultiSelect() {
 		},
 	}
 
-	data, _ := prepareData(csvFile, "csv", cfg)
+	data, _, _ := prepareData(csvFile, "csv", cfg)
 	s.Len(data, 2)
 	s.Equal("West", data[0].XAxis)
 	s.Require().Len(data[0].Stats, 4)
@@ -1022,7 +1051,7 @@ func (s *PipelineSuite) TestAssembleDatasetGroupedClearsPreserveRows() {
 		GroupPattern: "x,y",
 		Group:        []string{"region", "category"},
 	}
-	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, cfg)
+	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, cfg, nil)
 	s.False(ds.PreserveRows)
 }
 
@@ -1036,7 +1065,7 @@ func (s *PipelineSuite) TestPrepareDataColAxisExpandsOntoX() {
 	})
 	s.Require().NoError(err)
 
-	results, effective := prepareData(csvFile, "csv", cfg)
+	results, effective, _ := prepareData(csvFile, "csv", cfg)
 	s.Equal("x", effective.ColAxis)
 	// 2 load rows × 2 frameworks
 	s.Require().Len(results, 4)
@@ -1055,7 +1084,7 @@ func (s *PipelineSuite) TestPrepareDataColAxisExpandsOntoX() {
 	s.ElementsMatch([]string{"default", "chi"}, keysOf(xVals))
 	s.ElementsMatch([]string{"100", "1000"}, keysOf(yVals))
 
-	ds := assembleDataset(results, RunMeta{Name: "HTTP frameworks", Parser: "csv"}, nil, effective)
+	ds := assembleDataset(results, RunMeta{Name: "HTTP frameworks", Parser: "csv"}, nil, effective, nil)
 	s.ElementsMatch([]string{"x", "y"}, axisKeyList(ds.Axes))
 }
 
@@ -1082,7 +1111,7 @@ func (s *PipelineSuite) TestPrepareDataColAxisWithoutGroupWarnsAndSkips() {
 	var results []shared.DataPoint
 	var effective parser.Config
 	errOut := testutil.CaptureStderr(func() {
-		results, effective = prepareData(csvFile, "csv", cfg)
+		results, effective, _ = prepareData(csvFile, "csv", cfg)
 	})
 	s.Contains(errOut, "--col-axis requires grouping")
 	s.Empty(effective.ColAxis) // cleared on skip
@@ -1103,7 +1132,7 @@ func (s *PipelineSuite) TestPrepareDataColAxisNonTabularWarns() {
 
 	var effective parser.Config
 	errOut := testutil.CaptureStderr(func() {
-		_, effective = prepareData(benchFile, "go", cfg)
+		_, effective, _ = prepareData(benchFile, "go", cfg)
 	})
 	s.Contains(errOut, "only supported for csv/json")
 	s.Empty(effective.ColAxis)
@@ -1126,7 +1155,7 @@ func (s *PipelineSuite) TestPrepareDataColAxisSelectModeSkips() {
 	var results []shared.DataPoint
 	var effective parser.Config
 	errOut := testutil.CaptureStderr(func() {
-		results, effective = prepareData(csvFile, "csv", cfg)
+		results, effective, _ = prepareData(csvFile, "csv", cfg)
 	})
 	s.Contains(errOut, "requires grouped multi-column stats")
 	s.Empty(effective.ColAxis)
@@ -1157,7 +1186,7 @@ func (s *PipelineSuite) TestPrepareDataColAxisZWithXY() {
 	})
 	s.Require().NoError(err)
 
-	results, effective := prepareData(csvFile, "csv", cfg)
+	results, effective, _ := prepareData(csvFile, "csv", cfg)
 	s.Equal("z", effective.ColAxis)
 	s.Require().NotEmpty(results)
 	zVals := map[string]struct{}{}
@@ -1168,7 +1197,7 @@ func (s *PipelineSuite) TestPrepareDataColAxisZWithXY() {
 	}
 	s.ElementsMatch([]string{"default", "chi"}, keysOf(zVals))
 
-	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, effective)
+	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, effective, nil)
 	s.Contains(axisKeyList(ds.Axes), "z")
 }
 
@@ -1197,7 +1226,7 @@ func (s *PipelineSuite) TestAssembleDatasetMultiSelectStatAxesLabel() {
 			{Columns: []parser.ColumnSpec{{Source: "region", Label: "Region", AxisKey: "x"}, {Source: "amount", AxisKey: "y"}}},
 		},
 	}
-	ds := assembleDataset(results, RunMeta{Parser: "csv"}, nil, cfg)
+	ds := assembleDataset(results, RunMeta{Parser: "csv"}, nil, cfg, nil)
 	s.Require().Len(ds.Axes, 1)
 	s.Equal("x", ds.Axes[0].Key)
 	s.Equal("Region", ds.Axes[0].Label)

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -119,7 +119,7 @@ func Convert(in ConvertInput) (ConvertResult, error) {
 	if err != nil {
 		return ConvertResult{}, err
 	}
-	points, effectiveCfg, err := parseFn(bytes.NewReader(data), cfg)
+	points, effectiveCfg, system, err := parseFn(bytes.NewReader(data), cfg)
 	if err != nil {
 		return ConvertResult{}, err
 	}
@@ -134,7 +134,11 @@ func Convert(in ConvertInput) (ConvertResult, error) {
 		return ConvertResult{}, fmt.Errorf("no dataset found")
 	}
 
-	dataset := Assemble(AssembleInput{Points: points, Parser: key, Config: effectiveCfg, Metadata: in.Metadata, Charts: in.Charts})
+	metadata := in.Metadata
+	if metadata.System == nil {
+		metadata.System = system
+	}
+	dataset := Assemble(AssembleInput{Points: points, Parser: key, Config: effectiveCfg, Metadata: metadata, Charts: in.Charts})
 	for _, chart := range in.Charts {
 		if swap := chart.SwapString(); swap != "" {
 			if err := shared.ValidateSwap(swap, dataset.Axes); err != nil {

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"math"
 	"strings"
+	"sync"
 	"testing"
 
 	internalcharts "github.com/goptics/vizb/internal/charts"
@@ -149,6 +150,70 @@ func (s *CoreSuite) TestConvertBenchmarkFormats() {
 			s.Require().Len(result.Dataset.Data, 1)
 		})
 	}
+}
+
+func (s *CoreSuite) TestConvertGoBenchmarkMetadataIsRequestLocal() {
+	cases := []struct {
+		input string
+		meta  shared.Meta
+	}{
+		{
+			input: "goos: linux\ngoarch: amd64\npkg: example.com/linux\ncpu: Linux CPU\nBenchmarkFoo-4 100 123 ns/op\n",
+			meta:  shared.Meta{OS: "linux", Arch: "amd64", Pkg: "example.com/linux", CPU: &shared.CPUInfo{Name: "Linux CPU", Cores: 4}},
+		},
+		{
+			input: "goos: darwin\ngoarch: arm64\npkg: example.com/darwin\ncpu: Darwin CPU\nBenchmarkBar-12 100 456 ns/op\n",
+			meta:  shared.Meta{OS: "darwin", Arch: "arm64", Pkg: "example.com/darwin", CPU: &shared.CPUInfo{Name: "Darwin CPU", Cores: 12}},
+		},
+	}
+	type outcome struct {
+		index   int
+		dataset *shared.Dataset
+		err     error
+	}
+
+	const conversions = 64
+	start := make(chan struct{})
+	outcomes := make(chan outcome, conversions)
+	var wg sync.WaitGroup
+	for i := 0; i < conversions; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			<-start
+			tc := cases[index%len(cases)]
+			result, err := Convert(ConvertInput{
+				Input:  []byte(tc.input),
+				Parser: "go",
+				Config: parser.Config{GroupPattern: "y", TimeUnit: "ns"},
+				Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
+			})
+			outcomes <- outcome{index: index, dataset: result.Dataset, err: err}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(outcomes)
+
+	for outcome := range outcomes {
+		s.Require().NoError(outcome.err)
+		s.Require().NotNil(outcome.dataset)
+		s.Equal(&cases[outcome.index%len(cases)].meta, outcome.dataset.Meta)
+	}
+}
+
+func (s *CoreSuite) TestConvertKeepsExplicitSystemMetadata() {
+	explicit := &shared.Meta{OS: "caller"}
+	result, err := Convert(ConvertInput{
+		Input:    []byte("goos: linux\nBenchmarkFoo-4 100 123 ns/op\n"),
+		Parser:   "go",
+		Config:   parser.Config{GroupPattern: "y", TimeUnit: "ns"},
+		Metadata: Metadata{System: explicit},
+		Charts:   []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
+	})
+
+	s.Require().NoError(err)
+	s.Same(explicit, result.Dataset.Meta)
 }
 
 func (s *CoreSuite) TestConvertAutoJSONPathEnvelope() {

--- a/pkg/parser/csv/csv.go
+++ b/pkg/parser/csv/csv.go
@@ -32,12 +32,13 @@ func parseFinite(s string) (float64, bool) {
 // ignored unless named in --group/-g, whose values are joined with the
 // separators from --group-pattern/-p and routed through the grouping machinery
 // (-p/-r) for name/xAxis/yAxis placement.
-func ParseCSV(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, error) {
+func ParseCSV(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, *shared.Meta, error) {
 	autoDetect := parser.AutoDetectTabularConfig
 	if cfg.QuietAutoDetect {
 		autoDetect = parser.AutoDetectTabularConfigQuiet
 	}
-	return parseReader(input, cfg, autoDetect)
+	points, effectiveCfg, err := parseReader(input, cfg, autoDetect)
+	return points, effectiveCfg, nil, err
 }
 
 type autoDetectFunc func(parser.Config, []string, [][]string) (parser.Config, error)

--- a/pkg/parser/csv/csv_test.go
+++ b/pkg/parser/csv/csv_test.go
@@ -28,7 +28,8 @@ func parseCSVFile(t testing.TB, path string, cfg parser.Config) ([]shared.DataPo
 		return nil, cfg, err
 	}
 	defer input.Close()
-	return ParseCSV(input, cfg)
+	points, effectiveCfg, _, err := ParseCSV(input, cfg)
+	return points, effectiveCfg, err
 }
 
 func parseCSVFileError(t testing.TB, path string, cfg parser.Config) error {
@@ -358,7 +359,7 @@ func (s *CSVSuite) TestLessThanTwoRowsReturnsNil() {
 }
 
 func (s *CSVSuite) TestParseCSVReturnsResultsAndErrors() {
-	results, cfg, err := ParseCSV(strings.NewReader("name,sells\nalpha,10\n"), parser.Config{
+	results, cfg, _, err := ParseCSV(strings.NewReader("name,sells\nalpha,10\n"), parser.Config{
 		GroupPattern: "x",
 		Group:        []string{"name"},
 	})
@@ -367,16 +368,16 @@ func (s *CSVSuite) TestParseCSVReturnsResultsAndErrors() {
 	s.Require().Len(results, 1)
 	s.Equal("alpha", results[0].XAxis)
 
-	_, _, err = ParseCSV(strings.NewReader("name,sells\nalpha,10\n"), parser.Config{
+	_, _, _, err = ParseCSV(strings.NewReader("name,sells\nalpha,10\n"), parser.Config{
 		GroupPattern: "x",
 		Group:        []string{"missing"},
 	})
 	s.ErrorContains(err, `group column "missing" not found`)
 
-	_, _, err = ParseCSV(strings.NewReader("name,sells\nalpha,\"bad\n"), parser.Config{GroupPattern: "x"})
+	_, _, _, err = ParseCSV(strings.NewReader("name,sells\nalpha,\"bad\n"), parser.Config{GroupPattern: "x"})
 	s.ErrorContains(err, "read CSV")
 
-	_, _, err = ParseCSV(strings.NewReader("name,sells\nalpha,10\n"), parser.Config{
+	_, _, _, err = ParseCSV(strings.NewReader("name,sells\nalpha,10\n"), parser.Config{
 		Group:        []string{"name", "sells"},
 		GroupPattern: "x",
 	})
@@ -396,7 +397,7 @@ func (s *CSVSuite) TestParseCSVReturnsAutoDetectError() {
 }
 
 func (s *CSVSuite) TestParseCSVReturnsGroupRowError() {
-	_, _, err := ParseCSV(strings.NewReader("name,sells\nalpha,10\n"), parser.Config{
+	_, _, _, err := ParseCSV(strings.NewReader("name,sells\nalpha,10\n"), parser.Config{
 		Group:      []string{"name"},
 		GroupRegex: "explicit-regex-bypasses-tabular-pattern",
 	})

--- a/pkg/parser/golang/golang.go
+++ b/pkg/parser/golang/golang.go
@@ -18,14 +18,6 @@ func init() {
 	parser.Parsers["go"] = ParseGoBenchmark
 }
 
-func storeCpuCount(cpu string) {
-	if shared.CPUCount == 0 {
-		if cpuCount, err := strconv.Atoi(cpu); err == nil {
-			shared.CPUCount = cpuCount
-		}
-	}
-}
-
 func parseBenchmarkName(name benchfmt.Name) (benchName string, cpu string) {
 	b, ps := name.Parts()
 	benchName = string(b)
@@ -43,12 +35,15 @@ func parseBenchmarkName(name benchfmt.Name) (benchName string, cpu string) {
 	return
 }
 
-func ParseGoBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, error) {
+func ParseGoBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, *shared.Meta, error) {
 	var results []shared.DataPoint
+	var system shared.Meta
+	var cpuName string
+	var cpuCount int
 
 	benchmarkInput, err := prepareBenchmarkInput(input)
 	if err != nil {
-		return nil, cfg, err
+		return nil, cfg, nil, err
 	}
 	reader := benchfmt.NewReader(benchmarkInput, "input")
 
@@ -62,12 +57,15 @@ func ParseGoBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, p
 			continue
 		}
 
-		shared.OS, shared.Arch, shared.Pkg, shared.CPU = result.GetConfig("goos"), result.GetConfig("goarch"), result.GetConfig("pkg"), result.GetConfig("cpu")
+		system.OS = result.GetConfig("goos")
+		system.Arch = result.GetConfig("goarch")
+		system.Pkg = result.GetConfig("pkg")
+		cpuName = strings.TrimSpace(result.GetConfig("cpu"))
 		rawBenchName, cpuCore := parseBenchmarkName(result.Name)
 
 		include, err := parser.ShouldIncludeBenchmark(rawBenchName, cfg)
 		if err != nil {
-			return nil, cfg, err
+			return nil, cfg, nil, err
 		}
 		if !include {
 			continue
@@ -76,12 +74,16 @@ func ParseGoBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, p
 		group, err := parser.GroupBenchmarkName(rawBenchName, cfg)
 
 		if err != nil {
-			return nil, cfg, fmt.Errorf("parse group from benchmark name: %w", err)
+			return nil, cfg, nil, fmt.Errorf("parse group from benchmark name: %w", err)
 		}
 
 		benchName, xAxis, yAxis, zAxis := group["name"], group["xAxis"], group["yAxis"], group["zAxis"]
 
-		storeCpuCount(cpuCore)
+		if cpuCount == 0 {
+			if count, err := strconv.Atoi(cpuCore); err == nil {
+				cpuCount = count
+			}
+		}
 
 		var benchStats []shared.Stat
 
@@ -142,7 +144,7 @@ func ParseGoBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, p
 		allIters = append(allIters, result.Iters)
 	}
 	if err := reader.Err(); err != nil {
-		return nil, cfg, fmt.Errorf("read Go benchmark: %w", err)
+		return nil, cfg, nil, fmt.Errorf("read Go benchmark: %w", err)
 	}
 
 	hasDifferentIters := false
@@ -165,7 +167,14 @@ func ParseGoBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, p
 		}
 	}
 
-	return results, cfg, nil
+	if cpuName != "" || cpuCount != 0 {
+		system.CPU = &shared.CPUInfo{Name: cpuName, Cores: cpuCount}
+	}
+	var systemOutput *shared.Meta
+	if system != (shared.Meta{}) {
+		systemOutput = &system
+	}
+	return results, cfg, systemOutput, nil
 }
 
 // prepareBenchmarkInput converts Go test -json events to their benchmark text

--- a/pkg/parser/golang/golang.go
+++ b/pkg/parser/golang/golang.go
@@ -35,6 +35,8 @@ func parseBenchmarkName(name benchfmt.Name) (benchName string, cpu string) {
 	return
 }
 
+// ParseGoBenchmark converts Go benchmark text or go test JSON events into data
+// points and returns any system metadata found in the benchmark configuration.
 func ParseGoBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, *shared.Meta, error) {
 	var results []shared.DataPoint
 	var system shared.Meta

--- a/pkg/parser/golang/golang_test.go
+++ b/pkg/parser/golang/golang_test.go
@@ -24,8 +24,7 @@ type testBlock struct {
 	expectCPUCount int
 }
 
-// GoBenchmarkSuite exercises ParseGoBenchmark with a per-case parser.Config,
-// resetting the shared.CPUCount global between cases.
+// GoBenchmarkSuite exercises ParseGoBenchmark with a per-case parser.Config.
 type GoBenchmarkSuite struct {
 	suite.Suite
 }
@@ -48,14 +47,6 @@ func (r *dataErrorReader) Read(p []byte) (int, error) {
 	}
 	r.done = true
 	return copy(p, r.data), r.err
-}
-
-func (s *GoBenchmarkSuite) SetupTest() {
-	shared.CPUCount = 0
-}
-
-func (s *GoBenchmarkSuite) TearDownTest() {
-	shared.CPUCount = 0
 }
 
 func (s *GoBenchmarkSuite) TestParseGoBenchmark() {
@@ -241,7 +232,6 @@ func (s *GoBenchmarkSuite) TestParseGoBenchmark() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			shared.CPUCount = 0
 			cfg := parser.Config{
 				GroupPattern: tt.pattern,
 				TimeUnit:     tt.timeUnit,
@@ -249,7 +239,7 @@ func (s *GoBenchmarkSuite) TestParseGoBenchmark() {
 				NumberUnit:   tt.allocUnit,
 			}
 
-			results, _, err := ParseGoBenchmark(strings.NewReader(strings.Join(tt.benchContent, "\n")), cfg)
+			results, _, system, err := ParseGoBenchmark(strings.NewReader(strings.Join(tt.benchContent, "\n")), cfg)
 			s.Require().NoError(err)
 
 			s.Require().Len(results, len(tt.expected))
@@ -269,16 +259,39 @@ func (s *GoBenchmarkSuite) TestParseGoBenchmark() {
 				}
 			}
 
-			s.Equal(tt.expectCPUCount, shared.CPUCount, "CPUCount")
+			cpuCount := 0
+			if system != nil && system.CPU != nil {
+				cpuCount = system.CPU.Cores
+			}
+			s.Equal(tt.expectCPUCount, cpuCount, "CPUCount")
 		})
 	}
+}
+
+func (s *GoBenchmarkSuite) TestParseGoBenchmarkReturnsSystemMetadata() {
+	input := strings.Join([]string{
+		"goos: linux",
+		"goarch: arm64",
+		"pkg: example.com/request-a",
+		"cpu: Request A CPU",
+		"BenchmarkExample-12 100 123 ns/op",
+	}, "\n")
+
+	_, _, system, err := ParseGoBenchmark(strings.NewReader(input), parser.Config{GroupPattern: "y"})
+
+	s.Require().NoError(err)
+	s.Require().NotNil(system)
+	s.Equal("linux", system.OS)
+	s.Equal("arm64", system.Arch)
+	s.Equal("example.com/request-a", system.Pkg)
+	s.Equal(&shared.CPUInfo{Name: "Request A CPU", Cores: 12}, system.CPU)
 }
 
 func (s *GoBenchmarkSuite) TestParseGoBenchmarkReturnsErrors() {
 	benchmark := "BenchmarkExample 100 123 ns/op"
 
 	s.Run("invalid filter", func() {
-		_, _, err := ParseGoBenchmark(strings.NewReader(benchmark), parser.Config{
+		_, _, _, err := ParseGoBenchmark(strings.NewReader(benchmark), parser.Config{
 			GroupPattern: "y",
 			Filter:       "[",
 		})
@@ -286,14 +299,14 @@ func (s *GoBenchmarkSuite) TestParseGoBenchmarkReturnsErrors() {
 	})
 
 	s.Run("invalid benchmark group pattern", func() {
-		_, _, err := ParseGoBenchmark(strings.NewReader(benchmark), parser.Config{
+		_, _, _, err := ParseGoBenchmark(strings.NewReader(benchmark), parser.Config{
 			GroupPattern: "[n/y]",
 		})
 		s.ErrorContains(err, "bracket slots")
 	})
 
 	s.Run("filter excludes benchmark", func() {
-		results, _, err := ParseGoBenchmark(strings.NewReader(benchmark), parser.Config{
+		results, _, _, err := ParseGoBenchmark(strings.NewReader(benchmark), parser.Config{
 			GroupPattern: "y",
 			Filter:       "^Other$",
 		})
@@ -302,7 +315,7 @@ func (s *GoBenchmarkSuite) TestParseGoBenchmarkReturnsErrors() {
 	})
 
 	s.Run("non-result record is ignored", func() {
-		results, _, err := ParseGoBenchmark(strings.NewReader("BenchmarkBroken not-a-result\n"), parser.Config{
+		results, _, _, err := ParseGoBenchmark(strings.NewReader("BenchmarkBroken not-a-result\n"), parser.Config{
 			GroupPattern: "y",
 		})
 		s.Require().NoError(err)
@@ -310,7 +323,7 @@ func (s *GoBenchmarkSuite) TestParseGoBenchmarkReturnsErrors() {
 	})
 
 	s.Run("reader failure", func() {
-		_, _, err := ParseGoBenchmark(goErrorReader{}, parser.Config{GroupPattern: "y"})
+		_, _, _, err := ParseGoBenchmark(goErrorReader{}, parser.Config{GroupPattern: "y"})
 		s.ErrorContains(err, "read Go benchmark")
 	})
 
@@ -319,7 +332,7 @@ func (s *GoBenchmarkSuite) TestParseGoBenchmarkReturnsErrors() {
 			data: []byte("BenchmarkExample 100 123 ns/op\n"),
 			err:  errors.New("injected trailing failure"),
 		}
-		_, _, err := ParseGoBenchmark(input, parser.Config{GroupPattern: "y"})
+		_, _, _, err := ParseGoBenchmark(input, parser.Config{GroupPattern: "y"})
 		s.ErrorContains(err, "read Go benchmark")
 	})
 }
@@ -331,7 +344,7 @@ func (s *GoBenchmarkSuite) TestParseGoBenchmarkJSONEvents() {
 		`{"Action":"pass","Test":"BenchmarkExample"}`,
 	}, "\n")
 
-	results, _, err := ParseGoBenchmark(strings.NewReader(input), parser.Config{
+	results, _, system, err := ParseGoBenchmark(strings.NewReader(input), parser.Config{
 		GroupPattern: "y",
 		TimeUnit:     "ns",
 	})
@@ -339,7 +352,8 @@ func (s *GoBenchmarkSuite) TestParseGoBenchmarkJSONEvents() {
 	s.Require().NoError(err)
 	s.Require().Len(results, 1)
 	s.Equal("Example", results[0].YAxis)
-	s.Equal(8, shared.CPUCount)
+	s.Require().NotNil(system)
+	s.Equal(&shared.CPUInfo{Cores: 8}, system.CPU)
 	s.Require().Len(results[0].Stats, 1)
 	s.Equal("Execution Time (ns/op)", results[0].Stats[0].Type)
 	s.InDelta(123, *results[0].Stats[0].Value, 0.001)
@@ -348,7 +362,7 @@ func (s *GoBenchmarkSuite) TestParseGoBenchmarkJSONEvents() {
 func (s *GoBenchmarkSuite) TestParseGoBenchmarkJSONEventErrors() {
 	s.Run("malformed later event", func() {
 		input := "{\"Action\":\"run\"}\nnot-json\n"
-		_, _, err := ParseGoBenchmark(strings.NewReader(input), parser.Config{GroupPattern: "y"})
+		_, _, _, err := ParseGoBenchmark(strings.NewReader(input), parser.Config{GroupPattern: "y"})
 		s.ErrorContains(err, "read Go benchmark JSON")
 	})
 
@@ -357,7 +371,7 @@ func (s *GoBenchmarkSuite) TestParseGoBenchmarkJSONEventErrors() {
 			data: []byte(`{"Action":"run"}`),
 			err:  errors.New("injected event failure"),
 		}
-		_, _, err := ParseGoBenchmark(input, parser.Config{GroupPattern: "y"})
+		_, _, _, err := ParseGoBenchmark(input, parser.Config{GroupPattern: "y"})
 		s.ErrorContains(err, "read Go benchmark JSON")
 	})
 
@@ -366,7 +380,7 @@ func (s *GoBenchmarkSuite) TestParseGoBenchmarkJSONEventErrors() {
 			data: []byte("{\"Action\":\"run\"}\n"),
 			err:  errors.New("injected event failure"),
 		}
-		_, _, err := ParseGoBenchmark(input, parser.Config{GroupPattern: "y"})
+		_, _, _, err := ParseGoBenchmark(input, parser.Config{GroupPattern: "y"})
 		s.ErrorContains(err, "read Go benchmark JSON")
 	})
 
@@ -380,7 +394,7 @@ func (s *GoBenchmarkSuite) TestParseGoBenchmarkJSONEventErrors() {
 
 	s.Run("single event without trailing newline", func() {
 		input := `{"Action":"output","Output":"BenchmarkExample 100 123 ns/op\n"}`
-		results, _, err := ParseGoBenchmark(strings.NewReader(input), parser.Config{
+		results, _, _, err := ParseGoBenchmark(strings.NewReader(input), parser.Config{
 			GroupPattern: "y",
 			TimeUnit:     "ns",
 		})

--- a/pkg/parser/javascript/tinybench.go
+++ b/pkg/parser/javascript/tinybench.go
@@ -51,6 +51,7 @@ func parseMedWithMAD(s string) (med, mad float64) {
 	return
 }
 
+// ParseTinyBenchBenchmark converts Tinybench table output into data points.
 func ParseTinyBenchBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, *shared.Meta, error) {
 	scanner := bufio.NewScanner(input)
 	var results []shared.DataPoint

--- a/pkg/parser/javascript/tinybench.go
+++ b/pkg/parser/javascript/tinybench.go
@@ -51,7 +51,7 @@ func parseMedWithMAD(s string) (med, mad float64) {
 	return
 }
 
-func ParseTinyBenchBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, error) {
+func ParseTinyBenchBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, *shared.Meta, error) {
 	scanner := bufio.NewScanner(input)
 	var results []shared.DataPoint
 
@@ -76,7 +76,7 @@ func ParseTinyBenchBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataP
 
 		include, err := parser.ShouldIncludeBenchmark(taskName, cfg)
 		if err != nil {
-			return nil, cfg, err
+			return nil, cfg, nil, err
 		}
 		if !include {
 			continue
@@ -96,7 +96,7 @@ func ParseTinyBenchBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataP
 
 		group, groupErr := parser.GroupBenchmarkName(taskName, cfg)
 		if groupErr != nil {
-			return nil, cfg, fmt.Errorf("parse tinybench name: %w", groupErr)
+			return nil, cfg, nil, fmt.Errorf("parse tinybench name: %w", groupErr)
 		}
 
 		benchName, xAxis, yAxis, zAxis := group["name"], group["xAxis"], group["yAxis"], group["zAxis"]
@@ -121,8 +121,8 @@ func ParseTinyBenchBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataP
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, cfg, fmt.Errorf("read tinybench benchmark: %w", err)
+		return nil, cfg, nil, fmt.Errorf("read tinybench benchmark: %w", err)
 	}
 
-	return results, cfg, nil
+	return results, cfg, nil, nil
 }

--- a/pkg/parser/javascript/tinybench_test.go
+++ b/pkg/parser/javascript/tinybench_test.go
@@ -38,7 +38,7 @@ func (s *TinyBenchSuite) SetupTest() {
 }
 
 func (s *TinyBenchSuite) TestRealTinybenchOutput() {
-	results, _, err := ParseTinyBenchBenchmark(javascriptTestInput(s.T(), testSortingTable), s.cfg)
+	results, _, _, err := ParseTinyBenchBenchmark(javascriptTestInput(s.T(), testSortingTable), s.cfg)
 	s.Require().NoError(err)
 	s.Len(results, 6)
 
@@ -65,7 +65,7 @@ func (s *TinyBenchSuite) TestRealTinybenchOutput() {
 func (s *TinyBenchSuite) TestUnitConversionToUs() {
 	s.cfg.TimeUnit = "us"
 
-	results, _, err := ParseTinyBenchBenchmark(javascriptTestInput(s.T(), testSortingTable), s.cfg)
+	results, _, _, err := ParseTinyBenchBenchmark(javascriptTestInput(s.T(), testSortingTable), s.cfg)
 	s.Require().NoError(err)
 	s.Len(results, 6)
 
@@ -76,7 +76,7 @@ func (s *TinyBenchSuite) TestUnitConversionToUs() {
 func (s *TinyBenchSuite) TestFilterRegex() {
 	s.cfg.Filter = "bubbleSort"
 
-	results, _, err := ParseTinyBenchBenchmark(javascriptTestInput(s.T(), testSortingTable), s.cfg)
+	results, _, _, err := ParseTinyBenchBenchmark(javascriptTestInput(s.T(), testSortingTable), s.cfg)
 	s.Require().NoError(err)
 	s.Len(results, 3)
 	for _, r := range results {
@@ -87,7 +87,7 @@ func (s *TinyBenchSuite) TestFilterRegex() {
 func (s *TinyBenchSuite) TestEmptyFile() {
 	s.cfg.GroupPattern = "y"
 
-	results, _, err := ParseTinyBenchBenchmark(javascriptTestInput(s.T(), ""), s.cfg)
+	results, _, _, err := ParseTinyBenchBenchmark(javascriptTestInput(s.T(), ""), s.cfg)
 	s.Require().NoError(err)
 	s.Empty(results)
 }
@@ -96,19 +96,19 @@ func (s *TinyBenchSuite) TestReturnsErrors() {
 	s.Run("invalid filter", func() {
 		cfg := s.cfg
 		cfg.Filter = "["
-		_, _, err := ParseTinyBenchBenchmark(javascriptTestInput(s.T(), testSortingTable), cfg)
+		_, _, _, err := ParseTinyBenchBenchmark(javascriptTestInput(s.T(), testSortingTable), cfg)
 		s.ErrorContains(err, "invalid filter regex")
 	})
 
 	s.Run("invalid benchmark group pattern", func() {
 		cfg := s.cfg
 		cfg.GroupPattern = "[n/y]"
-		_, _, err := ParseTinyBenchBenchmark(javascriptTestInput(s.T(), testSortingTable), cfg)
+		_, _, _, err := ParseTinyBenchBenchmark(javascriptTestInput(s.T(), testSortingTable), cfg)
 		s.ErrorContains(err, "bracket slots")
 	})
 
 	s.Run("reader failure", func() {
-		_, _, err := ParseTinyBenchBenchmark(javascriptErrorReader{}, s.cfg)
+		_, _, _, err := ParseTinyBenchBenchmark(javascriptErrorReader{}, s.cfg)
 		s.ErrorContains(err, "read tinybench benchmark")
 	})
 }

--- a/pkg/parser/javascript/vitest.go
+++ b/pkg/parser/javascript/vitest.go
@@ -26,7 +26,7 @@ func parseNum(s string) float64 {
 	return n
 }
 
-func ParseVitestBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, error) {
+func ParseVitestBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, *shared.Meta, error) {
 	scanner := bufio.NewScanner(input)
 	var results []shared.DataPoint
 	var currentSuite string
@@ -64,7 +64,7 @@ func ParseVitestBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoin
 
 		include, err := parser.ShouldIncludeBenchmark(name, cfg)
 		if err != nil {
-			return nil, cfg, err
+			return nil, cfg, nil, err
 		}
 		if !include {
 			continue
@@ -85,7 +85,7 @@ func ParseVitestBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoin
 
 		group, groupErr := parser.GroupBenchmarkName(name, cfg)
 		if groupErr != nil {
-			return nil, cfg, fmt.Errorf("parse vitest benchmark name: %w", groupErr)
+			return nil, cfg, nil, fmt.Errorf("parse vitest benchmark name: %w", groupErr)
 		}
 
 		benchName, xAxis, yAxis, zAxis := group["name"], group["xAxis"], group["yAxis"], group["zAxis"]
@@ -111,8 +111,8 @@ func ParseVitestBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoin
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, cfg, fmt.Errorf("read vitest benchmark: %w", err)
+		return nil, cfg, nil, fmt.Errorf("read vitest benchmark: %w", err)
 	}
 
-	return results, cfg, nil
+	return results, cfg, nil, nil
 }

--- a/pkg/parser/javascript/vitest.go
+++ b/pkg/parser/javascript/vitest.go
@@ -26,6 +26,7 @@ func parseNum(s string) float64 {
 	return n
 }
 
+// ParseVitestBenchmark converts Vitest benchmark output into data points.
 func ParseVitestBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, *shared.Meta, error) {
 	scanner := bufio.NewScanner(input)
 	var results []shared.DataPoint

--- a/pkg/parser/javascript/vitest_test.go
+++ b/pkg/parser/javascript/vitest_test.go
@@ -64,7 +64,7 @@ func (s *VitestSuite) SetupTest() {
 }
 
 func (s *VitestSuite) TestRealVitestOutput() {
-	results, _, err := ParseVitestBenchmark(javascriptTestInput(s.T(), testVitestTable), s.cfg)
+	results, _, _, err := ParseVitestBenchmark(javascriptTestInput(s.T(), testVitestTable), s.cfg)
 	s.Require().NoError(err)
 	s.Len(results, 6)
 
@@ -92,7 +92,7 @@ func (s *VitestSuite) TestRealVitestOutput() {
 func (s *VitestSuite) TestUnitConversionToUs() {
 	s.cfg.TimeUnit = "us"
 
-	results, _, err := ParseVitestBenchmark(javascriptTestInput(s.T(), testVitestTable), s.cfg)
+	results, _, _, err := ParseVitestBenchmark(javascriptTestInput(s.T(), testVitestTable), s.cfg)
 	s.Require().NoError(err)
 	s.Len(results, 6)
 
@@ -103,7 +103,7 @@ func (s *VitestSuite) TestUnitConversionToUs() {
 func (s *VitestSuite) TestFilterRegex() {
 	s.cfg.Filter = "bubbleSort"
 
-	results, _, err := ParseVitestBenchmark(javascriptTestInput(s.T(), testVitestTable), s.cfg)
+	results, _, _, err := ParseVitestBenchmark(javascriptTestInput(s.T(), testVitestTable), s.cfg)
 	s.Require().NoError(err)
 	s.Len(results, 3)
 	for _, r := range results {
@@ -114,7 +114,7 @@ func (s *VitestSuite) TestFilterRegex() {
 func (s *VitestSuite) TestEmptyFile() {
 	s.cfg.GroupPattern = "y"
 
-	results, _, err := ParseVitestBenchmark(javascriptTestInput(s.T(), ""), s.cfg)
+	results, _, _, err := ParseVitestBenchmark(javascriptTestInput(s.T(), ""), s.cfg)
 	s.Require().NoError(err)
 	s.Empty(results)
 }
@@ -123,19 +123,19 @@ func (s *VitestSuite) TestReturnsErrors() {
 	s.Run("invalid filter", func() {
 		cfg := s.cfg
 		cfg.Filter = "["
-		_, _, err := ParseVitestBenchmark(javascriptTestInput(s.T(), testVitestTable), cfg)
+		_, _, _, err := ParseVitestBenchmark(javascriptTestInput(s.T(), testVitestTable), cfg)
 		s.ErrorContains(err, "invalid filter regex")
 	})
 
 	s.Run("invalid benchmark group pattern", func() {
 		cfg := s.cfg
 		cfg.GroupPattern = "[n/y]"
-		_, _, err := ParseVitestBenchmark(javascriptTestInput(s.T(), testVitestTable), cfg)
+		_, _, _, err := ParseVitestBenchmark(javascriptTestInput(s.T(), testVitestTable), cfg)
 		s.ErrorContains(err, "bracket slots")
 	})
 
 	s.Run("reader failure", func() {
-		_, _, err := ParseVitestBenchmark(javascriptErrorReader{}, s.cfg)
+		_, _, _, err := ParseVitestBenchmark(javascriptErrorReader{}, s.cfg)
 		s.ErrorContains(err, "read vitest benchmark")
 	})
 }

--- a/pkg/parser/json/json.go
+++ b/pkg/parser/json/json.go
@@ -65,8 +65,9 @@ func stringify(v any) string {
 // the separators from --group-pattern/-p and routed through the grouping
 // machinery (-p/-r). Nested objects are
 // flattened to dotted keys; array-valued fields inside objects are skipped.
-func ParseJSON(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, error) {
-	return parseReader(input, cfg, !cfg.QuietAutoDetect)
+func ParseJSON(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, *shared.Meta, error) {
+	points, effectiveCfg, err := parseReader(input, cfg, !cfg.QuietAutoDetect)
+	return points, effectiveCfg, nil, err
 }
 
 func parseReader(input io.Reader, cfg parser.Config, logAuto bool) ([]shared.DataPoint, parser.Config, error) {

--- a/pkg/parser/json/json_test.go
+++ b/pkg/parser/json/json_test.go
@@ -30,7 +30,8 @@ func parseJSONFile(t testing.TB, path string, cfg parser.Config) ([]shared.DataP
 		return nil, cfg, err
 	}
 	defer input.Close()
-	return ParseJSON(input, cfg)
+	points, effectiveCfg, _, err := ParseJSON(input, cfg)
+	return points, effectiveCfg, err
 }
 
 func parseJSONFileError(t testing.TB, path string, cfg parser.Config) error {
@@ -508,7 +509,7 @@ func (s *JSONSuite) TestNonArrayInputReturnsNil() {
 }
 
 func (s *JSONSuite) TestParseJSONReturnsResultsAndErrors() {
-	results, cfg, err := ParseJSON(strings.NewReader(`[{"name":"alpha","sells":10}]`), parser.Config{
+	results, cfg, _, err := ParseJSON(strings.NewReader(`[{"name":"alpha","sells":10}]`), parser.Config{
 		GroupPattern: "x",
 		Group:        []string{"name"},
 	})
@@ -517,16 +518,16 @@ func (s *JSONSuite) TestParseJSONReturnsResultsAndErrors() {
 	s.Require().Len(results, 1)
 	s.Equal("alpha", results[0].XAxis)
 
-	_, _, err = ParseJSON(strings.NewReader(`[{"name":"alpha","sells":10}]`), parser.Config{
+	_, _, _, err = ParseJSON(strings.NewReader(`[{"name":"alpha","sells":10}]`), parser.Config{
 		GroupPattern: "x",
 		Group:        []string{"missing"},
 	})
 	s.ErrorContains(err, `group field "missing" not found`)
 
-	_, _, err = ParseJSON(strings.NewReader(`[{"name":`), parser.Config{GroupPattern: "x"})
+	_, _, _, err = ParseJSON(strings.NewReader(`[{"name":`), parser.Config{GroupPattern: "x"})
 	s.ErrorContains(err, "read JSON")
 
-	results, _, err = ParseJSON(strings.NewReader(`[{"name":"alpha","sells":10}]`), parser.Config{
+	results, _, _, err = ParseJSON(strings.NewReader(`[{"name":"alpha","sells":10}]`), parser.Config{
 		AutoGroup:  true,
 		ChartTypes: []string{"scatter"},
 	})
@@ -634,18 +635,18 @@ func (s *JSONErrorSuite) TestMalformedMatrixReturnsError() {
 
 func (s *JSONErrorSuite) TestInitialTokenRead() {
 	s.Run("empty input remains empty", func() {
-		results, _, err := ParseJSON(strings.NewReader(""), s.cfg)
+		results, _, _, err := ParseJSON(strings.NewReader(""), s.cfg)
 		s.Require().NoError(err)
 		s.Empty(results)
 	})
 
 	s.Run("malformed input returns decoder error", func() {
-		_, _, err := ParseJSON(strings.NewReader("not-json"), s.cfg)
+		_, _, _, err := ParseJSON(strings.NewReader("not-json"), s.cfg)
 		s.ErrorContains(err, "read JSON")
 	})
 
 	s.Run("reader failure is preserved", func() {
-		_, _, err := ParseJSON(jsonErrorReader{}, s.cfg)
+		_, _, _, err := ParseJSON(jsonErrorReader{}, s.cfg)
 		s.ErrorContains(err, "injected read failure")
 	})
 }

--- a/pkg/parser/registry.go
+++ b/pkg/parser/registry.go
@@ -56,7 +56,9 @@ type SelectView struct {
 	TypeLabel string
 }
 
-type ParseFunc func(io.Reader, Config) ([]shared.DataPoint, Config, error)
+// ParseFunc parses request-local input and returns data points, the effective
+// config, and any system metadata discovered in the input.
+type ParseFunc func(io.Reader, Config) ([]shared.DataPoint, Config, *shared.Meta, error)
 
 var Parsers = map[string]ParseFunc{}
 

--- a/pkg/parser/registry_test.go
+++ b/pkg/parser/registry_test.go
@@ -27,7 +27,7 @@ func (s *RegistrySuite) TestGetParserKnown() {
 	s.NoError(err)
 	s.NotNil(fn)
 
-	points, _, err := fn(strings.NewReader(""), parser.Config{})
+	points, _, _, err := fn(strings.NewReader(""), parser.Config{})
 	s.NoError(err)
 	s.Empty(points)
 }

--- a/pkg/parser/rust/criterion.go
+++ b/pkg/parser/rust/criterion.go
@@ -19,7 +19,7 @@ func init() {
 
 var criterionRe = regexp.MustCompile(`^(\S+)\s+time:\s+\[([\d.]+)\s*(ns|µs|μs|ms|s)\s+([\d.]+)\s*(ns|µs|μs|ms|s)\s+([\d.]+)\s*(ns|µs|μs|ms|s)\]`)
 
-func ParseCriterionBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, error) {
+func ParseCriterionBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, *shared.Meta, error) {
 	scanner := bufio.NewScanner(input)
 	var results []shared.DataPoint
 
@@ -36,7 +36,7 @@ func ParseCriterionBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataP
 		name := match[1]
 		include, err := parser.ShouldIncludeBenchmark(name, cfg)
 		if err != nil {
-			return nil, cfg, err
+			return nil, cfg, nil, err
 		}
 		if !include {
 			continue
@@ -48,7 +48,7 @@ func ParseCriterionBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataP
 
 		group, groupErr := parser.GroupBenchmarkName(name, cfg)
 		if groupErr != nil {
-			return nil, cfg, fmt.Errorf("parse criterion benchmark name: %w", groupErr)
+			return nil, cfg, nil, fmt.Errorf("parse criterion benchmark name: %w", groupErr)
 		}
 
 		benchName, xAxis, yAxis, zAxis := group["name"], group["xAxis"], group["yAxis"], group["zAxis"]
@@ -67,8 +67,8 @@ func ParseCriterionBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataP
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, cfg, fmt.Errorf("read criterion benchmark: %w", err)
+		return nil, cfg, nil, fmt.Errorf("read criterion benchmark: %w", err)
 	}
 
-	return results, cfg, nil
+	return results, cfg, nil, nil
 }

--- a/pkg/parser/rust/criterion.go
+++ b/pkg/parser/rust/criterion.go
@@ -19,6 +19,7 @@ func init() {
 
 var criterionRe = regexp.MustCompile(`^(\S+)\s+time:\s+\[([\d.]+)\s*(ns|µs|μs|ms|s)\s+([\d.]+)\s*(ns|µs|μs|ms|s)\s+([\d.]+)\s*(ns|µs|μs|ms|s)\]`)
 
+// ParseCriterionBenchmark converts Criterion benchmark output into data points.
 func ParseCriterionBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, *shared.Meta, error) {
 	scanner := bufio.NewScanner(input)
 	var results []shared.DataPoint

--- a/pkg/parser/rust/criterion_test.go
+++ b/pkg/parser/rust/criterion_test.go
@@ -96,7 +96,7 @@ func (s *CriterionSuite) SetupTest() {
 }
 
 func (s *CriterionSuite) TestRealCargoCriterionOutput() {
-	results, _, err := ParseCriterionBenchmark(rustTestInput(s.T(), testCargoTable), s.cfg)
+	results, _, _, err := ParseCriterionBenchmark(rustTestInput(s.T(), testCargoTable), s.cfg)
 	s.Require().NoError(err)
 	s.Len(results, 6)
 
@@ -125,7 +125,7 @@ func (s *CriterionSuite) TestRealCargoCriterionOutput() {
 func (s *CriterionSuite) TestUnitConversionToUs() {
 	s.cfg.TimeUnit = "us"
 
-	results, _, err := ParseCriterionBenchmark(rustTestInput(s.T(), testCargoTable), s.cfg)
+	results, _, _, err := ParseCriterionBenchmark(rustTestInput(s.T(), testCargoTable), s.cfg)
 	s.Require().NoError(err)
 	s.Len(results, 6)
 
@@ -137,7 +137,7 @@ func (s *CriterionSuite) TestUnitConversionToUs() {
 func (s *CriterionSuite) TestFilterRegex() {
 	s.cfg.Filter = "bubbleSort"
 
-	results, _, err := ParseCriterionBenchmark(rustTestInput(s.T(), testCargoTable), s.cfg)
+	results, _, _, err := ParseCriterionBenchmark(rustTestInput(s.T(), testCargoTable), s.cfg)
 	s.Require().NoError(err)
 	s.Len(results, 3)
 	for _, r := range results {
@@ -148,7 +148,7 @@ func (s *CriterionSuite) TestFilterRegex() {
 func (s *CriterionSuite) TestEmptyFile() {
 	s.cfg.GroupPattern = "y"
 
-	results, _, err := ParseCriterionBenchmark(rustTestInput(s.T(), ""), s.cfg)
+	results, _, _, err := ParseCriterionBenchmark(rustTestInput(s.T(), ""), s.cfg)
 	s.Require().NoError(err)
 	s.Empty(results)
 }
@@ -157,19 +157,19 @@ func (s *CriterionSuite) TestReturnsErrors() {
 	s.Run("invalid filter", func() {
 		cfg := s.cfg
 		cfg.Filter = "["
-		_, _, err := ParseCriterionBenchmark(rustTestInput(s.T(), testCargoTable), cfg)
+		_, _, _, err := ParseCriterionBenchmark(rustTestInput(s.T(), testCargoTable), cfg)
 		s.ErrorContains(err, "invalid filter regex")
 	})
 
 	s.Run("invalid benchmark group pattern", func() {
 		cfg := s.cfg
 		cfg.GroupPattern = "[n/y]"
-		_, _, err := ParseCriterionBenchmark(rustTestInput(s.T(), testCargoTable), cfg)
+		_, _, _, err := ParseCriterionBenchmark(rustTestInput(s.T(), testCargoTable), cfg)
 		s.ErrorContains(err, "bracket slots")
 	})
 
 	s.Run("reader failure", func() {
-		_, _, err := ParseCriterionBenchmark(rustErrorReader{}, s.cfg)
+		_, _, _, err := ParseCriterionBenchmark(rustErrorReader{}, s.cfg)
 		s.ErrorContains(err, "read criterion benchmark")
 	})
 }

--- a/pkg/parser/rust/divan.go
+++ b/pkg/parser/rust/divan.go
@@ -21,7 +21,7 @@ var divanRowRe = regexp.MustCompile(`^[├╰]─\s+(\S+)\s+(.+)$`)
 
 var divanValRe = regexp.MustCompile(`([\d.]+)\s*(ns|µs|μs|ms|s)`)
 
-func ParseDivanBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, error) {
+func ParseDivanBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, *shared.Meta, error) {
 	scanner := bufio.NewScanner(input)
 	var results []shared.DataPoint
 
@@ -38,7 +38,7 @@ func ParseDivanBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint
 		name := match[1]
 		include, err := parser.ShouldIncludeBenchmark(name, cfg)
 		if err != nil {
-			return nil, cfg, err
+			return nil, cfg, nil, err
 		}
 		if !include {
 			continue
@@ -70,7 +70,7 @@ func ParseDivanBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint
 
 		group, groupErr := parser.GroupBenchmarkName(name, cfg)
 		if groupErr != nil {
-			return nil, cfg, fmt.Errorf("parse divan benchmark name: %w", groupErr)
+			return nil, cfg, nil, fmt.Errorf("parse divan benchmark name: %w", groupErr)
 		}
 
 		benchName, xAxis, yAxis, zAxis := group["name"], group["xAxis"], group["yAxis"], group["zAxis"]
@@ -91,8 +91,8 @@ func ParseDivanBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, cfg, fmt.Errorf("read divan benchmark: %w", err)
+		return nil, cfg, nil, fmt.Errorf("read divan benchmark: %w", err)
 	}
 
-	return results, cfg, nil
+	return results, cfg, nil, nil
 }

--- a/pkg/parser/rust/divan.go
+++ b/pkg/parser/rust/divan.go
@@ -21,6 +21,7 @@ var divanRowRe = regexp.MustCompile(`^[├╰]─\s+(\S+)\s+(.+)$`)
 
 var divanValRe = regexp.MustCompile(`([\d.]+)\s*(ns|µs|μs|ms|s)`)
 
+// ParseDivanBenchmark converts Divan benchmark output into data points.
 func ParseDivanBenchmark(input io.Reader, cfg parser.Config) ([]shared.DataPoint, parser.Config, *shared.Meta, error) {
 	scanner := bufio.NewScanner(input)
 	var results []shared.DataPoint

--- a/pkg/parser/rust/divan_test.go
+++ b/pkg/parser/rust/divan_test.go
@@ -27,7 +27,7 @@ func (s *DivanSuite) SetupTest() {
 }
 
 func (s *DivanSuite) TestRealDivanOutput() {
-	results, _, err := ParseDivanBenchmark(rustTestInput(s.T(), testDivanTable), s.cfg)
+	results, _, _, err := ParseDivanBenchmark(rustTestInput(s.T(), testDivanTable), s.cfg)
 	s.Require().NoError(err)
 	s.Len(results, 6)
 
@@ -49,7 +49,7 @@ func (s *DivanSuite) TestRealDivanOutput() {
 func (s *DivanSuite) TestUnitConversionToUs() {
 	s.cfg.TimeUnit = "us"
 
-	results, _, err := ParseDivanBenchmark(rustTestInput(s.T(), testDivanTable), s.cfg)
+	results, _, _, err := ParseDivanBenchmark(rustTestInput(s.T(), testDivanTable), s.cfg)
 	s.Require().NoError(err)
 	s.Len(results, 6)
 
@@ -61,7 +61,7 @@ func (s *DivanSuite) TestUnitConversionToUs() {
 func (s *DivanSuite) TestFilterRegex() {
 	s.cfg.Filter = "insertion"
 
-	results, _, err := ParseDivanBenchmark(rustTestInput(s.T(), testDivanTable), s.cfg)
+	results, _, _, err := ParseDivanBenchmark(rustTestInput(s.T(), testDivanTable), s.cfg)
 	s.Require().NoError(err)
 	s.Len(results, 3)
 	for _, r := range results {
@@ -70,7 +70,7 @@ func (s *DivanSuite) TestFilterRegex() {
 }
 
 func (s *DivanSuite) TestEmptyFile() {
-	results, _, err := ParseDivanBenchmark(rustTestInput(s.T(), ""), s.cfg)
+	results, _, _, err := ParseDivanBenchmark(rustTestInput(s.T(), ""), s.cfg)
 	s.Require().NoError(err)
 	s.Empty(results)
 }
@@ -79,19 +79,19 @@ func (s *DivanSuite) TestReturnsErrors() {
 	s.Run("invalid filter", func() {
 		cfg := s.cfg
 		cfg.Filter = "["
-		_, _, err := ParseDivanBenchmark(rustTestInput(s.T(), testDivanTable), cfg)
+		_, _, _, err := ParseDivanBenchmark(rustTestInput(s.T(), testDivanTable), cfg)
 		s.ErrorContains(err, "invalid filter regex")
 	})
 
 	s.Run("invalid benchmark group pattern", func() {
 		cfg := s.cfg
 		cfg.GroupPattern = "[n/y]"
-		_, _, err := ParseDivanBenchmark(rustTestInput(s.T(), testDivanTable), cfg)
+		_, _, _, err := ParseDivanBenchmark(rustTestInput(s.T(), testDivanTable), cfg)
 		s.ErrorContains(err, "bracket slots")
 	})
 
 	s.Run("reader failure", func() {
-		_, _, err := ParseDivanBenchmark(rustErrorReader{}, s.cfg)
+		_, _, _, err := ParseDivanBenchmark(rustErrorReader{}, s.cfg)
 		s.ErrorContains(err, "read divan benchmark")
 	})
 }

--- a/shared/bench_state.go
+++ b/shared/bench_state.go
@@ -1,4 +1,0 @@
-package shared
-
-var CPUCount int
-var OS, Arch, Pkg, CPU string

--- a/shared/exit_with_err_test.go
+++ b/shared/exit_with_err_test.go
@@ -77,8 +77,13 @@ func (s *ExitWithErrorSuite) TestExitWithError() {
 }
 
 func (s *ExitWithErrorSuite) TestExitWithErrorConcurrent() {
-	restore, exitCalled := TrapOsExitPanic(s.T())
-	defer restore()
+	origOsExit := OsExit
+	exitCalls := make(chan struct{}, 5)
+	OsExit = func(int) {
+		exitCalls <- struct{}{}
+		panic("exit")
+	}
+	defer func() { OsExit = origOsExit }()
 
 	oldStderr := os.Stderr
 	r, w, _ := os.Pipe()
@@ -103,7 +108,7 @@ func (s *ExitWithErrorSuite) TestExitWithErrorConcurrent() {
 	_, _ = io.Copy(&buf, r)
 	os.Stderr = oldStderr
 
-	s.True(*exitCalled, "Should have received at least one OsExit call")
+	s.NotEmpty(exitCalls, "Should have received at least one OsExit call")
 	s.NotEmpty(buf.String(), "stderr should contain error messages")
 }
 

--- a/shared/tmp_files_manager.go
+++ b/shared/tmp_files_manager.go
@@ -2,9 +2,11 @@ package shared
 
 import (
 	"os"
+	"sync"
 )
 
 type TmpFilesManager struct {
+	mu    sync.Mutex
 	files []string
 }
 
@@ -19,13 +21,17 @@ func NewTmpFileManager() TmpFilesManager {
 }
 
 func (tfm *TmpFilesManager) Store(args ...string) {
+	tfm.mu.Lock()
+	defer tfm.mu.Unlock()
 	tfm.files = append(tfm.files, args...)
 }
 
 func (tfm *TmpFilesManager) RemoveAll() {
+	tfm.mu.Lock()
+	defer tfm.mu.Unlock()
+
 	for _, filePath := range tfm.files {
 		os.Remove(filePath)
 	}
-
 	tfm.files = make([]string, 0)
 }

--- a/shared/tmp_files_manager_test.go
+++ b/shared/tmp_files_manager_test.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -91,6 +92,22 @@ func (s *TmpFilesManagerSuite) TestTmpFilesManagerEmptyStore() {
 	manager := NewTmpFileManager()
 
 	manager.Store()
+
+	s.Empty(manager.files)
+}
+
+func (s *TmpFilesManagerSuite) TestTmpFilesManagerConcurrentAccess() {
+	manager := NewTmpFileManager()
+	var wg sync.WaitGroup
+
+	for range 20 {
+		wg.Go(func() {
+			manager.Store("nonexistent.txt")
+			manager.RemoveAll()
+		})
+	}
+	wg.Wait()
+	manager.RemoveAll()
 
 	s.Empty(manager.files)
 }

--- a/shared/tmp_files_manager_test.go
+++ b/shared/tmp_files_manager_test.go
@@ -101,10 +101,12 @@ func (s *TmpFilesManagerSuite) TestTmpFilesManagerConcurrentAccess() {
 	var wg sync.WaitGroup
 
 	for range 20 {
-		wg.Go(func() {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 			manager.Store("nonexistent.txt")
 			manager.RemoveAll()
-		})
+		}()
 	}
 	wg.Wait()
 	manager.RemoveAll()


### PR DESCRIPTION
## Related Issue
Resolve #236 

## Changes:

- Parser API now returns request-local *shared.Meta.
- Go benchmark parsing no longer writes shared globals.
- Removed shared/bench_state.go.
- core.Convert passes parsed metadata into core.Assemble, while preserving
  explicit caller metadata.

- CLI Dataset metadata and JSON wire format remain unchanged.
- Added a 64-way concurrent conversion regression test.
  
## Test Result
```bash
task build:cli

printf '%s\n' \
    'goos: linux' \
    'goarch: amd64' \
    'pkg: example.com/local-test' \
    'cpu: Local Test CPU' \
    'BenchmarkExample-8 100 1234 ns/op' \
    > /tmp/vizb-benchmark.txt
    
 ./bin/vizb /tmp/vizb-benchmark.txt --output /tmp/vizb-result.json
  jq '.meta' /tmp/vizb-result.json
```
```bash
# result
{
    "cpu": {
      "name": "Local Test CPU",
      "cores": 8
    "os": "linux",
    "arch": "amd64",
    "pkg": "example.com/local-test"
  }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Benchmark parsing and conversions now carry system metadata (OS, architecture, package, CPU) through to the assembled dataset and JSON output.
  * Explicit metadata provided at conversion time is preserved.
* **Bug Fixes**
  * Metadata is now request-local, improving correctness for concurrent conversions.
  * Temporary file management is now concurrency-safe.
* **Tests**
  * Updated parser/core pipeline tests for the new metadata return contract.
  * Added coverage for metadata preservation, request-local behavior under concurrency, and concurrent temporary-file access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->