### PR TITLE
feat(api): add root conversion endpoint

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -127,7 +127,7 @@ components:
                 tag: v2
                 theme: westeros
                 parser: csv
-                select: [region, latency]
+                select: ["region,latency"]
                 charts:
                   types: [bar, line]
                   configs:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -617,8 +617,7 @@ components:
         stack: { type: boolean }
         showLabels: { type: boolean }
         symbol:
-          type: string
-          description: ECharts built-in symbol, image:// or path:// reference, or SVG path.
+          $ref: '#/components/schemas/SeriesSymbol'
         symbolSize: { type: number, exclusiveMinimum: 0 }
         smooth: { type: boolean }
         threeDRotate: { type: boolean }
@@ -636,14 +635,24 @@ components:
         scale: { type: string, enum: [linear, log] }
         showLabels: { type: boolean }
         symbol:
-          type: string
-          description: ECharts built-in symbol, image:// or path:// reference, or SVG path.
+          $ref: '#/components/schemas/SeriesSymbol'
         symbolSize: { type: number, exclusiveMinimum: 0 }
         threeDRotate: { type: boolean }
         threeD: { type: boolean }
         threeDVisualMap: { type: boolean }
         visualMap: { type: boolean }
         stat: { $ref: '#/components/schemas/StatisticsConfig' }
+    SeriesSymbol:
+      description: ECharts built-in symbol, image:// or path:// reference, or an SVG path.
+      oneOf:
+        - type: string
+          pattern: '^(?:[Cc][Ii][Rr][Cc][Ll][Ee]|[Rr][Ee][Cc][Tt]|[Rr][Oo][Uu][Nn][Dd][Rr][Ee][Cc][Tt]|[Tt][Rr][Ii][Aa][Nn][Gg][Ll][Ee]|[Dd][Ii][Aa][Mm][Oo][Nn][Dd]|[Pp][Ii][Nn]|[Aa][Rr][Rr][Oo][Ww]|[Nn][Oo][Nn][Ee])$'
+        - type: string
+          pattern: '^image://.+'
+        - type: string
+          pattern: '^path://.+'
+        - type: string
+          pattern: '^[Mm].*'
     PieChartConfig:
       type: object
       additionalProperties: false

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -121,6 +121,11 @@ components:
               summary: Convert inline CSV into a Dataset.
               value:
                 input: "region,latency\nwest,12\neast,18\n"
+                id: api-latency
+                name: API latency
+                description: Latency by region
+                tag: v2
+                theme: westeros
                 parser: csv
                 select: [region, latency]
                 charts:
@@ -130,6 +135,24 @@ components:
                       showLabels: true
                 output:
                   format: dataset
+            jsonHTMLConversion:
+              summary: Convert native JSON input into self-contained HTML.
+              value:
+                input:
+                  - { region: west, latency: 12 }
+                  - { region: east, latency: 18 }
+                name: API latency
+                parser: json
+                grouping:
+                  pattern: x
+                  columns: [region]
+                charts:
+                  types: [bar]
+                  configs:
+                    - type: bar
+                      showLabels: true
+                output:
+                  format: html
     MergeRequest:
       required: true
       content:
@@ -179,8 +202,11 @@ components:
           examples:
             convertedDataset:
               value:
+                id: api-latency
                 name: API latency
                 description: Latency by region
+                tag: v2
+                theme: westeros
                 axes: [{ key: name }, { key: y, type: value }]
                 settings: [{ type: bar, showLabels: true }, { type: line }]
                 data: [{ name: west, yAxis: "12" }, { name: east, yAxis: "18" }]
@@ -280,6 +306,25 @@ components:
       properties:
         input:
           $ref: '#/components/schemas/RawInput'
+        id:
+          type: string
+          description: Dataset identifier used by UI deep links.
+        name:
+          type: string
+          default: Comparisons
+          description: Dataset display name.
+        description:
+          type: string
+          description: Dataset description.
+        tag:
+          type: string
+          description: Dataset tag or run identifier.
+        theme:
+          type: string
+          minLength: 1
+          default: default
+          description: Built-in theme name or a comma-separated palette of at least two hex colors.
+          examples: [westeros, "#5470C6,#3BA272"]
         parser:
           type: string
           enum: [auto, csv, json, go, javascript, rust]
@@ -310,7 +355,7 @@ components:
       type: object
       additionalProperties: false
       properties:
-        pattern: { type: string }
+        pattern: { type: string, minLength: 1 }
         regex: { type: string }
         columns:
           type: array
@@ -571,7 +616,9 @@ components:
         scale: { type: string, enum: [linear, log] }
         stack: { type: boolean }
         showLabels: { type: boolean }
-        symbol: { type: string }
+        symbol:
+          type: string
+          description: ECharts built-in symbol, image:// or path:// reference, or SVG path.
         symbolSize: { type: number, exclusiveMinimum: 0 }
         smooth: { type: boolean }
         threeDRotate: { type: boolean }
@@ -588,7 +635,9 @@ components:
         sort: { $ref: '#/components/schemas/Sort' }
         scale: { type: string, enum: [linear, log] }
         showLabels: { type: boolean }
-        symbol: { type: string }
+        symbol:
+          type: string
+          description: ECharts built-in symbol, image:// or path:// reference, or SVG path.
         symbolSize: { type: number, exclusiveMinimum: 0 }
         threeDRotate: { type: boolean }
         threeD: { type: boolean }

--- a/api/openapi_test.go
+++ b/api/openapi_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -176,6 +177,20 @@ func (s *OpenAPISuite) TestUIContractRejectsRemoteInputAndReturnsHTML() {
 	s.NotNil(successContent["text/html"])
 }
 
+func (s *OpenAPISuite) TestLineAndScatterSymbolsMatchServerValidation() {
+	contract := readContract(s.T())
+	schemas := mustMap(s.T(), mustMap(s.T(), contract["components"], "components")["schemas"], "components.schemas")
+	for _, schemaName := range []string{"LineChartConfig", "ScatterChartConfig"} {
+		s.Run(schemaName, func() {
+			schema := schemas[schemaName]
+			for _, symbol := range []string{"circle", "CIRCLE", "image://marker.svg", "path://M0 0", "M0 0"} {
+				s.NoError(validateSchema(contract, schema, map[string]any{"type": strings.TrimSuffix(strings.ToLower(schemaName), "chartconfig"), "symbol": symbol}, schemaName))
+			}
+			s.Error(validateSchema(contract, schema, map[string]any{"type": strings.TrimSuffix(strings.ToLower(schemaName), "chartconfig"), "symbol": "star"}, schemaName))
+		})
+	}
+}
+
 func (s *OpenAPISuite) TestRootConversionContract() {
 	t := s.T()
 	contract := readContract(t)
@@ -192,7 +207,7 @@ func (s *OpenAPISuite) TestRootConversionContract() {
 	paths := mustMap(t, contract["paths"], "paths")
 	root := mustMap(t, mustMap(t, paths["/"], "paths./")["post"], "paths./.post")
 	responses := mustMap(t, root["responses"], "paths./.post.responses")
-	s.Equal([]string{"200", "400", "406", "415", "422", "500"}, sortedMapKeys(responses))
+	s.Equal([]string{"200", "400", "406", "413", "415", "422", "500"}, sortedMapKeys(responses))
 
 	allResponses := mustMap(t, components["responses"], "components.responses")
 	success := mustMap(t, allResponses["ConvertSuccess"], "components.responses.ConvertSuccess")
@@ -401,6 +416,15 @@ func validateSchema(root map[string]any, rawSchema, value any, location string) 
 		}
 		if min, ok := schema["minLength"].(int); ok && len(stringValue) < min {
 			return fmt.Errorf("%s has length %d, want at least %d", location, len(stringValue), min)
+		}
+		if pattern, ok := schema["pattern"].(string); ok {
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				return fmt.Errorf("%s has invalid pattern %q: %w", location, pattern, err)
+			}
+			if !re.MatchString(stringValue) {
+				return fmt.Errorf("%s = %#v does not match pattern %q", location, stringValue, pattern)
+			}
 		}
 	case "boolean":
 		if _, ok := value.(bool); !ok {

--- a/api/openapi_test.go
+++ b/api/openapi_test.go
@@ -176,6 +176,33 @@ func (s *OpenAPISuite) TestUIContractRejectsRemoteInputAndReturnsHTML() {
 	s.NotNil(successContent["text/html"])
 }
 
+func (s *OpenAPISuite) TestRootConversionContract() {
+	t := s.T()
+	contract := readContract(t)
+	components := mustMap(t, contract["components"], "components")
+	schemas := mustMap(t, components["schemas"], "components.schemas")
+	request := mustMap(t, schemas["ConvertRequest"], "components.schemas.ConvertRequest")
+	s.Equal(
+		[]string{"charts", "description", "grouping", "id", "input", "jsonPath", "name", "output", "parser", "select", "tag", "theme", "units"},
+		propertyNames(t, request, "ConvertRequest"),
+	)
+	s.Equal([]string{"input"}, stringSliceValue(request["required"]))
+	s.NotContains(propertyNames(t, request, "ConvertRequest"), "metadata")
+
+	paths := mustMap(t, contract["paths"], "paths")
+	root := mustMap(t, mustMap(t, paths["/"], "paths./")["post"], "paths./.post")
+	responses := mustMap(t, root["responses"], "paths./.post.responses")
+	s.Equal([]string{"200", "400", "406", "415", "422", "500"}, sortedMapKeys(responses))
+
+	allResponses := mustMap(t, components["responses"], "components.responses")
+	success := mustMap(t, allResponses["ConvertSuccess"], "components.responses.ConvertSuccess")
+	content := mustMap(t, success["content"], "components.responses.ConvertSuccess.content")
+	s.Equal([]string{"application/json", "text/html"}, sortedMapKeys(content))
+	jsonResponse := mustMap(t, content["application/json"], "ConvertSuccess.application/json")
+	jsonSchema := mustMap(t, jsonResponse["schema"], "ConvertSuccess.application/json.schema")
+	s.Equal("#/components/schemas/Dataset", jsonSchema["$ref"])
+}
+
 func TestOpenAPISuite(t *testing.T) {
 	suite.Run(t, new(OpenAPISuite))
 }
@@ -230,7 +257,7 @@ func verifyOperationExamples(t *testing.T, root map[string]any) {
 		}
 	}
 	for _, name := range []string{
-		"csvConversion", "convertedDataset", "convertedHTML", "taggedDatasets",
+		"csvConversion", "jsonHTMLConversion", "convertedDataset", "convertedHTML", "taggedDatasets",
 		"mergedDatasets", "datasetUI", "selfContainedHTML", "unknownOption", "invalidCSV",
 	} {
 		if !seen[name] {
@@ -368,8 +395,12 @@ func validateSchema(root map[string]any, rawSchema, value any, location string) 
 			}
 		}
 	case "string":
-		if _, ok := value.(string); !ok {
+		stringValue, ok := value.(string)
+		if !ok {
 			return fmt.Errorf("%s must be a string, got %T", location, value)
+		}
+		if min, ok := schema["minLength"].(int); ok && len(stringValue) < min {
+			return fmt.Errorf("%s has length %d, want at least %d", location, len(stringValue), min)
 		}
 	case "boolean":
 		if _, ok := value.(bool); !ok {
@@ -513,4 +544,12 @@ func sorted(values []string) []string {
 		}
 	}
 	return result
+}
+
+func sortedMapKeys(values map[string]any) []string {
+	result := make([]string, 0, len(values))
+	for key := range values {
+		result = append(result, key)
+	}
+	return sorted(result)
 }

--- a/cmd/cli/dataflags.go
+++ b/cmd/cli/dataflags.go
@@ -2,11 +2,11 @@ package cli
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/goptics/vizb/internal/flags"
 	"github.com/goptics/vizb/pkg/parser"
+	"github.com/goptics/vizb/pkg/style"
 )
 
 // DataFlags are the parser/grouping/metadata descriptors every data-consuming
@@ -16,7 +16,7 @@ import (
 // the former CommonOptions hand-written Bind + validationRules.
 var DataFlags = []flags.Flag{
 	{Name: "name", Shorthand: "n", Default: "Comparisons", Usage: "Name of the comparison", Kind: flags.KindString},
-	{Name: "theme", Usage: "Initial series color theme (a built-in name or comma-separated hex palette)", Kind: flags.KindString, Default: "default", Normalizer: normalizeThemeFlag, SoftValidate: validateTheme},
+	{Name: "theme", Usage: "Initial series color theme (a built-in name or comma-separated hex palette)", Kind: flags.KindString, Default: "default", Normalizer: style.NormalizeTheme, SoftValidate: style.ValidateTheme},
 	{Name: "description", Shorthand: "d", Usage: "Description of the comparison", Kind: flags.KindString},
 	{Name: "output", Shorthand: "o", Usage: "Output file path/name", Kind: flags.KindString},
 	{Name: "tag", Shorthand: "t", Usage: "Tag/identifier for the comparison", Kind: flags.KindString},
@@ -64,45 +64,6 @@ var DataFlags = []flags.Flag{
 		ValidSet: []string{"n", "x", "y", "z"},
 	},
 	{Name: "json-path", Usage: "json only: select a nested array to chart via a jq-like dot path (e.g. --json-path '.data.results')", Kind: flags.KindString},
-}
-
-var (
-	builtInThemes = map[string]struct{}{
-		"default": {}, "vintage": {}, "meadow": {}, "westeros": {}, "essos": {},
-		"wonderland": {}, "walden": {}, "chalk": {}, "infographic": {},
-		"macarons": {}, "roma": {}, "shine": {}, "purple-passion": {},
-	}
-	hexColorPattern = regexp.MustCompile(`^#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?$`)
-)
-
-// validateTheme accepts a built-in name or a custom palette containing at
-// least two comma-separated #rgb/#rrggbb colors.
-func validateTheme(value string) error {
-	if _, ok := builtInThemes[strings.ToLower(value)]; ok {
-		return nil
-	}
-	colors := strings.Split(value, ",")
-	if len(colors) < 2 {
-		return fmt.Errorf("expected a built-in theme or at least two comma-separated hex colors")
-	}
-	for _, color := range colors {
-		if !hexColorPattern.MatchString(strings.TrimSpace(color)) {
-			return fmt.Errorf("invalid hex color %q", strings.TrimSpace(color))
-		}
-	}
-	return nil
-}
-
-func normalizeThemeFlag(value string) string {
-	trimmed := strings.TrimSpace(value)
-	if _, ok := builtInThemes[strings.ToLower(trimmed)]; ok {
-		return strings.ToLower(trimmed)
-	}
-	colors := strings.Split(trimmed, ",")
-	for i := range colors {
-		colors[i] = strings.TrimSpace(colors[i])
-	}
-	return strings.Join(colors, ",")
 }
 
 // normalizeMemUnit canonicalises lowercase memory units (kb/mb/gb) to their

--- a/cmd/cli/flagbag_test.go
+++ b/cmd/cli/flagbag_test.go
@@ -6,6 +6,7 @@ import (
 
 	internal_charts "github.com/goptics/vizb/internal/charts"
 	"github.com/goptics/vizb/internal/flags"
+	"github.com/goptics/vizb/pkg/style"
 	"github.com/goptics/vizb/testutil"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/suite"
@@ -209,10 +210,10 @@ func (s *FlagBagSuite) TestValidateThemeCatalogAndCustomPalettes() {
 		"#f00,#0f0", "#ff0000, #00ff00, #0000ff",
 	}
 	for _, value := range valid {
-		s.NoError(validateTheme(value), value)
+		s.NoError(style.ValidateTheme(value), value)
 	}
 	for _, value := range []string{"unknown", "#f00", "#ggg,#000", "#ffff,#000"} {
-		s.Error(validateTheme(value), value)
+		s.Error(style.ValidateTheme(value), value)
 	}
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -288,9 +288,6 @@ func handleMerge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	tagAxis := request.TagAxis
-	if tagAxis == "" {
-		tagAxis = "name"
-	}
 	datasets, validationErr := decodeDatasetArray(request.Datasets, "/datasets")
 	if validationErr != nil {
 		writeValidationProblem(w, r, *validationErr)
@@ -298,7 +295,7 @@ func handleMerge(w http.ResponseWriter, r *http.Request) {
 	}
 	merged, err := core.Merge(datasets, shared.Dimension(tagAxis))
 	if err != nil {
-		writeValidationProblem(w, r, bodyValidationError("/tagAxis", "invalid_enum", err.Error()))
+		writeValidationProblem(w, r, bodyValidationError("/tagAxis", "invalid_enum", "tagAxis must be one of name, x, y, or z"))
 		return
 	}
 	writeAPIJSON(w, http.StatusOK, merged)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -166,9 +166,8 @@ func runServer(ctx context.Context, opts serveOptions, deps serveDependencies) e
 			shutdown = (*http.Server).Shutdown
 		}
 		if err := shutdown(server, shutdownCtx); err != nil {
-			if closeErr := server.Close(); closeErr != nil && !errors.Is(closeErr, http.ErrServerClosed) {
-				return fmt.Errorf("shutdown HTTP server: %w", errors.Join(err, fmt.Errorf("close HTTP server: %w", closeErr)))
-			}
+			_ = server.Close()
+			<-serveResult
 			return fmt.Errorf("shutdown HTTP server: %w", err)
 		}
 		if err := <-serveResult; err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -212,8 +212,12 @@ func handleConvertWithGenerator(
 	if !decodeAPIRequest(w, r, &request) {
 		return
 	}
-	if len(request.Input) == 0 || string(request.Input) == "null" {
+	if len(request.Input) == 0 {
 		writeValidationProblem(w, r, bodyValidationError("/input", "required", "input is required"))
+		return
+	}
+	if string(request.Input) == "null" {
+		writeValidationProblem(w, r, bodyValidationError("/input", "invalid_type", "input must be a string, JSON object, or JSON array"))
 		return
 	}
 	input, err := inlineInput(request.Input)
@@ -221,9 +225,9 @@ func handleConvertWithGenerator(
 		writeValidationProblem(w, r, bodyValidationError("/input", "invalid_type", err.Error()))
 		return
 	}
-	format := request.Output.Format
-	if format == "" {
-		format = "dataset"
+	format := "dataset"
+	if request.Output != nil && request.Output.Format != nil {
+		format = *request.Output.Format
 	}
 	if format != "dataset" && format != "html" {
 		writeValidationProblem(w, r, bodyValidationError("/output/format", "invalid_enum", "output.format must be dataset or html"))
@@ -245,7 +249,16 @@ func handleConvertWithGenerator(
 	}
 	result, err := core.Convert(convertInput)
 	if err != nil {
+		var optionErr *core.OptionError
+		if errors.As(err, &optionErr) {
+			writeValidationProblem(w, r, conversionOptionValidationError(request.Charts, optionErr))
+			return
+		}
 		writeAPIProblem(w, r, http.StatusUnprocessableEntity, "Input processing failed", err.Error())
+		return
+	}
+	if len(result.Warnings) > 0 {
+		writeValidationProblem(w, r, conversionWarningValidationErrors(request.Charts, result.Warnings)...)
 		return
 	}
 	if format == "html" {
@@ -352,6 +365,11 @@ func decodeAPIRequest(w http.ResponseWriter, r *http.Request, target any) bool {
 }
 
 func writeRequestDecodeProblem(w http.ResponseWriter, r *http.Request, err error) {
+	var validationErr apiValidationError
+	if errors.As(err, &validationErr) {
+		writeValidationProblem(w, r, validationErr)
+		return
+	}
 	var maxBytesErr *http.MaxBytesError
 	if errors.As(err, &maxBytesErr) {
 		writeAPIProblem(w, r, http.StatusRequestEntityTooLarge, "Content too large", fmt.Sprintf("Request body must not exceed %d bytes.", maxBytesErr.Limit))

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -28,19 +28,6 @@ type unitOptions struct {
 	Number string `json:"number"`
 }
 
-<<<<<<< HEAD
-=======
-type metadataOptions struct {
-	ID          string       `json:"id"`
-	Name        string       `json:"name"`
-	Theme       string       `json:"theme"`
-	Description string       `json:"description"`
-	Tag         string       `json:"tag"`
-	Timestamp   string       `json:"timestamp"`
-	Meta        *shared.Meta `json:"meta"`
-}
-
->>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 type chartSelection struct {
 	Types   []string          `json:"types"`
 	Configs []json.RawMessage `json:"configs"`
@@ -54,10 +41,6 @@ type statisticsOptions struct {
 type convertRequest struct {
 	Input    json.RawMessage  `json:"input"`
 	Parser   string           `json:"parser"`
-<<<<<<< HEAD
-=======
-	Metadata *metadataOptions `json:"metadata"`
->>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 	Grouping *groupingOptions `json:"grouping"`
 	Units    *unitOptions     `json:"units"`
 	Select   []string         `json:"select"`
@@ -74,13 +57,8 @@ type mergeRequest struct {
 }
 
 type uiRequest struct {
-<<<<<<< HEAD
 	Datasets   json.RawMessage    `json:"datasets"`
 	Charts     chartSelection     `json:"charts"`
-=======
-	Datasets   json.RawMessage   `json:"datasets"`
-	Charts     chartSelection    `json:"charts"`
->>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 	Statistics *statisticsOptions `json:"statistics"`
 }
 
@@ -91,13 +69,10 @@ type apiValidationError struct {
 	Message  string `json:"message"`
 }
 
-<<<<<<< HEAD
 func (e apiValidationError) Error() string {
 	return e.Message
 }
 
-=======
->>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 func bodyValidationError(path, code, message string) apiValidationError {
 	return apiValidationError{Location: "body", Path: path, Code: code, Message: message}
 }
@@ -121,7 +96,6 @@ func buildConvertInput(request convertRequest, input []byte) (core.ConvertInput,
 		return core.ConvertInput{}, nil, validationErr
 	}
 
-<<<<<<< HEAD
 	return core.ConvertInput{
 		Input:  input,
 		Parser: key,
@@ -131,35 +105,6 @@ func buildConvertInput(request convertRequest, input []byte) (core.ConvertInput,
 			Theme: "default",
 		},
 		Charts: configs,
-=======
-	metadata := core.Metadata{Name: "Comparisons", Theme: "default"}
-	if request.Metadata != nil {
-		if request.Metadata.Theme != "" {
-			if err := validateTheme(request.Metadata.Theme); err != nil {
-				validationErr := bodyValidationError("/metadata/theme", "invalid_value", err.Error())
-				return core.ConvertInput{}, nil, &validationErr
-			}
-		}
-		metadata = core.Metadata{
-			ID:          request.Metadata.ID,
-			Name:        request.Metadata.Name,
-			Theme:       request.Metadata.Theme,
-			Description: request.Metadata.Description,
-			Tag:         request.Metadata.Tag,
-			Timestamp:   request.Metadata.Timestamp,
-			System:      request.Metadata.Meta,
-		}
-		if metadata.Name == "" {
-			metadata.Name = "Comparisons"
-		}
-		if metadata.Theme == "" {
-			metadata.Theme = "default"
-		}
-	}
-
-	return core.ConvertInput{
-		Input: input, Parser: key, Config: cfg, Metadata: metadata, Charts: configs,
->>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 	}, types, nil
 }
 
@@ -234,15 +179,12 @@ func buildParserConfig(request convertRequest, key string) (parser.Config, *apiV
 		validationErr := bodyValidationError("/grouping", "invalid_grouping", err.Error())
 		return cfg, &validationErr
 	}
-<<<<<<< HEAD
 	if (key == "csv" || key == "json") && len(cfg.Group) > 0 {
 		if err := parser.ValidateTabularGroupAlignment(cfg); err != nil {
 			validationErr := bodyValidationError("/grouping", "invalid_grouping", err.Error())
 			return cfg, &validationErr
 		}
 	}
-=======
->>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 	if validationErr := applySelectOptions(&cfg, request.Select); validationErr != nil {
 		return cfg, validationErr
 	}
@@ -320,16 +262,8 @@ func materialiseConversionCharts(selection chartSelection) ([]internalcharts.Cha
 	}
 	configs := make([]internalcharts.ChartConfig, 0, len(types))
 	for _, chartType := range types {
-<<<<<<< HEAD
 		// chartType and overrides are validated above, so Materialise cannot fail.
 		config, _ := internalcharts.Materialise(chartType, nil, overrides[chartType])
-=======
-		config, err := internalcharts.Materialise(chartType, nil, overrides[chartType])
-		if err != nil {
-			validationErr := bodyValidationError("/charts/configs", "invalid_chart_config", err.Error())
-			return nil, nil, &validationErr
-		}
->>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 		configs = append(configs, config)
 	}
 	return configs, types, nil
@@ -386,11 +320,7 @@ func decodeChartConfig(raw json.RawMessage, path string) (internalcharts.ChartCo
 	var discriminator struct {
 		Type string `json:"type"`
 	}
-<<<<<<< HEAD
 	if err := json.Unmarshal(raw, &discriminator); err != nil {
-=======
-	if err := strictDecode(raw, &discriminator); err != nil {
->>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 		validationErr := bodyValidationError(path, "invalid_chart_config", err.Error())
 		return nil, &validationErr
 	}
@@ -537,14 +467,7 @@ func applyUIOptions(datasets []shared.Dataset, selection chartSelection, statist
 		configs := make([]internalcharts.ChartConfig, 0, len(targetTypes))
 		for _, chartType := range targetTypes {
 			base, hasBase := existing[chartType]
-<<<<<<< HEAD
 			override := overrides[chartType]
-=======
-			override, hasOverride := overrides[chartType]
-			if !hasBase && !hasOverride {
-				continue
-			}
->>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 			seed := map[string]any{}
 			if hasBase {
 				raw, err := json.Marshal(base)
@@ -552,28 +475,13 @@ func applyUIOptions(datasets []shared.Dataset, selection chartSelection, statist
 					validationErr := bodyValidationError("/datasets", "invalid_dataset", err.Error())
 					return nil, nil, &validationErr
 				}
-<<<<<<< HEAD
 				_ = json.Unmarshal(raw, &seed) // json.Marshal always produces valid JSON.
-=======
-				if err := json.Unmarshal(raw, &seed); err != nil {
-					validationErr := bodyValidationError("/datasets", "invalid_dataset", err.Error())
-					return nil, nil, &validationErr
-				}
->>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 			}
 			if stat != nil {
 				seed["stat"] = stat
 			}
-<<<<<<< HEAD
 			// chartType and override were validated before assembling the seed.
 			config, _ := internalcharts.Materialise(chartType, seed, override)
-=======
-			config, err := internalcharts.Materialise(chartType, seed, override)
-			if err != nil {
-				validationErr := bodyValidationError("/charts/configs", "invalid_chart_config", err.Error())
-				return nil, nil, &validationErr
-			}
->>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 			configs = append(configs, config)
 		}
 		result[i].Settings = configs
@@ -582,7 +490,6 @@ func applyUIOptions(datasets []shared.Dataset, selection chartSelection, statist
 }
 
 type datasetWire struct {
-<<<<<<< HEAD
 	ID           string              `json:"id"`
 	Tag          string              `json:"tag"`
 	Timestamp    string              `json:"timestamp"`
@@ -595,20 +502,6 @@ type datasetWire struct {
 	Settings     *[]json.RawMessage  `json:"settings"`
 	Data         *[]shared.DataPoint `json:"data"`
 	PreserveRows bool                `json:"preserveRows"`
-=======
-	ID           string            `json:"id"`
-	Tag          string            `json:"tag"`
-	Timestamp    string            `json:"timestamp"`
-	Name         *string           `json:"name"`
-	Theme        string            `json:"theme"`
-	History      []historyWire     `json:"history"`
-	Description  string            `json:"description"`
-	Meta         *shared.Meta      `json:"meta"`
-	Axes         *[]axisWire       `json:"axes"`
-	Settings     *[]json.RawMessage `json:"settings"`
-	Data         *[]shared.DataPoint `json:"data"`
-	PreserveRows bool              `json:"preserveRows"`
->>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 }
 
 type historyWire struct {
@@ -663,7 +556,6 @@ func decodeStrictDataset(raw json.RawMessage, path string) (shared.Dataset, *api
 	}
 
 	settings := make([]internalcharts.ChartConfig, 0, len(*wire.Settings))
-<<<<<<< HEAD
 	settingTypes := make(map[string]bool, len(*wire.Settings))
 	for i, rawConfig := range *wire.Settings {
 		configPath := fmt.Sprintf("%s/settings/%d", path, i)
@@ -676,13 +568,6 @@ func decodeStrictDataset(raw json.RawMessage, path string) (shared.Dataset, *api
 			return shared.Dataset{}, &validationErr
 		}
 		settingTypes[config.ChartType()] = true
-=======
-	for i, rawConfig := range *wire.Settings {
-		config, validationErr := decodeChartConfig(rawConfig, fmt.Sprintf("%s/settings/%d", path, i))
-		if validationErr != nil {
-			return shared.Dataset{}, validationErr
-		}
->>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 		settings = append(settings, config)
 	}
 

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -41,6 +41,21 @@ type statisticsOptions struct {
 	Math    []string `json:"math"`
 }
 
+func (o *statisticsOptions) UnmarshalJSON(data []byte) error {
+	if err := rejectNullFields(data, "/statistics", map[string]string{
+		"enabled": "/statistics/enabled", "math": "/statistics/math",
+	}); err != nil {
+		return err
+	}
+	type wire statisticsOptions
+	var decoded wire
+	if err := strictDecodeRequestObject(data, &decoded, "/statistics"); err != nil {
+		return err
+	}
+	*o = statisticsOptions(decoded)
+	return nil
+}
+
 type convertRequest struct {
 	Input       json.RawMessage  `json:"input"`
 	ID          *string          `json:"id"`
@@ -183,6 +198,19 @@ type uiRequest struct {
 	Datasets   json.RawMessage    `json:"datasets"`
 	Charts     chartSelection     `json:"charts"`
 	Statistics *statisticsOptions `json:"statistics"`
+}
+
+func (r *uiRequest) UnmarshalJSON(data []byte) error {
+	if err := rejectNullFields(data, "/", map[string]string{"statistics": "/statistics"}); err != nil {
+		return err
+	}
+	type wire uiRequest
+	var decoded wire
+	if err := strictDecodeRequestObject(data, &decoded, ""); err != nil {
+		return err
+	}
+	*r = uiRequest(decoded)
+	return nil
 }
 
 type apiValidationError struct {

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -3,29 +3,32 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
 	"slices"
+	"sort"
 	"strings"
 
 	internalcharts "github.com/goptics/vizb/internal/charts"
 	"github.com/goptics/vizb/pkg/core"
 	"github.com/goptics/vizb/pkg/parser"
+	"github.com/goptics/vizb/pkg/style"
 	"github.com/goptics/vizb/shared"
 )
 
 type groupingOptions struct {
-	Pattern string   `json:"pattern"`
+	Pattern *string  `json:"pattern"`
 	Regex   string   `json:"regex"`
 	Columns []string `json:"columns"`
 	Filter  string   `json:"filter"`
 }
 
 type unitOptions struct {
-	Memory string `json:"memory"`
-	Time   string `json:"time"`
-	Number string `json:"number"`
+	Memory *string `json:"memory"`
+	Time   *string `json:"time"`
+	Number *string `json:"number"`
 }
 
 type chartSelection struct {
@@ -39,16 +42,136 @@ type statisticsOptions struct {
 }
 
 type convertRequest struct {
-	Input    json.RawMessage  `json:"input"`
-	Parser   string           `json:"parser"`
-	Grouping *groupingOptions `json:"grouping"`
-	Units    *unitOptions     `json:"units"`
-	Select   []string         `json:"select"`
-	JSONPath string           `json:"jsonPath"`
-	Charts   chartSelection   `json:"charts"`
-	Output   struct {
-		Format string `json:"format"`
-	} `json:"output"`
+	Input       json.RawMessage  `json:"input"`
+	ID          *string          `json:"id"`
+	Name        *string          `json:"name"`
+	Theme       *string          `json:"theme"`
+	Description *string          `json:"description"`
+	Tag         *string          `json:"tag"`
+	Parser      *string          `json:"parser"`
+	Grouping    *groupingOptions `json:"grouping"`
+	Units       *unitOptions     `json:"units"`
+	Select      []string         `json:"select"`
+	JSONPath    string           `json:"jsonPath"`
+	Charts      chartSelection   `json:"charts"`
+	Output      *convertOutput   `json:"output"`
+}
+
+type convertOutput struct {
+	Format *string `json:"format"`
+}
+
+func (r *convertRequest) UnmarshalJSON(data []byte) error {
+	if err := rejectNullFields(data, "/", map[string]string{
+		"id": "/id", "name": "/name", "theme": "/theme", "description": "/description",
+		"tag": "/tag", "parser": "/parser", "grouping": "/grouping", "units": "/units",
+		"select": "/select", "jsonPath": "/jsonPath", "charts": "/charts", "output": "/output",
+	}); err != nil {
+		return err
+	}
+	type wire convertRequest
+	var decoded wire
+	if err := strictDecodeRequestObject(data, &decoded, ""); err != nil {
+		return err
+	}
+	*r = convertRequest(decoded)
+	return nil
+}
+
+func (o *groupingOptions) UnmarshalJSON(data []byte) error {
+	if err := rejectNullFields(data, "/grouping", map[string]string{
+		"pattern": "/grouping/pattern", "regex": "/grouping/regex",
+		"columns": "/grouping/columns", "filter": "/grouping/filter",
+	}); err != nil {
+		return err
+	}
+	type wire groupingOptions
+	var decoded wire
+	if err := strictDecodeRequestObject(data, &decoded, "/grouping"); err != nil {
+		return err
+	}
+	*o = groupingOptions(decoded)
+	return nil
+}
+
+func (o *unitOptions) UnmarshalJSON(data []byte) error {
+	if err := rejectNullFields(data, "/units", map[string]string{
+		"memory": "/units/memory", "time": "/units/time", "number": "/units/number",
+	}); err != nil {
+		return err
+	}
+	type wire unitOptions
+	var decoded wire
+	if err := strictDecodeRequestObject(data, &decoded, "/units"); err != nil {
+		return err
+	}
+	*o = unitOptions(decoded)
+	return nil
+}
+
+func (s *chartSelection) UnmarshalJSON(data []byte) error {
+	if err := rejectNullFields(data, "/charts", map[string]string{
+		"types": "/charts/types", "configs": "/charts/configs",
+	}); err != nil {
+		return err
+	}
+	type wire chartSelection
+	var decoded wire
+	if err := strictDecodeRequestObject(data, &decoded, "/charts"); err != nil {
+		return err
+	}
+	*s = chartSelection(decoded)
+	return nil
+}
+
+func (o *convertOutput) UnmarshalJSON(data []byte) error {
+	if err := rejectNullFields(data, "/output", map[string]string{"format": "/output/format"}); err != nil {
+		return err
+	}
+	type wire convertOutput
+	var decoded wire
+	if err := strictDecodeRequestObject(data, &decoded, "/output"); err != nil {
+		return err
+	}
+	*o = convertOutput(decoded)
+	return nil
+}
+
+func rejectNullFields(data []byte, nullPath string, paths map[string]string) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return bodyValidationError(nullPath, "invalid_type", nullPath+" must not be null")
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	keys := make([]string, 0, len(paths))
+	for field := range paths {
+		keys = append(keys, field)
+	}
+	sort.Strings(keys)
+	for _, field := range keys {
+		path := paths[field]
+		if raw, ok := fields[field]; ok && bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+			return bodyValidationError(path, "invalid_type", path+" must not be null")
+		}
+	}
+	return nil
+}
+
+func strictDecodeRequestObject(data []byte, target any, prefix string) error {
+	err := strictDecode(data, target)
+	if err == nil {
+		return nil
+	}
+	const unknownFieldPrefix = `json: unknown field "`
+	message := err.Error()
+	if strings.HasPrefix(message, unknownFieldPrefix) && strings.HasSuffix(message, `"`) {
+		field := strings.TrimSuffix(strings.TrimPrefix(message, unknownFieldPrefix), `"`)
+		path := prefix + "/" + strings.ReplaceAll(strings.ReplaceAll(field, "~", "~0"), "/", "~1")
+		return bodyValidationError(path, "unknown_field", "unknown request field "+field)
+	}
+	return err
 }
 
 type mergeRequest struct {
@@ -77,10 +200,85 @@ func bodyValidationError(path, code, message string) apiValidationError {
 	return apiValidationError{Location: "body", Path: path, Code: code, Message: message}
 }
 
+func conversionOptionValidationError(selection chartSelection, optionErr *core.OptionError) apiValidationError {
+	var path string
+	switch optionErr.Name {
+	case "filter":
+		path = "/grouping/filter"
+	case "grouping":
+		path = "/grouping"
+	case "jsonPath":
+		path = "/jsonPath"
+	case "select":
+		path = "/select"
+	case "swap":
+		path = chartConfigFieldPath(selection, "swap", 0)
+	default:
+		path = "/charts/configs"
+	}
+	return bodyValidationError(path, "inapplicable_option", optionErr.Error())
+}
+
+func conversionWarningValidationErrors(selection chartSelection, warnings []string) []apiValidationError {
+	result := make([]apiValidationError, 0, len(warnings))
+	occurrences := map[string]int{}
+	for _, warning := range warnings {
+		flagName := warningFlagName(warning)
+		jsonKey := chartFlagJSONKey(flagName)
+		path := "/charts/configs"
+		if jsonKey != "" {
+			path = chartConfigFieldPath(selection, jsonKey, occurrences[jsonKey])
+			occurrences[jsonKey]++
+		}
+		result = append(result, bodyValidationError(path, "inapplicable_option", warning))
+	}
+	return result
+}
+
+func warningFlagName(warning string) string {
+	const prefix = `flag "`
+	if !strings.HasPrefix(warning, prefix) {
+		return ""
+	}
+	name, _, ok := strings.Cut(strings.TrimPrefix(warning, prefix), `"`)
+	if !ok {
+		return ""
+	}
+	return name
+}
+
+func chartFlagJSONKey(flagName string) string {
+	for _, chartType := range internalcharts.Registered() {
+		for _, flag := range internalcharts.FlagsFor(chartType) {
+			if flag.Name == flagName {
+				return flag.JSONKey
+			}
+		}
+	}
+	return ""
+}
+
+func chartConfigFieldPath(selection chartSelection, field string, occurrence int) string {
+	matches := make([]string, 0, len(selection.Configs))
+	for i, raw := range selection.Configs {
+		var values map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &values); err != nil {
+			continue
+		}
+		if _, ok := values[field]; ok {
+			matches = append(matches, fmt.Sprintf("/charts/configs/%d/%s", i, field))
+		}
+	}
+	if occurrence < len(matches) {
+		return matches[occurrence]
+	}
+	return "/charts/configs"
+}
+
 func buildConvertInput(request convertRequest, input []byte) (core.ConvertInput, []string, *apiValidationError) {
-	key := strings.TrimSpace(request.Parser)
-	if key == "" {
-		key = "auto"
+	key := "auto"
+	if request.Parser != nil {
+		key = *request.Parser
 	}
 	if !slices.Contains([]string{"auto", "csv", "json", "go", "javascript", "rust"}, key) {
 		err := bodyValidationError("/parser", "invalid_enum", "parser must be one of auto, csv, json, go, javascript, or rust")
@@ -95,25 +293,50 @@ func buildConvertInput(request convertRequest, input []byte) (core.ConvertInput,
 	if validationErr != nil {
 		return core.ConvertInput{}, nil, validationErr
 	}
+	metadata, validationErr := buildConvertMetadata(request)
+	if validationErr != nil {
+		return core.ConvertInput{}, nil, validationErr
+	}
 
 	return core.ConvertInput{
-		Input:  input,
-		Parser: key,
-		Config: cfg,
-		Metadata: core.Metadata{
-			Name:  "Comparisons",
-			Theme: "default",
-		},
-		Charts: configs,
+		Input:    input,
+		Parser:   key,
+		Config:   cfg,
+		Metadata: metadata,
+		Charts:   configs,
 	}, types, nil
+}
+
+func buildConvertMetadata(request convertRequest) (core.Metadata, *apiValidationError) {
+	metadata := core.Metadata{Name: "Comparisons", Theme: "default"}
+	if request.ID != nil {
+		metadata.ID = *request.ID
+	}
+	if request.Name != nil {
+		metadata.Name = *request.Name
+	}
+	if request.Description != nil {
+		metadata.Description = *request.Description
+	}
+	if request.Tag != nil {
+		metadata.Tag = *request.Tag
+	}
+	if request.Theme == nil {
+		return metadata, nil
+	}
+	metadata.Theme = style.NormalizeTheme(*request.Theme)
+	if err := style.ValidateTheme(metadata.Theme); err != nil {
+		validationErr := bodyValidationError("/theme", "invalid_value", err.Error())
+		return core.Metadata{}, &validationErr
+	}
+	return metadata, nil
 }
 
 func buildParserConfig(request convertRequest, key string) (parser.Config, *apiValidationError) {
 	cfg := parser.Config{GroupPattern: "x", MemUnit: "B", TimeUnit: "ns", JSONPath: request.JSONPath}
 	if request.Grouping != nil {
-		cfg.GroupPattern = request.Grouping.Pattern
-		if cfg.GroupPattern == "" {
-			cfg.GroupPattern = "x"
+		if request.Grouping.Pattern != nil {
+			cfg.GroupPattern = *request.Grouping.Pattern
 		}
 		cfg.GroupRegex = request.Grouping.Regex
 		cfg.Group = slices.Clone(request.Grouping.Columns)
@@ -143,34 +366,27 @@ func buildParserConfig(request convertRequest, key string) (parser.Config, *apiV
 	}
 
 	if request.Units != nil {
-		if request.Units.Memory != "" && !slices.Contains([]string{"b", "B", "KB", "MB", "GB"}, request.Units.Memory) {
+		if request.Units.Memory != nil && !slices.Contains([]string{"b", "B", "KB", "MB", "GB"}, *request.Units.Memory) {
 			validationErr := bodyValidationError("/units/memory", "invalid_enum", "memory unit must be one of b, B, KB, MB, or GB")
 			return cfg, &validationErr
 		}
-		if request.Units.Time != "" && !slices.Contains([]string{"ns", "us", "ms", "s"}, request.Units.Time) {
+		if request.Units.Time != nil && !slices.Contains([]string{"ns", "us", "ms", "s"}, *request.Units.Time) {
 			validationErr := bodyValidationError("/units/time", "invalid_enum", "time unit must be one of ns, us, ms, or s")
 			return cfg, &validationErr
 		}
-		if request.Units.Number != "" && !slices.Contains([]string{"K", "M", "B", "T"}, request.Units.Number) {
+		if request.Units.Number != nil && !slices.Contains([]string{"K", "M", "B", "T"}, *request.Units.Number) {
 			validationErr := bodyValidationError("/units/number", "invalid_enum", "number unit must be one of K, M, B, or T")
 			return cfg, &validationErr
 		}
-		if request.Units.Memory != "" {
-			cfg.MemUnit = request.Units.Memory
+		if request.Units.Memory != nil {
+			cfg.MemUnit = *request.Units.Memory
 		}
-		if request.Units.Time != "" {
-			cfg.TimeUnit = request.Units.Time
+		if request.Units.Time != nil {
+			cfg.TimeUnit = *request.Units.Time
 		}
-		cfg.NumberUnit = request.Units.Number
-	}
-
-	if cfg.JSONPath != "" && key != "auto" && key != "json" {
-		validationErr := bodyValidationError("/jsonPath", "inapplicable_option", "jsonPath is only supported by the json parser")
-		return cfg, &validationErr
-	}
-	if len(request.Select) > 0 && slices.Contains([]string{"go", "javascript", "rust"}, key) {
-		validationErr := bodyValidationError("/select", "inapplicable_option", "select is only supported by csv and json input")
-		return cfg, &validationErr
+		if request.Units.Number != nil {
+			cfg.NumberUnit = *request.Units.Number
+		}
 	}
 
 	var err error
@@ -178,12 +394,6 @@ func buildParserConfig(request convertRequest, key string) (parser.Config, *apiV
 	if err != nil {
 		validationErr := bodyValidationError("/grouping", "invalid_grouping", err.Error())
 		return cfg, &validationErr
-	}
-	if (key == "csv" || key == "json") && len(cfg.Group) > 0 {
-		if err := parser.ValidateTabularGroupAlignment(cfg); err != nil {
-			validationErr := bodyValidationError("/grouping", "invalid_grouping", err.Error())
-			return cfg, &validationErr
-		}
 	}
 	if validationErr := applySelectOptions(&cfg, request.Select); validationErr != nil {
 		return cfg, validationErr
@@ -333,8 +543,12 @@ func decodeChartConfig(raw json.RawMessage, path string) (internalcharts.ChartCo
 		validationErr := bodyValidationError(path+"/type", "invalid_enum", err.Error())
 		return nil, &validationErr
 	}
-	if err := strictDecode(raw, config); err != nil {
-		validationErr := bodyValidationError(path, "invalid_chart_config", err.Error())
+	if err := strictDecodeRequestObject(raw, config, path); err != nil {
+		var validationErr apiValidationError
+		if errors.As(err, &validationErr) {
+			return nil, &validationErr
+		}
+		validationErr = bodyValidationError(path, "invalid_chart_config", err.Error())
 		return nil, &validationErr
 	}
 	if validationErr := validateChartConfigValues(raw, path); validationErr != nil {
@@ -349,10 +563,24 @@ func validateChartConfigValues(raw json.RawMessage, path string) *apiValidationE
 		validationErr := bodyValidationError(path, "invalid_chart_config", err.Error())
 		return &validationErr
 	}
+	if validationErr := rejectNullObjectValues(values, path); validationErr != nil {
+		return validationErr
+	}
 	if scaleRaw, ok := values["scale"]; ok {
 		var scale string
 		if err := json.Unmarshal(scaleRaw, &scale); err != nil || (scale != "linear" && scale != "log") {
 			validationErr := bodyValidationError(path+"/scale", "invalid_enum", "scale must be linear or log")
+			return &validationErr
+		}
+	}
+	if symbolRaw, ok := values["symbol"]; ok {
+		var symbol string
+		if err := json.Unmarshal(symbolRaw, &symbol); err != nil {
+			validationErr := bodyValidationError(path+"/symbol", "invalid_type", "symbol must be a string")
+			return &validationErr
+		}
+		if err := internalcharts.ValidateSymbolValue(symbol); err != nil {
+			validationErr := bodyValidationError(path+"/symbol", "invalid_value", err.Error())
 			return &validationErr
 		}
 	}
@@ -368,6 +596,9 @@ func validateChartConfigValues(raw json.RawMessage, path string) *apiValidationE
 		if err := json.Unmarshal(sortRaw, &sortFields); err != nil {
 			validationErr := bodyValidationError(path+"/sort", "invalid_value", "sort must be an object")
 			return &validationErr
+		}
+		if validationErr := rejectNullObjectValues(sortFields, path+"/sort"); validationErr != nil {
+			return validationErr
 		}
 		if _, ok := sortFields["enabled"]; !ok {
 			validationErr := bodyValidationError(path+"/sort/enabled", "required", "sort.enabled is required")
@@ -390,6 +621,9 @@ func validateChartConfigValues(raw json.RawMessage, path string) *apiValidationE
 			validationErr := bodyValidationError(path+"/stat", "invalid_value", "stat must be an object")
 			return &validationErr
 		}
+		if validationErr := rejectNullObjectValues(statFields, path+"/stat"); validationErr != nil {
+			return validationErr
+		}
 		if _, ok := statFields["enabled"]; !ok {
 			validationErr := bodyValidationError(path+"/stat/enabled", "required", "stat.enabled is required")
 			return &validationErr
@@ -405,6 +639,21 @@ func validateChartConfigValues(raw json.RawMessage, path string) *apiValidationE
 		}
 		if validationErr := validateStatMath(stat.Math, path+"/stat/math"); validationErr != nil {
 			return validationErr
+		}
+	}
+	return nil
+}
+
+func rejectNullObjectValues(values map[string]json.RawMessage, path string) *apiValidationError {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if bytes.Equal(bytes.TrimSpace(values[key]), []byte("null")) {
+			validationErr := bodyValidationError(path+"/"+key, "invalid_type", path+"/"+key+" must not be null")
+			return &validationErr
 		}
 	}
 	return nil

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -186,7 +186,15 @@ func strictDecodeRequestObject(data []byte, target any, prefix string) error {
 		path := prefix + "/" + strings.ReplaceAll(strings.ReplaceAll(field, "~", "~0"), "/", "~1")
 		return bodyValidationError(path, "unknown_field", "unknown request field "+field)
 	}
-	return requestTypeError(err, prefix)
+	var validationErr apiValidationError
+	if errors.As(requestTypeError(err, prefix), &validationErr) {
+		return validationErr
+	}
+	path := strings.TrimSuffix(prefix, "/")
+	if path == "" {
+		path = "/"
+	}
+	return bodyValidationError(path, "invalid_json", err.Error())
 }
 
 func requestTypeError(err error, prefix string) error {
@@ -589,11 +597,7 @@ func decodeChartConfig(raw json.RawMessage, path string) (internalcharts.ChartCo
 		return nil, &validationErr
 	}
 	if err := strictDecodeRequestObject(raw, config, path); err != nil {
-		var validationErr apiValidationError
-		if errors.As(err, &validationErr) {
-			return nil, &validationErr
-		}
-		validationErr = bodyValidationError(path, "invalid_chart_config", err.Error())
+		validationErr := err.(apiValidationError)
 		return nil, &validationErr
 	}
 	if validationErr := validateChartConfigValues(raw, path); validationErr != nil {

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -158,7 +158,7 @@ func rejectNullFields(data []byte, nullPath string, paths map[string]string) err
 	}
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(data, &fields); err != nil {
-		return err
+		return requestTypeError(err, nullPath)
 	}
 	keys := make([]string, 0, len(paths))
 	for field := range paths {
@@ -186,7 +186,24 @@ func strictDecodeRequestObject(data []byte, target any, prefix string) error {
 		path := prefix + "/" + strings.ReplaceAll(strings.ReplaceAll(field, "~", "~0"), "/", "~1")
 		return bodyValidationError(path, "unknown_field", "unknown request field "+field)
 	}
-	return err
+	return requestTypeError(err, prefix)
+}
+
+func requestTypeError(err error, prefix string) error {
+	var typeErr *json.UnmarshalTypeError
+	if !errors.As(err, &typeErr) {
+		return err
+	}
+	path := strings.TrimSuffix(prefix, "/")
+	for _, field := range strings.Split(typeErr.Field, ".") {
+		if field != "" {
+			path += "/" + strings.ReplaceAll(strings.ReplaceAll(field, "~", "~0"), "/", "~1")
+		}
+	}
+	if path == "" {
+		path = "/"
+	}
+	return bodyValidationError(path, "invalid_type", err.Error())
 }
 
 type mergeRequest struct {

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -28,6 +28,19 @@ type unitOptions struct {
 	Number string `json:"number"`
 }
 
+<<<<<<< HEAD
+=======
+type metadataOptions struct {
+	ID          string       `json:"id"`
+	Name        string       `json:"name"`
+	Theme       string       `json:"theme"`
+	Description string       `json:"description"`
+	Tag         string       `json:"tag"`
+	Timestamp   string       `json:"timestamp"`
+	Meta        *shared.Meta `json:"meta"`
+}
+
+>>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 type chartSelection struct {
 	Types   []string          `json:"types"`
 	Configs []json.RawMessage `json:"configs"`
@@ -41,6 +54,10 @@ type statisticsOptions struct {
 type convertRequest struct {
 	Input    json.RawMessage  `json:"input"`
 	Parser   string           `json:"parser"`
+<<<<<<< HEAD
+=======
+	Metadata *metadataOptions `json:"metadata"`
+>>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 	Grouping *groupingOptions `json:"grouping"`
 	Units    *unitOptions     `json:"units"`
 	Select   []string         `json:"select"`
@@ -57,8 +74,13 @@ type mergeRequest struct {
 }
 
 type uiRequest struct {
+<<<<<<< HEAD
 	Datasets   json.RawMessage    `json:"datasets"`
 	Charts     chartSelection     `json:"charts"`
+=======
+	Datasets   json.RawMessage   `json:"datasets"`
+	Charts     chartSelection    `json:"charts"`
+>>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 	Statistics *statisticsOptions `json:"statistics"`
 }
 
@@ -69,10 +91,13 @@ type apiValidationError struct {
 	Message  string `json:"message"`
 }
 
+<<<<<<< HEAD
 func (e apiValidationError) Error() string {
 	return e.Message
 }
 
+=======
+>>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 func bodyValidationError(path, code, message string) apiValidationError {
 	return apiValidationError{Location: "body", Path: path, Code: code, Message: message}
 }
@@ -96,6 +121,7 @@ func buildConvertInput(request convertRequest, input []byte) (core.ConvertInput,
 		return core.ConvertInput{}, nil, validationErr
 	}
 
+<<<<<<< HEAD
 	return core.ConvertInput{
 		Input:  input,
 		Parser: key,
@@ -105,6 +131,35 @@ func buildConvertInput(request convertRequest, input []byte) (core.ConvertInput,
 			Theme: "default",
 		},
 		Charts: configs,
+=======
+	metadata := core.Metadata{Name: "Comparisons", Theme: "default"}
+	if request.Metadata != nil {
+		if request.Metadata.Theme != "" {
+			if err := validateTheme(request.Metadata.Theme); err != nil {
+				validationErr := bodyValidationError("/metadata/theme", "invalid_value", err.Error())
+				return core.ConvertInput{}, nil, &validationErr
+			}
+		}
+		metadata = core.Metadata{
+			ID:          request.Metadata.ID,
+			Name:        request.Metadata.Name,
+			Theme:       request.Metadata.Theme,
+			Description: request.Metadata.Description,
+			Tag:         request.Metadata.Tag,
+			Timestamp:   request.Metadata.Timestamp,
+			System:      request.Metadata.Meta,
+		}
+		if metadata.Name == "" {
+			metadata.Name = "Comparisons"
+		}
+		if metadata.Theme == "" {
+			metadata.Theme = "default"
+		}
+	}
+
+	return core.ConvertInput{
+		Input: input, Parser: key, Config: cfg, Metadata: metadata, Charts: configs,
+>>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 	}, types, nil
 }
 
@@ -179,12 +234,15 @@ func buildParserConfig(request convertRequest, key string) (parser.Config, *apiV
 		validationErr := bodyValidationError("/grouping", "invalid_grouping", err.Error())
 		return cfg, &validationErr
 	}
+<<<<<<< HEAD
 	if (key == "csv" || key == "json") && len(cfg.Group) > 0 {
 		if err := parser.ValidateTabularGroupAlignment(cfg); err != nil {
 			validationErr := bodyValidationError("/grouping", "invalid_grouping", err.Error())
 			return cfg, &validationErr
 		}
 	}
+=======
+>>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 	if validationErr := applySelectOptions(&cfg, request.Select); validationErr != nil {
 		return cfg, validationErr
 	}
@@ -262,8 +320,16 @@ func materialiseConversionCharts(selection chartSelection) ([]internalcharts.Cha
 	}
 	configs := make([]internalcharts.ChartConfig, 0, len(types))
 	for _, chartType := range types {
+<<<<<<< HEAD
 		// chartType and overrides are validated above, so Materialise cannot fail.
 		config, _ := internalcharts.Materialise(chartType, nil, overrides[chartType])
+=======
+		config, err := internalcharts.Materialise(chartType, nil, overrides[chartType])
+		if err != nil {
+			validationErr := bodyValidationError("/charts/configs", "invalid_chart_config", err.Error())
+			return nil, nil, &validationErr
+		}
+>>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 		configs = append(configs, config)
 	}
 	return configs, types, nil
@@ -320,7 +386,11 @@ func decodeChartConfig(raw json.RawMessage, path string) (internalcharts.ChartCo
 	var discriminator struct {
 		Type string `json:"type"`
 	}
+<<<<<<< HEAD
 	if err := json.Unmarshal(raw, &discriminator); err != nil {
+=======
+	if err := strictDecode(raw, &discriminator); err != nil {
+>>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 		validationErr := bodyValidationError(path, "invalid_chart_config", err.Error())
 		return nil, &validationErr
 	}
@@ -467,7 +537,14 @@ func applyUIOptions(datasets []shared.Dataset, selection chartSelection, statist
 		configs := make([]internalcharts.ChartConfig, 0, len(targetTypes))
 		for _, chartType := range targetTypes {
 			base, hasBase := existing[chartType]
+<<<<<<< HEAD
 			override := overrides[chartType]
+=======
+			override, hasOverride := overrides[chartType]
+			if !hasBase && !hasOverride {
+				continue
+			}
+>>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 			seed := map[string]any{}
 			if hasBase {
 				raw, err := json.Marshal(base)
@@ -475,13 +552,28 @@ func applyUIOptions(datasets []shared.Dataset, selection chartSelection, statist
 					validationErr := bodyValidationError("/datasets", "invalid_dataset", err.Error())
 					return nil, nil, &validationErr
 				}
+<<<<<<< HEAD
 				_ = json.Unmarshal(raw, &seed) // json.Marshal always produces valid JSON.
+=======
+				if err := json.Unmarshal(raw, &seed); err != nil {
+					validationErr := bodyValidationError("/datasets", "invalid_dataset", err.Error())
+					return nil, nil, &validationErr
+				}
+>>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 			}
 			if stat != nil {
 				seed["stat"] = stat
 			}
+<<<<<<< HEAD
 			// chartType and override were validated before assembling the seed.
 			config, _ := internalcharts.Materialise(chartType, seed, override)
+=======
+			config, err := internalcharts.Materialise(chartType, seed, override)
+			if err != nil {
+				validationErr := bodyValidationError("/charts/configs", "invalid_chart_config", err.Error())
+				return nil, nil, &validationErr
+			}
+>>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 			configs = append(configs, config)
 		}
 		result[i].Settings = configs
@@ -490,6 +582,7 @@ func applyUIOptions(datasets []shared.Dataset, selection chartSelection, statist
 }
 
 type datasetWire struct {
+<<<<<<< HEAD
 	ID           string              `json:"id"`
 	Tag          string              `json:"tag"`
 	Timestamp    string              `json:"timestamp"`
@@ -502,6 +595,20 @@ type datasetWire struct {
 	Settings     *[]json.RawMessage  `json:"settings"`
 	Data         *[]shared.DataPoint `json:"data"`
 	PreserveRows bool                `json:"preserveRows"`
+=======
+	ID           string            `json:"id"`
+	Tag          string            `json:"tag"`
+	Timestamp    string            `json:"timestamp"`
+	Name         *string           `json:"name"`
+	Theme        string            `json:"theme"`
+	History      []historyWire     `json:"history"`
+	Description  string            `json:"description"`
+	Meta         *shared.Meta      `json:"meta"`
+	Axes         *[]axisWire       `json:"axes"`
+	Settings     *[]json.RawMessage `json:"settings"`
+	Data         *[]shared.DataPoint `json:"data"`
+	PreserveRows bool              `json:"preserveRows"`
+>>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 }
 
 type historyWire struct {
@@ -556,6 +663,7 @@ func decodeStrictDataset(raw json.RawMessage, path string) (shared.Dataset, *api
 	}
 
 	settings := make([]internalcharts.ChartConfig, 0, len(*wire.Settings))
+<<<<<<< HEAD
 	settingTypes := make(map[string]bool, len(*wire.Settings))
 	for i, rawConfig := range *wire.Settings {
 		configPath := fmt.Sprintf("%s/settings/%d", path, i)
@@ -568,6 +676,13 @@ func decodeStrictDataset(raw json.RawMessage, path string) (shared.Dataset, *api
 			return shared.Dataset{}, &validationErr
 		}
 		settingTypes[config.ChartType()] = true
+=======
+	for i, rawConfig := range *wire.Settings {
+		config, validationErr := decodeChartConfig(rawConfig, fmt.Sprintf("%s/settings/%d", path, i))
+		if validationErr != nil {
+			return shared.Dataset{}, validationErr
+		}
+>>>>>>> bce573e (fix(api): align REST handlers with OpenAPI contract)
 		settings = append(settings, config)
 	}
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/goptics/vizb/cmd/cli"
 	internalcharts "github.com/goptics/vizb/internal/charts"
-	"github.com/goptics/vizb/internal/flags"
 	"github.com/goptics/vizb/pkg/core"
 	"github.com/goptics/vizb/pkg/parser"
 	"github.com/goptics/vizb/shared"
@@ -207,9 +206,9 @@ func (s *ServeSuite) TestCancellationShutsDownInMemoryListener() {
 			listen:     func(string, string) (net.Listener, error) { return listener, nil },
 		})
 	}()
-	<-listener.acceptStarted
+	s.waitForSignal(listener.acceptStarted)
 	cancel()
-	s.Require().NoError(<-result)
+	s.Require().NoError(s.waitForResult(result))
 }
 
 func (s *ServeSuite) TestCancellationTriggersGracefulShutdown() {
@@ -229,9 +228,9 @@ func (s *ServeSuite) TestCancellationTriggersGracefulShutdown() {
 		})
 	}()
 
-	<-listener.acceptStarted
+	s.waitForSignal(listener.acceptStarted)
 	cancel()
-	s.Require().NoError(<-result)
+	s.Require().NoError(s.waitForResult(result))
 	s.True(shutdownCalled.Load())
 }
 
@@ -245,19 +244,17 @@ func (s *ServeSuite) TestShutdownFailureIsReturned() {
 		result <- runServer(ctx, serveOptions{Host: defaultServeHost, Port: defaultServePort}, serveDependencies{
 			newHandler: http.NotFoundHandler,
 			listen:     func(string, string) (net.Listener, error) { return listener, nil },
-			shutdown: func(server *http.Server, _ context.Context) error {
-				_ = server.Close()
-				return errors.New("drain failed")
-			},
+			shutdown:   func(*http.Server, context.Context) error { return errors.New("drain failed") },
 		})
 	}()
 
-	<-listener.acceptStarted
+	s.waitForSignal(listener.acceptStarted)
 	cancel()
-	s.EqualError(<-result, "shutdown HTTP server: drain failed")
+	s.EqualError(s.waitForResult(result), "shutdown HTTP server: drain failed")
+	s.waitForSignal(listener.closed)
 }
 
-func (s *ServeSuite) TestShutdownFailurePreservesCloseFailure() {
+func (s *ServeSuite) TestShutdownFailureIgnoresCloseError() {
 	listener := closeErrorListener{
 		blockingListener: newBlockingListener(),
 		err:              errors.New("close failed"),
@@ -274,11 +271,11 @@ func (s *ServeSuite) TestShutdownFailurePreservesCloseFailure() {
 		})
 	}()
 
-	<-listener.acceptStarted
+	s.waitForSignal(listener.acceptStarted)
 	cancel()
-	err := <-result
+	err := s.waitForResult(result)
 	s.ErrorIs(err, drainErr)
-	s.ErrorContains(err, "close HTTP server: close failed")
+	s.waitForSignal(listener.closed)
 }
 
 func (s *ServeSuite) TestShutdownDeadlineForceClosesActiveConnections() {
@@ -297,7 +294,11 @@ func (s *ServeSuite) TestShutdownDeadlineForceClosesActiveConnections() {
 				return http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 					defer close(handlerFinished)
 					close(requestStarted)
-					<-releaseRequest
+					select {
+					case <-releaseRequest:
+					case <-time.After(time.Second):
+						s.Fail("timed out waiting to release the active request")
+					}
 				})
 			},
 			listen: func(string, string) (net.Listener, error) { return listener, nil },
@@ -328,9 +329,9 @@ func (s *ServeSuite) TestShutdownDeadlineForceClosesActiveConnections() {
 			err      error
 		}{response: response, err: err}
 	}()
-	<-requestStarted
+	s.waitForSignal(requestStarted)
 	cancel()
-	s.EqualError(<-result, "shutdown HTTP server: context deadline exceeded")
+	s.EqualError(s.waitForResult(result), "shutdown HTTP server: context deadline exceeded")
 	select {
 	case client := <-clientResult:
 		s.NoError(client.err)
@@ -362,9 +363,9 @@ func (s *ServeSuite) TestServeFailureDuringShutdownIsReturned() {
 		})
 	}()
 
-	<-listener.acceptStarted
+	s.waitForSignal(listener.acceptStarted)
 	cancel()
-	s.EqualError(<-result, "serve HTTP: accept failed during shutdown")
+	s.EqualError(s.waitForResult(result), "serve HTTP: accept failed during shutdown")
 }
 
 func (s *ServeSuite) TestServeAddress() {
@@ -576,8 +577,8 @@ func (s *ServeSuite) TestMergeEndpoint() {
 	s.Equal(http.StatusBadRequest, recorder.Code)
 
 	recorder = s.apiRequest(handler, "/merge", `{"datasets":[],"extra":true}`, "application/json", "")
-	s.Equal(http.StatusBadRequest, recorder.Code)
-	s.Contains(recorder.Body.String(), "/extra")
+	s.Equal(http.StatusUnprocessableEntity, recorder.Code)
+	s.Contains(recorder.Body.String(), `"path":"/"`)
 
 	recorder = s.apiRequest(handler, "/merge", `{"datasets":[{"name":"one"}]}`, "application/json", "")
 	s.Equal(http.StatusUnprocessableEntity, recorder.Code)
@@ -808,8 +809,9 @@ func (s *ServeSuite) TestRequestHelpers() {
 	cfg = parser.Config{}
 	validationErr = applySelectOptions(&cfg, []string{"region,value"})
 	s.Nil(validationErr)
+	pattern := "x,y"
 	_, validationErr = buildParserConfig(convertRequest{
-		Grouping: &groupingOptions{Pattern: "x,y", Columns: []string{"region/value"}},
+		Grouping: &groupingOptions{Pattern: &pattern, Columns: []string{"region/value"}},
 	}, "csv")
 	s.NotNil(validationErr)
 
@@ -872,6 +874,37 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 		}
 	})
 
+	s.Run("statistics decoding", func() {
+		for _, test := range []struct {
+			name string
+			raw  string
+			path string
+		}{
+			{name: "null statistics", raw: `{"statistics":null}`, path: "/statistics"},
+			{name: "null enabled", raw: `{"statistics":{"enabled":null}}`, path: "/statistics/enabled"},
+			{name: "null math", raw: `{"statistics":{"math":null}}`, path: "/statistics/math"},
+			{name: "unknown statistics field", raw: `{"statistics":{"bogus":true}}`, path: "/statistics/bogus"},
+		} {
+			s.Run(test.name, func() {
+				var request uiRequest
+				err := json.Unmarshal([]byte(test.raw), &request)
+				var validationErr apiValidationError
+				s.Require().ErrorAs(err, &validationErr)
+				s.Equal(test.path, validationErr.Path)
+			})
+		}
+
+		var omitted uiRequest
+		s.Require().NoError(json.Unmarshal([]byte(`{}`), &omitted))
+		s.Nil(omitted.Statistics)
+
+		var populated uiRequest
+		s.Require().NoError(json.Unmarshal([]byte(`{"statistics":{"enabled":false,"math":["counts"]}}`), &populated))
+		s.Require().NotNil(populated.Statistics)
+		s.False(*populated.Statistics.Enabled)
+		s.Equal([]string{"counts"}, populated.Statistics.Math)
+	})
+
 	s.Run("conversion option paths", func() {
 		selection := chartSelection{Configs: []json.RawMessage{
 			json.RawMessage(`invalid`),
@@ -920,7 +953,7 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 		}
 	})
 
-	s.Run("UI materialisation errors", func() {
+	s.Run("UI materialisation marshal error", func() {
 		for _, test := range []struct {
 			name   string
 			config internalcharts.ChartConfig
@@ -928,14 +961,6 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 			{
 				name:   "marshal base",
 				config: testChartConfig{chartType: "bar", marshalErr: errors.New("marshal failed")},
-			},
-			{
-				name:   "decode base",
-				config: testChartConfig{chartType: "bar", raw: json.RawMessage(`[]`)},
-			},
-			{
-				name:   "materialise unknown chart",
-				config: testChartConfig{chartType: "unknown", raw: json.RawMessage(`{"type":"unknown"}`)},
 			},
 		} {
 			s.Run(test.name, func() {
@@ -959,22 +984,24 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 	})
 }
 
-func (s *ServeSuite) TestMaterialiseConversionChartsReportsFailure() {
-	saved := append([]flags.Flag(nil), internalcharts.FlagsFor("bar")...)
-	s.T().Cleanup(func() { internalcharts.SetFlags("bar", saved) })
-	internalcharts.SetFlags("bar", append(saved, flags.Flag{
-		Name:    "invalid-default",
-		Kind:    flags.KindString,
-		JSONKey: "invalidDefault",
-		Default: func() {},
-	}))
+func (s *ServeSuite) waitForSignal(signal <-chan struct{}) {
+	s.T().Helper()
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		s.FailNow("timed out waiting for signal")
+	}
+}
 
-	_, _, validationErr := materialiseConversionCharts(chartSelection{Types: []string{"bar"}})
-
-	s.Require().NotNil(validationErr)
-	s.Equal("/charts/configs", validationErr.Path)
-	s.Equal("invalid_chart_config", validationErr.Code)
-	s.ErrorContains(validationErr, "unsupported type")
+func (s *ServeSuite) waitForResult(result <-chan error) error {
+	s.T().Helper()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(time.Second):
+		s.FailNow("timed out waiting for server result")
+		return nil
+	}
 }
 
 func (s *ServeSuite) apiRequest(handler http.Handler, path, body, contentType, accept string) *httptest.ResponseRecorder {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -478,6 +478,7 @@ func (s *ServeSuite) TestConvertEndpointRejectsInvalidRequests() {
 		{name: "invalid output format", body: `{"input":"x,y\na,1\n","output":{"format":"csv"}}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true},
 		{name: "metadata is not supported", body: `{"input":"x,y\na,1\n","metadata":{"name":"example"}}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true},
 		{name: "unknown field", body: `{"input":"x,y\na,1\n","extra":true}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true},
+		{name: "request not object", body: `"foo"`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true, wantPath: "/"},
 		{name: "grouping not object", body: `{"input":"x,y\na,1\n","grouping":"foo"}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true, wantPath: "/grouping"},
 		{name: "grouping pattern wrong type", body: `{"input":"x,y\na,1\n","grouping":{"pattern":123}}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true, wantPath: "/grouping/pattern"},
 		{name: "missing content type", body: `{}`, wantStatus: http.StatusUnsupportedMediaType},

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/goptics/vizb/cmd/cli"
 	internalcharts "github.com/goptics/vizb/internal/charts"
+	"github.com/goptics/vizb/internal/flags"
 	"github.com/goptics/vizb/pkg/core"
 	"github.com/goptics/vizb/pkg/parser"
 	"github.com/goptics/vizb/shared"
@@ -589,6 +590,7 @@ func (s *ServeSuite) TestMergeEndpoint() {
 
 	recorder = s.apiRequest(handler, "/merge", `{"datasets":[`+firstMergeJSON+`,`+secondMergeJSON+`],"tagAxis":"invalid"}`, "application/json", "")
 	s.Equal(http.StatusUnprocessableEntity, recorder.Code)
+	s.Contains(recorder.Body.String(), `"/tagAxis"`)
 
 	recorder = s.apiRequest(handler, "/merge", `{"datasets":[{"name":"one"},{"name":"two"}]}`, "application/json", "")
 	s.Equal(http.StatusUnprocessableEntity, recorder.Code)
@@ -955,6 +957,24 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 		s.Require().Len(datasets[0].History, 1)
 		s.Equal("v1", datasets[0].History[0].Tag)
 	})
+}
+
+func (s *ServeSuite) TestMaterialiseConversionChartsReportsFailure() {
+	saved := append([]flags.Flag(nil), internalcharts.FlagsFor("bar")...)
+	s.T().Cleanup(func() { internalcharts.SetFlags("bar", saved) })
+	internalcharts.SetFlags("bar", append(saved, flags.Flag{
+		Name:    "invalid-default",
+		Kind:    flags.KindString,
+		JSONKey: "invalidDefault",
+		Default: func() {},
+	}))
+
+	_, _, validationErr := materialiseConversionCharts(chartSelection{Types: []string{"bar"}})
+
+	s.Require().NotNil(validationErr)
+	s.Equal("/charts/configs", validationErr.Path)
+	s.Equal("invalid_chart_config", validationErr.Code)
+	s.ErrorContains(validationErr, "unsupported type")
 }
 
 func (s *ServeSuite) apiRequest(handler http.Handler, path, body, contentType, accept string) *httptest.ResponseRecorder {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -999,6 +999,11 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 		}
 
 		s.Error(rejectNullFields([]byte(`{`), "/", map[string]string{}))
+		err := strictDecodeRequestObject([]byte(`{} {}`), new(groupingOptions), "")
+		var validationErr apiValidationError
+		s.Require().ErrorAs(err, &validationErr)
+		s.Equal("/", validationErr.Path)
+		s.Equal("invalid_json", validationErr.Code)
 	})
 
 	s.Run("conversion metadata", func() {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -571,6 +571,26 @@ func (s *ServeSuite) TestConvertEndpointReportsUIGenerationFailure() {
 	s.Contains(recorder.Body.String(), "could not generate the response")
 }
 
+func (s *ServeSuite) TestConvertEndpointReportsInapplicableChartOptions() {
+	handler := newRESTHandler()
+	recorder := s.apiRequest(
+		handler,
+		"/",
+		`{"input":"region,value\nwest,12\n","parser":"csv","charts":{"types":["bar"],"configs":[{"type":"bar","threeDRotate":true}]}}`,
+		"application/json",
+		"application/json",
+	)
+	s.Equal(http.StatusUnprocessableEntity, recorder.Code, recorder.Body.String())
+
+	var problem struct {
+		Errors []apiValidationError `json:"errors"`
+	}
+	s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &problem))
+	s.Require().Len(problem.Errors, 1)
+	s.Equal("/charts/configs/0/threeDRotate", problem.Errors[0].Path)
+	s.Equal("inapplicable_option", problem.Errors[0].Code)
+}
+
 func (s *ServeSuite) TestMergeEndpoint() {
 	handler := newRESTHandler()
 	recorder := s.apiRequest(handler, "/merge", `{`, "application/json", "")
@@ -931,6 +951,65 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 		s.Empty(warningFlagName("unstructured warning"))
 		s.Empty(warningFlagName(`flag "unterminated`))
 		s.Empty(chartFlagJSONKey("not-a-flag"))
+		s.Equal("show-labels", warningFlagName(`flag "show-labels" skipped: unsupported`))
+		s.Equal("showLabels", chartFlagJSONKey("show-labels"))
+
+		selection := chartSelection{Configs: []json.RawMessage{
+			json.RawMessage(`{"type":"bar","showLabels":true}`),
+			json.RawMessage(`{"type":"line","showLabels":false}`),
+		}}
+		errors := conversionWarningValidationErrors(selection, []string{
+			`flag "show-labels" skipped: unsupported`,
+			`flag "show-labels" skipped: unsupported`,
+			"unstructured warning",
+		})
+		s.Equal([]string{
+			"/charts/configs/0/showLabels",
+			"/charts/configs/1/showLabels",
+			"/charts/configs",
+		}, []string{errors[0].Path, errors[1].Path, errors[2].Path})
+	})
+
+	s.Run("conversion request decoding", func() {
+		for _, test := range []struct {
+			name   string
+			raw    string
+			target any
+			path   string
+		}{
+			{name: "null convert field", raw: `{"theme":null}`, target: new(convertRequest), path: "/theme"},
+			{name: "unknown grouping field", raw: `{"unexpected":true}`, target: new(groupingOptions), path: "/grouping/unexpected"},
+			{name: "null unit field", raw: `{"memory":null}`, target: new(unitOptions), path: "/units/memory"},
+			{name: "unknown unit field", raw: `{"unexpected":true}`, target: new(unitOptions), path: "/units/unexpected"},
+		} {
+			s.Run(test.name, func() {
+				err := json.Unmarshal([]byte(test.raw), test.target)
+				var validationErr apiValidationError
+				s.Require().ErrorAs(err, &validationErr)
+				s.Equal(test.path, validationErr.Path)
+			})
+		}
+
+		s.Error(rejectNullFields([]byte(`{`), "/", map[string]string{}))
+	})
+
+	s.Run("conversion metadata", func() {
+		id, name := "run-1", "Example"
+		description, tag, theme := "Description", "release", " Westeros "
+		metadata, validationErr := buildConvertMetadata(convertRequest{
+			ID:          &id,
+			Name:        &name,
+			Description: &description,
+			Tag:         &tag,
+			Theme:       &theme,
+		})
+		s.Require().Nil(validationErr)
+		s.Equal(core.Metadata{ID: id, Name: name, Description: description, Tag: tag, Theme: "westeros"}, metadata)
+
+		invalidTheme := "not-a-theme"
+		_, _, validationErr = buildConvertInput(convertRequest{Theme: &invalidTheme}, []byte("x,y\\na,1\\n"))
+		s.Require().NotNil(validationErr)
+		s.Equal("/theme", validationErr.Path)
 	})
 
 	s.Run("chart config decoding", func() {
@@ -944,8 +1023,11 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 
 		for _, raw := range []string{
 			`{`,
+			`{"scale":null}`,
 			`{"symbol":1}`,
+			`{"symbol":"not-a-symbol"}`,
 			`{"sort":true}`,
+			`{"sort":{"enabled":null,"order":"asc"}}`,
 			`{"stat":true}`,
 			`{"stat":{"enabled":"yes","math":[]}}`,
 		} {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/goptics/vizb/cmd/cli"
 	internalcharts "github.com/goptics/vizb/internal/charts"
+	"github.com/goptics/vizb/pkg/core"
 	"github.com/goptics/vizb/pkg/parser"
 	"github.com/goptics/vizb/shared"
 	"github.com/stretchr/testify/suite"
@@ -513,10 +514,13 @@ func (s *ServeSuite) TestConvertEndpointValidatesStructuredOptions() {
 		{name: "json path with csv", body: `{"input":"x,y\na,1\n","parser":"csv","jsonPath":".data"}`},
 		{name: "select with benchmark", body: `{"input":"BenchmarkFoo 100 1 ns/op\n","parser":"go","select":["x,y"]}`},
 		{name: "empty select", body: `{"input":"x,y\na,1\n","select":[""]}`},
+		{name: "empty grouped select", body: `{"input":"region,value\nwest,1\n","grouping":{"columns":["region"]},"select":[""]}`},
+		{name: "invalid grouped select", body: `{"input":"region,value\nwest,1\n","grouping":{"columns":["region"]},"select":["value{"]}`},
 		{name: "invalid solo select", body: `{"input":"x,y\na,1\n","select":["x"]}`},
 		{name: "invalid repeatable select", body: `{"input":"a,b,c\n1,2,3\n","select":["a,b,c","a,b"]}`},
 		{name: "duplicate grouped select", body: `{"input":"region,value\nwest,1\n","parser":"csv","grouping":{"pattern":"x","columns":["region"]},"select":["value","value"]}`},
 		{name: "group select conflict", body: `{"input":"region,value\nwest,1\n","parser":"csv","grouping":{"pattern":"x","columns":["region"]},"select":["region"]}`},
+		{name: "structured grouping separator mismatch", body: `{"input":"a,b,c\nx,y,1\n","grouping":{"pattern":"x,y,z","columns":["a/b/c"]}}`},
 		{name: "empty chart types", body: `{"input":"x,y\na,1\n","charts":{"types":[]}}`},
 		{name: "duplicate chart types", body: `{"input":"x,y\na,1\n","charts":{"types":["bar","bar"]}}`},
 		{name: "missing config type", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"showLabels":true}]}}`},
@@ -533,6 +537,7 @@ func (s *ServeSuite) TestConvertEndpointValidatesStructuredOptions() {
 		{name: "stat not object", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","stat":true}]}}`},
 		{name: "stat missing enabled", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","stat":{"math":[]}}]}}`},
 		{name: "stat missing math", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","stat":{"enabled":true}}]}}`},
+		{name: "null stat math", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","stat":{"enabled":true,"math":null}}]}}`},
 		{name: "stat invalid math", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","stat":{"enabled":true,"math":["bogus"]}}]}}`},
 		{name: "stat duplicate math", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","stat":{"enabled":true,"math":["counts","counts"]}}]}}`},
 	}
@@ -568,6 +573,10 @@ func (s *ServeSuite) TestMergeEndpoint() {
 	handler := newRESTHandler()
 	recorder := s.apiRequest(handler, "/merge", `{`, "application/json", "")
 	s.Equal(http.StatusBadRequest, recorder.Code)
+
+	recorder = s.apiRequest(handler, "/merge", `{"datasets":[],"extra":true}`, "application/json", "")
+	s.Equal(http.StatusBadRequest, recorder.Code)
+	s.Contains(recorder.Body.String(), "/extra")
 
 	recorder = s.apiRequest(handler, "/merge", `{"datasets":[{"name":"one"}]}`, "application/json", "")
 	s.Equal(http.StatusUnprocessableEntity, recorder.Code)
@@ -669,6 +678,22 @@ func (s *ServeSuite) TestUIEndpointMaterialisesDefaultsForSelectedChartTypes() {
 	s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
 }
 
+func (s *ServeSuite) TestUIEndpointAddsAnUnselectedOverrideType() {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleUIWithGenerator(w, r, func(datasets []shared.Dataset, charts []string) (string, error) {
+			s.Nil(charts)
+			s.Require().Len(datasets, 1)
+			s.Require().Len(datasets[0].Settings, 2)
+			s.Equal("bar", datasets[0].Settings[0].ChartType())
+			s.Equal("line", datasets[0].Settings[1].ChartType())
+			return "<html>ok</html>", nil
+		})
+	})
+	body := `{"datasets":` + validDatasetJSON + `,"charts":{"configs":[{"type":"line","smooth":true}]}}`
+	recorder := s.apiRequest(handler, "/ui", body, "application/json", "text/html")
+	s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+}
+
 func (s *ServeSuite) TestUIEndpointValidatesDatasetsAndStatistics() {
 	handler := newRESTHandler()
 	tests := []struct {
@@ -689,6 +714,7 @@ func (s *ServeSuite) TestUIEndpointValidatesDatasetsAndStatistics() {
 		{name: "history missing timestamp", datasets: `{"name":"Bench","history":[{"tag":"v1"}],"axes":[],"settings":[],"data":[]}`},
 		{name: "invalid statistics", datasets: validDatasetJSON, suffix: `,"statistics":{"math":["bogus"]}`},
 		{name: "duplicate statistics", datasets: validDatasetJSON, suffix: `,"statistics":{"math":["counts","counts"]}`},
+		{name: "unselected chart config", datasets: validDatasetJSON, suffix: `,"charts":{"types":["bar"],"configs":[{"type":"line"}]}`},
 	}
 	for _, test := range tests {
 		s.Run(test.name, func() {
@@ -754,6 +780,7 @@ func (s *ServeSuite) TestRequestHelpers() {
 	s.False(accepts(request, "text/html"))
 	request.Header.Set("Accept", "text")
 	s.False(accepts(request, "text/html"))
+	request.Header.Set("Accept", "invalid")
 	s.False(accepts(request, "invalid"))
 
 	var target map[string]any
@@ -818,6 +845,116 @@ func (s *ServeSuite) TestRequestHelpers() {
 
 	_, validationErr = decodeStrictDataset(json.RawMessage(`{"name":"Bench","history":[{"tag":"v1","timestamp":"now"}],"axes":[],"settings":[],"data":[]}`), "/datasets/0")
 	s.Nil(validationErr)
+}
+
+func (s *ServeSuite) TestRequestContractHelpers() {
+	s.Run("nested object decoding", func() {
+		for _, test := range []struct {
+			name   string
+			raw    string
+			target any
+			path   string
+		}{
+			{name: "null grouping", raw: `null`, target: new(groupingOptions), path: "/grouping"},
+			{name: "null charts", raw: `null`, target: new(chartSelection), path: "/charts"},
+			{name: "unknown charts field", raw: `{"bogus":true}`, target: new(chartSelection), path: "/charts/bogus"},
+			{name: "null output", raw: `null`, target: new(convertOutput), path: "/output"},
+			{name: "unknown output field", raw: `{"bogus":true}`, target: new(convertOutput), path: "/output/bogus"},
+		} {
+			s.Run(test.name, func() {
+				err := json.Unmarshal([]byte(test.raw), test.target)
+				var validationErr apiValidationError
+				s.Require().ErrorAs(err, &validationErr)
+				s.Equal(test.path, validationErr.Path)
+			})
+		}
+	})
+
+	s.Run("conversion option paths", func() {
+		selection := chartSelection{Configs: []json.RawMessage{
+			json.RawMessage(`invalid`),
+			json.RawMessage(`{"type":"bar","swap":"yx"}`),
+		}}
+		for _, test := range []struct {
+			name string
+			path string
+		}{
+			{name: "filter", path: "/grouping/filter"},
+			{name: "grouping", path: "/grouping"},
+			{name: "jsonPath", path: "/jsonPath"},
+			{name: "select", path: "/select"},
+			{name: "swap", path: "/charts/configs/1/swap"},
+			{name: "other", path: "/charts/configs"},
+		} {
+			got := conversionOptionValidationError(selection, &core.OptionError{Name: test.name, Err: errors.New("not applicable")})
+			s.Equal(test.path, got.Path)
+		}
+		s.Equal("/charts/configs", chartConfigFieldPath(selection, "swap", 1))
+	})
+
+	s.Run("warning parsing", func() {
+		s.Empty(warningFlagName("unstructured warning"))
+		s.Empty(warningFlagName(`flag "unterminated`))
+		s.Empty(chartFlagJSONKey("not-a-flag"))
+	})
+
+	s.Run("chart config decoding", func() {
+		_, validationErr := decodeChartConfig(json.RawMessage(`{`), "/config")
+		s.Require().NotNil(validationErr)
+		s.Equal("/config", validationErr.Path)
+
+		_, validationErr = decodeChartConfig(json.RawMessage(`{"type":"bar","showLabels":"yes"}`), "/config")
+		s.Require().NotNil(validationErr)
+		s.Equal("/config", validationErr.Path)
+
+		for _, raw := range []string{
+			`{`,
+			`{"symbol":1}`,
+			`{"sort":true}`,
+			`{"stat":true}`,
+			`{"stat":{"enabled":"yes","math":[]}}`,
+		} {
+			s.NotNil(validateChartConfigValues(json.RawMessage(raw), "/config"), raw)
+		}
+	})
+
+	s.Run("UI materialisation errors", func() {
+		for _, test := range []struct {
+			name   string
+			config internalcharts.ChartConfig
+		}{
+			{
+				name:   "marshal base",
+				config: testChartConfig{chartType: "bar", marshalErr: errors.New("marshal failed")},
+			},
+			{
+				name:   "decode base",
+				config: testChartConfig{chartType: "bar", raw: json.RawMessage(`[]`)},
+			},
+			{
+				name:   "materialise unknown chart",
+				config: testChartConfig{chartType: "unknown", raw: json.RawMessage(`{"type":"unknown"}`)},
+			},
+		} {
+			s.Run(test.name, func() {
+				_, _, validationErr := applyUIOptions(
+					[]shared.Dataset{{Settings: []internalcharts.ChartConfig{test.config}}},
+					chartSelection{},
+					nil,
+				)
+				s.Require().NotNil(validationErr)
+			})
+		}
+	})
+
+	s.Run("valid history", func() {
+		raw := json.RawMessage(`{"name":"Bench","history":[{"tag":"v1","timestamp":"now"}],"axes":[],"settings":[],"data":[]}`)
+		datasets, validationErr := decodeDatasets(raw)
+		s.Require().Nil(validationErr)
+		s.Require().Len(datasets, 1)
+		s.Require().Len(datasets[0].History, 1)
+		s.Equal("v1", datasets[0].History[0].Tag)
+	})
 }
 
 func (s *ServeSuite) apiRequest(handler http.Handler, path, body, contentType, accept string) *httptest.ResponseRecorder {
@@ -955,6 +1092,21 @@ func (l *singleConnectionListener) Addr() net.Addr { return testAddr("in-memory"
 
 func directSignalContext(ctx context.Context, _ ...os.Signal) (context.Context, context.CancelFunc) {
 	return context.WithCancel(ctx)
+}
+
+type testChartConfig struct {
+	chartType  string
+	raw        json.RawMessage
+	marshalErr error
+}
+
+func (c testChartConfig) ChartType() string { return c.chartType }
+func (testChartConfig) StatEnabled() bool   { return false }
+func (testChartConfig) StatMath() []string  { return nil }
+func (testChartConfig) SwapString() string  { return "" }
+
+func (c testChartConfig) MarshalJSON() ([]byte, error) {
+	return c.raw, c.marshalErr
 }
 
 func TestServeSuite(t *testing.T) {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -466,6 +466,7 @@ func (s *ServeSuite) TestConvertEndpointRejectsInvalidRequests() {
 		accept      string
 		wantStatus  int
 		wantErrors  bool
+		wantPath    string
 	}{
 		{name: "missing input", body: `{}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true},
 		{name: "null input", body: `{"input":null}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true},
@@ -477,6 +478,8 @@ func (s *ServeSuite) TestConvertEndpointRejectsInvalidRequests() {
 		{name: "invalid output format", body: `{"input":"x,y\na,1\n","output":{"format":"csv"}}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true},
 		{name: "metadata is not supported", body: `{"input":"x,y\na,1\n","metadata":{"name":"example"}}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true},
 		{name: "unknown field", body: `{"input":"x,y\na,1\n","extra":true}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true},
+		{name: "grouping not object", body: `{"input":"x,y\na,1\n","grouping":"foo"}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true, wantPath: "/grouping"},
+		{name: "grouping pattern wrong type", body: `{"input":"x,y\na,1\n","grouping":{"pattern":123}}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantErrors: true, wantPath: "/grouping/pattern"},
 		{name: "missing content type", body: `{}`, wantStatus: http.StatusUnsupportedMediaType},
 		{name: "wrong content type", body: `{}`, contentType: "text/plain", wantStatus: http.StatusUnsupportedMediaType},
 		{name: "malformed content type", body: `{}`, contentType: `application/json; charset="`, wantStatus: http.StatusUnsupportedMediaType},
@@ -493,6 +496,10 @@ func (s *ServeSuite) TestConvertEndpointRejectsInvalidRequests() {
 				}
 				s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &problem))
 				s.NotEmpty(problem.Errors)
+				if test.wantPath != "" {
+					s.Equal(test.wantPath, problem.Errors[0].Path)
+					s.Equal("invalid_type", problem.Errors[0].Code)
+				}
 			}
 		})
 	}
@@ -1019,7 +1026,7 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 
 		_, validationErr = decodeChartConfig(json.RawMessage(`{"type":"bar","showLabels":"yes"}`), "/config")
 		s.Require().NotNil(validationErr)
-		s.Equal("/config", validationErr.Path)
+		s.Equal("/config/showLabels", validationErr.Path)
 
 		for _, raw := range []string{
 			`{`,

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -405,6 +405,15 @@ func (s *ServeSuite) TestConvertEndpoint() {
 	recorder = s.apiRequest(handler, "/", `{"input":[{"region":"west","value":12}],"charts":{"types":["bar"]}}`, "application/json", "")
 	s.Equal(http.StatusOK, recorder.Code)
 
+	recorder = s.apiRequest(
+		handler,
+		"/",
+		`{"input":"region,latency\nwest,12\neast,18\n","parser":"csv","select":["region,latency"],"charts":{"types":["bar"]}}`,
+		"application/json",
+		"application/json",
+	)
+	s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+
 	documented := `{
 		"input":{"data":[{"region":"west","latency":12},{"region":"east","latency":18}]},
 		"parser":"auto",

--- a/docs/src/content/docs/commands/serve.mdx
+++ b/docs/src/content/docs/commands/serve.mdx
@@ -62,7 +62,7 @@ curl -sS http://127.0.0.1:8080/ \
     "tag": "v2",
     "theme": "westeros",
     "parser": "csv",
-    "select": ["region", "latency"],
+    "select": ["region,latency"],
     "charts": { "types": ["bar", "line"] },
     "output": { "format": "dataset" }
   }'

--- a/docs/src/content/docs/commands/serve.mdx
+++ b/docs/src/content/docs/commands/serve.mdx
@@ -56,6 +56,11 @@ curl -sS http://127.0.0.1:8080/ \
   -H 'Accept: application/json' \
   --data '{
     "input": "region,latency\\nwest,12\\neast,18\\n",
+    "id": "api-latency",
+    "name": "API latency",
+    "description": "Latency by region",
+    "tag": "v2",
+    "theme": "westeros",
     "parser": "csv",
     "select": ["region", "latency"],
     "charts": { "types": ["bar", "line"] },

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -62,6 +62,22 @@ type ConvertResult struct {
 	Warnings []string
 }
 
+// OptionError identifies a caller-supplied conversion option that cannot be
+// applied. Transport adapters use it to distinguish request validation from
+// malformed or otherwise unprocessable input.
+type OptionError struct {
+	Name string
+	Err  error
+}
+
+func (e *OptionError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *OptionError) Unwrap() error {
+	return e.Err
+}
+
 // Convert parses inline supported data, aggregates tabular rows, applies chart
 // rules, and builds a Dataset. Every dependency receives request-local values
 // and every failure is returned to the caller.
@@ -88,7 +104,7 @@ func Convert(in ConvertInput) (ConvertResult, error) {
 	}
 	if in.Config.Filter != "" {
 		if _, err := regexp.Compile(in.Config.Filter); err != nil {
-			return ConvertResult{}, fmt.Errorf("invalid filter regex: %w", err)
+			return ConvertResult{}, &OptionError{Name: "filter", Err: fmt.Errorf("invalid filter regex: %w", err)}
 		}
 	}
 
@@ -99,6 +115,19 @@ func Convert(in ConvertInput) (ConvertResult, error) {
 	}
 	cfg.ChartTypes = append(slices.Clone(cfg.ChartTypes), chartTypes(in.Charts)...)
 	tabular := key == "csv" || key == "json"
+	if tabular && len(cfg.Group) > 0 && cfg.GroupRegex == "" {
+		var err error
+		cfg, err = parser.FinalizeGroupConfig(cfg)
+		if err != nil {
+			return ConvertResult{}, &OptionError{Name: "grouping", Err: err}
+		}
+	}
+	if !tabular && parser.HasSelect(cfg) {
+		return ConvertResult{}, &OptionError{
+			Name: "select",
+			Err:  fmt.Errorf("select is only supported by csv and json input"),
+		}
+	}
 	if tabular && parser.NoExplicitGrouping(cfg) && !parser.HasSelect(cfg) {
 		cfg.AutoGroup = true
 	}
@@ -106,7 +135,10 @@ func Convert(in ConvertInput) (ConvertResult, error) {
 	data := in.Input
 	if cfg.JSONPath != "" {
 		if key != "json" {
-			return ConvertResult{}, fmt.Errorf("json path is only supported by the json parser")
+			return ConvertResult{}, &OptionError{
+				Name: "jsonPath",
+				Err:  fmt.Errorf("json path is only supported by the json parser"),
+			}
 		}
 		var err error
 		data, err = jsonparser.SelectBytes(data, cfg.JSONPath)
@@ -142,7 +174,7 @@ func Convert(in ConvertInput) (ConvertResult, error) {
 	for _, chart := range in.Charts {
 		if swap := chart.SwapString(); swap != "" {
 			if err := shared.ValidateSwap(swap, dataset.Axes); err != nil {
-				return ConvertResult{}, err
+				return ConvertResult{}, &OptionError{Name: "swap", Err: err}
 			}
 		}
 	}

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"math"
 	"strings"
 	"sync"
@@ -120,6 +121,38 @@ func (s *CoreSuite) TestConvertBranchErrorsAndAutoDetection() {
 	})
 	s.Require().NoError(err)
 	s.Len(result.Dataset.Data, 1)
+}
+
+func (s *CoreSuite) TestConvertIdentifiesInapplicableOptions() {
+	chart := []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}}
+	for _, input := range []ConvertInput{
+		{
+			Input:  []byte("BenchmarkFoo-8 100 123 ns/op\n"),
+			Parser: "auto",
+			Config: parser.Config{
+				SelectViews: []parser.SelectView{{Columns: []parser.ColumnSpec{{Source: "x"}, {Source: "y"}}}},
+			},
+			Charts: chart,
+		},
+		{
+			Input:  []byte("x,y\na,1\n"),
+			Parser: "csv",
+			Config: parser.Config{GroupPattern: "x", Group: []string{"x"}},
+			Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Swap: "x:z"}},
+		},
+		{
+			Input:  []byte("a,b,c\nx,y,1\n"),
+			Parser: "auto",
+			Config: parser.Config{GroupPattern: "x/y", Group: []string{"a", "b"}},
+			Charts: chart,
+		},
+	} {
+		_, err := Convert(input)
+		var optionErr *OptionError
+		s.Require().ErrorAs(err, &optionErr)
+		s.NotEmpty(optionErr.Name)
+		s.True(errors.Is(optionErr, optionErr.Err))
+	}
 }
 
 func (s *CoreSuite) TestConvertBenchmarkFormats() {

--- a/pkg/style/style.go
+++ b/pkg/style/style.go
@@ -1,6 +1,12 @@
 package style
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
 
 var (
 	// Error style (Red, Bold)
@@ -20,3 +26,43 @@ var (
 	Info = lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#8BE9FD"))
 )
+
+var (
+	builtInThemes = map[string]struct{}{
+		"default": {}, "vintage": {}, "meadow": {}, "westeros": {}, "essos": {},
+		"wonderland": {}, "walden": {}, "chalk": {}, "infographic": {},
+		"macarons": {}, "roma": {}, "shine": {}, "purple-passion": {},
+	}
+	hexColorPattern = regexp.MustCompile(`^#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?$`)
+)
+
+// ValidateTheme accepts a built-in name or a custom palette containing at
+// least two comma-separated #rgb/#rrggbb colors.
+func ValidateTheme(value string) error {
+	if _, ok := builtInThemes[strings.ToLower(value)]; ok {
+		return nil
+	}
+	colors := strings.Split(value, ",")
+	if len(colors) < 2 {
+		return fmt.Errorf("expected a built-in theme or at least two comma-separated hex colors")
+	}
+	for _, color := range colors {
+		if !hexColorPattern.MatchString(strings.TrimSpace(color)) {
+			return fmt.Errorf("invalid hex color %q", strings.TrimSpace(color))
+		}
+	}
+	return nil
+}
+
+// NormalizeTheme canonicalizes built-in names and custom palette whitespace.
+func NormalizeTheme(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if _, ok := builtInThemes[strings.ToLower(trimmed)]; ok {
+		return strings.ToLower(trimmed)
+	}
+	colors := strings.Split(trimmed, ",")
+	for i := range colors {
+		colors[i] = strings.TrimSpace(colors[i])
+	}
+	return strings.Join(colors, ",")
+}

--- a/pkg/style/style_test.go
+++ b/pkg/style/style_test.go
@@ -1,0 +1,29 @@
+package style
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ThemeSuite struct {
+	suite.Suite
+}
+
+func (s *ThemeSuite) TestValidateAndNormalizeTheme() {
+	for _, value := range []string{"default", "Westeros", "#F00,#00ff00"} {
+		s.NoError(ValidateTheme(NormalizeTheme(value)))
+	}
+	s.Equal("westeros", NormalizeTheme(" Westeros "))
+	s.Equal("#F00,#00ff00", NormalizeTheme(" #F00, #00ff00 "))
+}
+
+func (s *ThemeSuite) TestRejectsInvalidTheme() {
+	for _, value := range []string{"", "unknown", "#F00", "#F00,not-a-color"} {
+		s.Error(ValidateTheme(NormalizeTheme(value)))
+	}
+}
+
+func TestThemeSuite(t *testing.T) {
+	suite.Run(t, new(ThemeSuite))
+}

--- a/shared/chart_spec_test.go
+++ b/shared/chart_spec_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/goptics/vizb/internal/flags"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -270,6 +271,20 @@ func (s *ChartSpecSuite) TestValidateSwap() {
 		s.NoError(ValidateSwap("yxn", axes))
 		s.Error(ValidateSwap("xym", axes))
 	})
+}
+
+func (s *ChartSpecSuite) TestConvertIntegerFlagValue() {
+	flag := flags.Flag{Name: "limit", Kind: flags.KindInt}
+
+	value, err := convertFlagValue(flag, "12", true, nil)
+	s.Require().NoError(err)
+	s.Equal(12, value)
+
+	_, err = convertFlagValue(flag, "twelve", true, nil)
+	s.EqualError(err, `--chart: key "limit" value "twelve" must be an integer`)
+
+	_, err = convertFlagValue(flag, "", false, nil)
+	s.EqualError(err, `--chart: key "limit" requires a value (e.g. limit=<value>)`)
 }
 
 func TestChartSpecSuite(t *testing.T) {


### PR DESCRIPTION
## Related Issue
Resolve #214 

## Changes
- Added strict POST / Dataset/HTML conversion flow through the shared core.
- Added top-level Dataset metadata and structured parser, grouping, unit,
  selection, chart, and output fields.

- Added strict validation for unknown, null, invalid, and inapplicable options.
- Updated api/openapi.yaml with schemas and examples.
- Expanded cmd/serve.go, cmd/serve_contract.go, and test coverage.

## Test Result
```bash
go run . serve --host 127.0.0.1 --port 8080
```
### Case 1
```bash
curl -i http://127.0.0.1:8080/ \
          -H 'Content-Type: application/json' \

          -H 'Accept: application/json' \
          --data '{
        "input": "region,latency\nwest,12\neast,18\n",
        "parser": "csv",
        "select": ["region,latency"],
        "charts": {"types": ["bar", "line"]},
        "output": {"format": "dataset"}
      }'
HTTP/1.1 200 OK
Content-Type: application/json
Date: Sat, 18 Jul 2026 18:29:56 GMT
Content-Length: 326

{"timestamp":"2026-07-18T18:29:56Z","name":"Comparisons","theme":"default","axes":[{"key":"x","label":"region"},{"key":"y","label":"latency","type":"value"}],"settings":[{"type":"bar","scale":"linear"},{"type":"line","scale":"linear"}],"data":[{"xAxis":"west","yAxis":"12"},{"xAxis":"east","yAxis":"18"}],"preserveRows":true}
```
### Case 2
```bash
curl -i http://127.0.0.1:8080/ \
          -H 'Content-Type: application/json' \

          -H 'Accept: application/json' \
          --data '{
        "input": [
          {"region":"west","latency":12},
          {"region":"east","latency":18}
        ],
        "parser":"json",
        "grouping":{"pattern":"x","columns":["region"]},
        "charts":{"types":["bar"]},
        "output":{"format":"dataset"}
      }'
HTTP/1.1 200 OK
Content-Type: application/json
Date: Sat, 18 Jul 2026 18:31:46 GMT
Content-Length: 282

{"timestamp":"2026-07-18T18:31:46Z","name":"Comparisons","theme":"default","axes":[{"key":"x","label":"region"}],"settings":[{"type":"bar","scale":"linear"}],"data":[{"xAxis":"west","stats":[{"type":"latency","value":12}]},{"xAxis":"east","stats":[{"type":"latency","value":18}]}]}
```
### Case 3
```bash
curl -i http://127.0.0.1:8080/ \
          -H 'Content-Type: application/json' \

          -H 'Accept: application/json' \
          --data '{
        "input":"region,value\nwest,12\n",
        "id":"test-dataset",
        "name":"Local test",
        "description":"Testing REST conversion",
        "tag":"v1",
        "theme":"#5470C6,#3BA272",
        "parser":"csv",
        "charts":{"types":["bar"]}
      }'
HTTP/1.1 200 OK
Content-Type: application/json
Date: Sat, 18 Jul 2026 18:32:55 GMT
Content-Length: 301

{"id":"test-dataset","tag":"v1","timestamp":"2026-07-18T18:32:55Z","name":"Local test","theme":"#5470C6,#3BA272","description":"Testing REST conversion","axes":[{"key":"x","label":"region"}],"settings":[{"type":"bar","scale":"linear"}],"data":[{"xAxis":"west","stats":[{"type":"value","value":12}]}]}
```
### Case 4
```bash
curl -i http://127.0.0.1:8080/ \
          -H 'Content-Type: application/json' \

          -H 'Accept: application/json' \
          --data '{
        "input":"BenchmarkFoo-8 100 123 ns/op\n",
        "parser":"go",
        "charts":{"types":["bar"]}
      }'
HTTP/1.1 200 OK
Content-Type: application/json
Date: Sat, 18 Jul 2026 18:33:40 GMT
Content-Length: 223

{"timestamp":"2026-07-18T18:33:40Z","name":"Comparisons","theme":"default","axes":[{"key":"x"}],"settings":[{"type":"bar","scale":"linear"}],"data":[{"xAxis":"Foo","stats":[{"type":"Execution Time (ns/op)","value":123}]}]}
```
### Case 5
```bash
curl -sS http://127.0.0.1:8080/ \
    -H 'Content-Type: application/json' \
    -H 'Accept: text/html' \
    --data '{
      "input":"region,value\nwest,12\neast,18\n",
      "parser":"csv",
      "charts":{"types":["bar"]},
      "output":{"format":"html"}
    }' \
    --output /tmp/vizb.html

  open /tmp/vizb.html
```
<img width="975" height="855" alt="Screenshot 2026-07-18 at 11 35 03 AM" src="https://github.com/user-attachments/assets/3aa33f4b-a59d-4a35-b760-1fb7cb490342" />
### Case 6
```bash
curl -i http://127.0.0.1:8080/ \
          -H 'Content-Type: application/json' \
          --data '{
        "input":"x,y\na,1\n",
        "unknownOption":true
      }'
HTTP/1.1 400 Bad Request
Content-Type: application/problem+json
Date: Sat, 18 Jul 2026 18:36:24 GMT
Content-Length: 274

{"detail":"Request validation failed.","errors":[{"location":"body","path":"/unknownOption","code":"unknown_field","message":"unknown request field unknownOption"}],"instance":"/","status":400,"title":"Invalid request","type":"https://vizb.goptics.org/problems/validation"}
```
### Case 7
```bash
curl -i http://127.0.0.1:8080/ \
          -H 'Content-Type: application/json' \

          --data '{
        "input":"x,y\na,1\n",
        "units":{"memory":null}
      }'
HTTP/1.1 400 Bad Request
Content-Type: application/problem+json
Date: Sat, 18 Jul 2026 18:36:54 GMT
Content-Length: 267

{"detail":"Request validation failed.","errors":[{"location":"body","path":"/units/memory","code":"invalid_type","message":"/units/memory must not be null"}],"instance":"/","status":400,"title":"Invalid request","type":"https://vizb.goptics.org/problems/validation"}
```
### Case 8
```bash
curl -i http://127.0.0.1:8080/ \
          -H 'Content-Type: application/json' \

          --data '{
        "input":"region,value\nwest,1\n",
        "parser":"csv",
        "charts":{
          "types":["bar"],
          "configs":[{"type":"bar","threeDRotate":true}]
        }
      }'
HTTP/1.1 400 Bad Request
Content-Type: application/problem+json
Date: Sat, 18 Jul 2026 18:37:29 GMT
Content-Length: 323

{"detail":"Request validation failed.","errors":[{"location":"body","path":"/charts/configs/0/threeDRotate","code":"inapplicable_option","message":"flag \"3d-rotate\" skipped: requires axis \"z\" (present: [x])"}],"instance":"/","status":400,"title":"Invalid request","type":"https://vizb.goptics.org/problems/validation"}
```
### Case 9
```bash
curl -i http://127.0.0.1:8080/ \
          -H 'Content-Type: application/json' \

          -H 'Accept: text/html' \
          --data '{
        "input":"x,y\na,1\n",
        "output":{"format":"dataset"}
      }'
HTTP/1.1 406 Not Acceptable
Content-Type: application/problem+json
Date: Sat, 18 Jul 2026 18:38:04 GMT
Content-Length: 159

{"detail":"Accept must allow application/json","instance":"/","status":406,"title":"Not acceptable","type":"https://vizb.goptics.org/problems/not-acceptable"}
```
### Case 10
```bash
curl -i http://127.0.0.1:8080/ \
          -H 'Content-Type: text/plain' \
          --data '{"input":"x,y\na,1\n"}'
HTTP/1.1 415 Unsupported Media Type
Content-Type: application/problem+json
Date: Sat, 18 Jul 2026 18:38:32 GMT
Content-Length: 178

{"detail":"Content-Type must be application/json","instance":"/","status":415,"title":"Unsupported media type","type":"https://vizb.goptics.org/problems/unsupported-media-type"}
```
### Case 11
```bash
 curl -i http://127.0.0.1:8080/ \
          -H 'Content-Type: application/json' \

          --data '{
        "input":"region,value\nwest,\"unterminated\n",
        "parser":"csv",
        "charts":{"types":["bar"]}
      }'
HTTP/1.1 422 Unprocessable Entity
Content-Type: application/problem+json
Date: Sat, 18 Jul 2026 18:39:16 GMT
Content-Length: 214

{"detail":"read CSV: parse error on line 2, column 20: extraneous or missing \" in quoted-field","instance":"/","status":422,"title":"Input processing failed","type":"https://vizb.goptics.org/problems/processing"}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Conversion requests and responses now support dataset metadata fields (ID, name, description, tag, theme), with updated examples including JSON-to-HTML.
  - Line/scatter chart series symbols now use a validated symbol set.

- **Bug Fixes**
  - Stricter API request decoding/validation, including clearer validation error paths and improved handling of `null`/empty inputs.
  - More consistent conversion/merge error reporting and defaults (including output format behavior).
  - Improved server shutdown behavior for more reliable termination.

- **Documentation**
  - Updated `serve` command example payloads and selector format to match the new metadata fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->