### PR TITLE
ci: organize example workflows and status badges

### DIFF
--- a/.github/workflows/comparisons-examples.yml
+++ b/.github/workflows/comparisons-examples.yml
@@ -1,4 +1,4 @@
-name: Prepare JavaScript Examples
+name: "Examples: Comparisons"
 on:
   workflow_call:
     inputs:
@@ -6,32 +6,29 @@ on:
         required: false
         type: boolean
         default: false
-        description: "Publish the generated JavaScript examples immediately"
+        description: "Publish the generated comparisons examples immediately"
   workflow_dispatch:
     inputs:
       publish:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated JavaScript examples immediately"
+        description: "Publish the generated comparisons examples immediately"
 
 jobs:
   convert:
-    name: Convert JavaScript Benchmarks
+    name: Convert Comparisons Data
     strategy:
       matrix:
         include:
-          - id: 00-tinybench
-            file: tinybench
-            name: "Bubble Vs Insertion Sort (tinybench)"
-            description: "Tinybench output — algorithm on X, input size on Y"
-            group-pattern: x/y
-          - id: 01-vitest
-            file: vitest
-            name: "Bubble Vs Insertion Sort (vitest)"
-            description: "Vitest bench output — benchmark name and case from regex groups"
-            group-regex: "n=(?<y>.*)/(?<x>.*)"
-
+          - id: 00-concurrency-frameworks
+            file: concurrency
+            name: "HTTP Framework Throughput"
+            description: "Competitor columns (frameworks) on one chart via --col-axis — load on Y, frameworks on X"
+            group: load
+            group-pattern: y
+            col-axis: x
+            charts: bar,line
 
     runs-on: ubuntu-latest
     steps:
@@ -40,16 +37,14 @@ jobs:
       - name: ${{ matrix.name }}
         uses: ./
         with:
-          file: examples/javascript/${{ matrix.file }}.txt
+          file: examples/csv/${{ matrix.file }}.csv
           id: ${{ matrix.id }}
           name: ${{ matrix.name }}
           description: ${{ matrix.description }}
+          group: ${{ matrix.group }}
           group-pattern: ${{ matrix.group-pattern }}
-          group-regex: ${{ matrix.group-regex }}
-          chart: |
-            bar:scale=log,sort=asc
-            line:scale=log,sort=asc
-            pie:sort=asc
+          col-axis: ${{ matrix.col-axis }}
+          charts: ${{ matrix.charts }}
           output-json: ${{ matrix.id }}.json
           vizb-binary: ${{ env.ACT == 'true' && './bin/vizb' || '' }}
 
@@ -61,15 +56,15 @@ jobs:
         if: env.ACT != 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: json-javascript-${{ matrix.id }}
+          name: json-comparisons-${{ matrix.id }}
           path: ${{ matrix.id }}.json
 
   merge:
-    name: Merge JavaScript Benchmarks
+    name: Merge Comparisons Data
     needs: convert
     permissions:
       contents: write
     uses: ./.github/workflows/merge-examples.yml
     with:
-      example_category: javascript
+      example_category: comparisons
       publish: ${{ inputs.publish }}

--- a/.github/workflows/github-legends.yml
+++ b/.github/workflows/github-legends.yml
@@ -1,4 +1,4 @@
-name: Prepare GitHub Legends
+name: "Examples: GitHub Legends"
 on:
   schedule:
     # Refresh contribution skylines every Friday (data is live from the API).

--- a/.github/workflows/go-examples.yml
+++ b/.github/workflows/go-examples.yml
@@ -1,4 +1,4 @@
-name: Prepare Go Examples
+name: "Examples: Go"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/javascript-examples.yml
+++ b/.github/workflows/javascript-examples.yml
@@ -1,4 +1,4 @@
-name: Prepare Rust Examples
+name: "Examples: JavaScript"
 on:
   workflow_call:
     inputs:
@@ -6,32 +6,32 @@ on:
         required: false
         type: boolean
         default: false
-        description: "Publish the generated Rust examples immediately"
+        description: "Publish the generated JavaScript examples immediately"
   workflow_dispatch:
     inputs:
       publish:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated Rust examples immediately"
+        description: "Publish the generated JavaScript examples immediately"
 
 jobs:
   convert:
-    name: Convert Rust Benchmarks
+    name: Convert JavaScript Benchmarks
     strategy:
       matrix:
         include:
-          - id: 00-criterion
-            file: criterion
-            name: "Bubble vs Insertion Sort (Criterion)"
-            description: "Criterion.rs output — algorithm on X, input size on Y"
-            group-regex: "(?<x>.*)/n=(?<y>.*)"
+          - id: 00-tinybench
+            file: tinybench
+            name: "Bubble Vs Insertion Sort (tinybench)"
+            description: "Tinybench output — algorithm on X, input size on Y"
+            group-pattern: x/y
+          - id: 01-vitest
+            file: vitest
+            name: "Bubble Vs Insertion Sort (vitest)"
+            description: "Vitest bench output — benchmark name and case from regex groups"
+            group-regex: "n=(?<y>.*)/(?<x>.*)"
 
-          - id: 01-divan
-            file: divan
-            name: "Bubble vs Insertion Sort (Divan)"
-            description: "Divan output — algorithm and input size from group pattern"
-            group-pattern: x__y
 
     runs-on: ubuntu-latest
     steps:
@@ -40,7 +40,7 @@ jobs:
       - name: ${{ matrix.name }}
         uses: ./
         with:
-          file: examples/rust/${{ matrix.file }}.txt
+          file: examples/javascript/${{ matrix.file }}.txt
           id: ${{ matrix.id }}
           name: ${{ matrix.name }}
           description: ${{ matrix.description }}
@@ -61,15 +61,15 @@ jobs:
         if: env.ACT != 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: json-rust-${{ matrix.id }}
+          name: json-javascript-${{ matrix.id }}
           path: ${{ matrix.id }}.json
 
   merge:
-    name: Merge Rust Benchmarks
+    name: Merge JavaScript Benchmarks
     needs: convert
     permissions:
       contents: write
     uses: ./.github/workflows/merge-examples.yml
     with:
-      example_category: rust
+      example_category: javascript
       publish: ${{ inputs.publish }}

--- a/.github/workflows/math-and-3d-examples.yml
+++ b/.github/workflows/math-and-3d-examples.yml
@@ -1,4 +1,4 @@
-name: Prepare Math & 3D Examples
+name: "Examples: Math & 3D"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,51 +108,51 @@ jobs:
       contents: write
 
   prepare-tabular-data-examples:
-    name: Prepare Tabular Data Examples
+    name: "Examples: Tabular Data"
     needs: goreleaser
-    uses: ./.github/workflows/prepare-tabular-data-examples.yml
+    uses: ./.github/workflows/tabular-data-examples.yml
     permissions:
       contents: write
 
   prepare-math-and-3d-examples:
-    name: Prepare Math & 3D Examples
+    name: "Examples: Math & 3D"
     needs: goreleaser
-    uses: ./.github/workflows/prepare-math-and-3d-examples.yml
+    uses: ./.github/workflows/math-and-3d-examples.yml
     permissions:
       contents: write
 
   prepare-comparisons-examples:
-    name: Prepare Comparisons Examples
+    name: "Examples: Comparisons"
     needs: goreleaser
-    uses: ./.github/workflows/prepare-comparisons-examples.yml
+    uses: ./.github/workflows/comparisons-examples.yml
     permissions:
       contents: write
 
   prepare-github-legends:
-    name: Prepare GitHub Legends
+    name: "Examples: GitHub Legends"
     needs: goreleaser
-    uses: ./.github/workflows/prepare-github-legends.yml
+    uses: ./.github/workflows/github-legends.yml
     permissions:
       contents: write
 
   prepare-go-examples:
-    name: Prepare Go Examples
+    name: "Examples: Go"
     needs: goreleaser
-    uses: ./.github/workflows/prepare-go-examples.yml
+    uses: ./.github/workflows/go-examples.yml
     permissions:
       contents: write
 
   prepare-javascript-examples:
-    name: Prepare JavaScript Examples
+    name: "Examples: JavaScript"
     needs: goreleaser
-    uses: ./.github/workflows/prepare-javascript-examples.yml
+    uses: ./.github/workflows/javascript-examples.yml
     permissions:
       contents: write
 
   prepare-rust-examples:
-    name: Prepare Rust Examples
+    name: "Examples: Rust"
     needs: goreleaser
-    uses: ./.github/workflows/prepare-rust-examples.yml
+    uses: ./.github/workflows/rust-examples.yml
     permissions:
       contents: write
 

--- a/.github/workflows/rust-examples.yml
+++ b/.github/workflows/rust-examples.yml
@@ -1,4 +1,4 @@
-name: Prepare Comparisons Examples
+name: "Examples: Rust"
 on:
   workflow_call:
     inputs:
@@ -6,29 +6,32 @@ on:
         required: false
         type: boolean
         default: false
-        description: "Publish the generated comparisons examples immediately"
+        description: "Publish the generated Rust examples immediately"
   workflow_dispatch:
     inputs:
       publish:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated comparisons examples immediately"
+        description: "Publish the generated Rust examples immediately"
 
 jobs:
   convert:
-    name: Convert Comparisons Data
+    name: Convert Rust Benchmarks
     strategy:
       matrix:
         include:
-          - id: 00-concurrency-frameworks
-            file: concurrency
-            name: "HTTP Framework Throughput"
-            description: "Competitor columns (frameworks) on one chart via --col-axis — load on Y, frameworks on X"
-            group: load
-            group-pattern: y
-            col-axis: x
-            charts: bar,line
+          - id: 00-criterion
+            file: criterion
+            name: "Bubble vs Insertion Sort (Criterion)"
+            description: "Criterion.rs output — algorithm on X, input size on Y"
+            group-regex: "(?<x>.*)/n=(?<y>.*)"
+
+          - id: 01-divan
+            file: divan
+            name: "Bubble vs Insertion Sort (Divan)"
+            description: "Divan output — algorithm and input size from group pattern"
+            group-pattern: x__y
 
     runs-on: ubuntu-latest
     steps:
@@ -37,14 +40,16 @@ jobs:
       - name: ${{ matrix.name }}
         uses: ./
         with:
-          file: examples/csv/${{ matrix.file }}.csv
+          file: examples/rust/${{ matrix.file }}.txt
           id: ${{ matrix.id }}
           name: ${{ matrix.name }}
           description: ${{ matrix.description }}
-          group: ${{ matrix.group }}
           group-pattern: ${{ matrix.group-pattern }}
-          col-axis: ${{ matrix.col-axis }}
-          charts: ${{ matrix.charts }}
+          group-regex: ${{ matrix.group-regex }}
+          chart: |
+            bar:scale=log,sort=asc
+            line:scale=log,sort=asc
+            pie:sort=asc
           output-json: ${{ matrix.id }}.json
           vizb-binary: ${{ env.ACT == 'true' && './bin/vizb' || '' }}
 
@@ -56,15 +61,15 @@ jobs:
         if: env.ACT != 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: json-comparisons-${{ matrix.id }}
+          name: json-rust-${{ matrix.id }}
           path: ${{ matrix.id }}.json
 
   merge:
-    name: Merge Comparisons Data
+    name: Merge Rust Benchmarks
     needs: convert
     permissions:
       contents: write
     uses: ./.github/workflows/merge-examples.yml
     with:
-      example_category: comparisons
+      example_category: rust
       publish: ${{ inputs.publish }}

--- a/.github/workflows/tabular-data-examples.yml
+++ b/.github/workflows/tabular-data-examples.yml
@@ -1,4 +1,4 @@
-name: Prepare Tabular Data Examples
+name: "Examples: Tabular Data"
 on:
   workflow_call:
     inputs:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     <a href="https://vizb.goptics.org/examples"><img src="https://img.shields.io/badge/Live-Examples-orange?style=for" alt="Examples" /></a>
     <a href="https://github.com/goptics/vizb/actions/workflows/cli.yml"><img src="https://github.com/goptics/vizb/actions/workflows/cli.yml/badge.svg" alt="CLI" /></a>
     <a href="https://github.com/goptics/vizb/actions/workflows/ui.yml"><img src="https://github.com/goptics/vizb/actions/workflows/ui.yml/badge.svg" alt="UI" /></a>
+    <a href="https://github.com/goptics/vizb/actions/workflows/release.yml"><img src="https://github.com/goptics/vizb/actions/workflows/release.yml/badge.svg" alt="Release" /></a>
     <a href="https://codecov.io/gh/goptics/vizb"><img src="https://codecov.io/gh/goptics/vizb/branch/main/graph/badge.svg" alt="Codecov" /></a>
     <a href="https://github.com/goptics/vizb/releases"><img src="https://img.shields.io/github/downloads/goptics/vizb/total?color=green&label=downloads" alt="Downloads" /></a>
     <a href="https://golang.org/doc/devel/release.html"><img src="https://img.shields.io/badge/Go-1.26+-00ADD8?style=for&logo=go" alt="Go Version" /></a>
@@ -22,7 +23,7 @@
   </p>
 
   <p>
-    A tabular visualization engine for <strong>CSV, JSON, and benchmark output</strong>. Turns numeric columns into interactive charts and descriptive statistics in one self-contained HTML file — no server, no dependencies, no build step.
+    A tabular visualization engine for <strong>CSV, JSON, and benchmark output</strong>. Turns numeric columns into interactive charts and descriptive statistics in one self-contained HTML file - no server, no dependencies, no build step.
   </p>
 
   <p>
@@ -94,12 +95,12 @@ curl -s "https://github-contributions-api.jogruber.de/v4/<your-github-username>"
 
 Flags used:
 
-- `--group date` — group rows by date
-- `--group-pattern '[z{Year}-y{Month}-x{Date}]'` — split each date into Year / Month / Day axes (z / y / x)
-- `--json-path '.contributions'` — pull the nested contributions array out of the API envelope
-- `--select 'count{Contributions}'` — keep only the count column and rename it to `Contributions`
-- `--stat` — add the statistics panel
-- `--output index.html` — write a self-contained HTML file
+- `--group date` - group rows by date
+- `--group-pattern '[z{Year}-y{Month}-x{Date}]'` - split each date into Year / Month / Day axes (z / y / x)
+- `--json-path '.contributions'` - pull the nested contributions array out of the API envelope
+- `--select 'count{Contributions}'` - keep only the count column and rename it to `Contributions`
+- `--stat` - add the statistics panel
+- `--output index.html` - write a self-contained HTML file
 
 ## Contributing
 
@@ -107,4 +108,4 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, bui
 
 ## License
 
-This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/docs/src/content/docs/examples/benchmarks.mdx
+++ b/docs/src/content/docs/examples/benchmarks.mdx
@@ -9,7 +9,9 @@ Benchmark text output from **Go**, **JavaScript**, and **Rust** toolchains. Use 
 
 ## Go
 
-**Live dashboard:** [vizb.goptics.org/examples/go/](https://vizb.goptics.org/examples/go/) · workflow [prepare-go-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-go-examples.yml)
+[![Go examples workflow status](https://github.com/goptics/vizb/actions/workflows/go-examples.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/go-examples.yml)
+
+**Live dashboard:** [vizb.goptics.org/examples/go/](https://vizb.goptics.org/examples/go/) · workflow [go-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/go-examples.yml)
 
 | Benchmark | Input file | Pattern | Regex | Dashboard |
 |-----------|-----------|---------|-------|-----------|
@@ -24,7 +26,9 @@ Benchmark text output from **Go**, **JavaScript**, and **Rust** toolchains. Use 
 
 ## JavaScript
 
-**Live dashboard:** [vizb.goptics.org/examples/javascript/](https://vizb.goptics.org/examples/javascript/) · workflow [prepare-javascript-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-javascript-examples.yml)
+[![JavaScript examples workflow status](https://github.com/goptics/vizb/actions/workflows/javascript-examples.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/javascript-examples.yml)
+
+**Live dashboard:** [vizb.goptics.org/examples/javascript/](https://vizb.goptics.org/examples/javascript/) · workflow [javascript-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/javascript-examples.yml)
 
 | Benchmark | Input file | Pattern | Regex | Dashboard |
 |-----------|-----------|---------|-------|-----------|
@@ -33,7 +37,9 @@ Benchmark text output from **Go**, **JavaScript**, and **Rust** toolchains. Use 
 
 ## Rust
 
-**Live dashboard:** [vizb.goptics.org/examples/rust/](https://vizb.goptics.org/examples/rust/) · workflow [prepare-rust-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-rust-examples.yml)
+[![Rust examples workflow status](https://github.com/goptics/vizb/actions/workflows/rust-examples.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/rust-examples.yml)
+
+**Live dashboard:** [vizb.goptics.org/examples/rust/](https://vizb.goptics.org/examples/rust/) · workflow [rust-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/rust-examples.yml)
 
 | Benchmark | Input file | Pattern | Regex | Dashboard |
 |-----------|-----------|---------|-------|-----------|

--- a/docs/src/content/docs/examples/comparisons.mdx
+++ b/docs/src/content/docs/examples/comparisons.mdx
@@ -5,6 +5,8 @@ description: Wide competitor tables on one chart with --col-axis — framework t
 
 import { Aside, LinkCard } from '@astrojs/starlight/components';
 
+[![Comparisons examples workflow status](https://github.com/goptics/vizb/actions/workflows/comparisons-examples.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/comparisons-examples.yml)
+
 **Wide tables** where each competitor is a numeric column: map category columns with `--group`, put competitor names on an axis with `--col-axis` (`-A`), and keep everyone on **one chart**. Parser: **CSV**.
 
 **Live dashboard:** [vizb.goptics.org/examples/comparisons/](https://vizb.goptics.org/examples/comparisons/)

--- a/docs/src/content/docs/examples/github-legends.mdx
+++ b/docs/src/content/docs/examples/github-legends.mdx
@@ -5,11 +5,13 @@ description: 3D GitHub contribution skylines of well-known OSS maintainers — f
 
 import { Aside } from '@astrojs/starlight/components';
 
+[![GitHub Legends examples workflow status](https://github.com/goptics/vizb/actions/workflows/github-legends.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/github-legends.yml)
+
 **GitHub Legends** turns public contribution calendars into 3D bar skylines. CI fetches each user from the [jogruber GitHub contributions API](https://github-contributions-api.jogruber.de/v4/) — no static repo files. Demonstrates `--json-path`, `--select`, and date axis splitting. Parser: **JSON**.
 
 **Live dashboard:** [vizb.goptics.org/examples/github-legends/](https://vizb.goptics.org/examples/github-legends/)
 
-The workflow [prepare-github-legends.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-github-legends.yml) runs on every release and on a **Friday schedule** (`0 12 * * 5` UTC) so skylines stay current.
+The workflow [github-legends.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/github-legends.yml) runs on every release and on a **Friday schedule** (`0 12 * * 5` UTC) so skylines stay current.
 
 | Chart | Source | Pattern | Dashboard |
 |-------|--------|---------|-----------|
@@ -23,7 +25,7 @@ The workflow [prepare-github-legends.yml](https://github.com/goptics/vizb/blob/m
 
 ## Adding a legend
 
-No repo file. Append one row to the matrix in [prepare-github-legends.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-github-legends.yml) — only `id` and `user`:
+No repo file. Append one row to the matrix in [github-legends.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/github-legends.yml) — only `id` and `user`:
 
 ```yaml
 - id: 07-octocat        # numbered ?id= deep link; prefix matches ?d=7 in matrix order

--- a/docs/src/content/docs/examples/index.mdx
+++ b/docs/src/content/docs/examples/index.mdx
@@ -44,22 +44,22 @@ Sample inputs live under [`examples/`](https://github.com/goptics/vizb/tree/main
 
 ## Live dashboards
 
-| Topic | Workflow | Dashboard |
-|-------|----------|-----------|
-| Tabular data | [prepare-tabular-data-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-tabular-data-examples.yml) | [vizb.goptics.org/examples/tabular-data/](https://vizb.goptics.org/examples/tabular-data/) |
-| Math & 3D | [prepare-math-and-3d-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-math-and-3d-examples.yml) | [vizb.goptics.org/examples/math-and-3d/](https://vizb.goptics.org/examples/math-and-3d/) |
-| Comparisons | [prepare-comparisons-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-comparisons-examples.yml) | [vizb.goptics.org/examples/comparisons/](https://vizb.goptics.org/examples/comparisons/) |
-| GitHub Legends | [prepare-github-legends.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-github-legends.yml) | [vizb.goptics.org/examples/github-legends/](https://vizb.goptics.org/examples/github-legends/) |
-| Go | [prepare-go-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-go-examples.yml) | [vizb.goptics.org/examples/go/](https://vizb.goptics.org/examples/go/) |
-| JavaScript | [prepare-javascript-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-javascript-examples.yml) | [vizb.goptics.org/examples/javascript/](https://vizb.goptics.org/examples/javascript/) |
-| Rust | [prepare-rust-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/prepare-rust-examples.yml) | [vizb.goptics.org/examples/rust/](https://vizb.goptics.org/examples/rust/) |
+| Topic | Workflow | Status | Dashboard |
+|-------|----------|--------|-----------|
+| Tabular data | [tabular-data-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/tabular-data-examples.yml) | [![Tabular Data examples workflow status](https://github.com/goptics/vizb/actions/workflows/tabular-data-examples.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/tabular-data-examples.yml) | [Open](https://vizb.goptics.org/examples/tabular-data/) |
+| Math & 3D | [math-and-3d-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/math-and-3d-examples.yml) | [![Math and 3D examples workflow status](https://github.com/goptics/vizb/actions/workflows/math-and-3d-examples.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/math-and-3d-examples.yml) | [Open](https://vizb.goptics.org/examples/math-and-3d/) |
+| Comparisons | [comparisons-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/comparisons-examples.yml) | [![Comparisons examples](https://github.com/goptics/vizb/actions/workflows/comparisons-examples.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/comparisons-examples.yml) | [Open](https://vizb.goptics.org/examples/comparisons/) |
+| GitHub Legends | [github-legends.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/github-legends.yml) | [![GitHub Legends examples workflow status](https://github.com/goptics/vizb/actions/workflows/github-legends.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/github-legends.yml) | [Open](https://vizb.goptics.org/examples/github-legends/) |
+| Go | [go-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/go-examples.yml) | [![Go examples workflow status](https://github.com/goptics/vizb/actions/workflows/go-examples.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/go-examples.yml) | [Open](https://vizb.goptics.org/examples/go/) |
+| JavaScript | [javascript-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/javascript-examples.yml) | [![JavaScript examples workflow status](https://github.com/goptics/vizb/actions/workflows/javascript-examples.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/javascript-examples.yml) | [Open](https://vizb.goptics.org/examples/javascript/) |
+| Rust | [rust-examples.yml](https://github.com/goptics/vizb/blob/main/.github/workflows/rust-examples.yml) | [![Rust examples workflow status](https://github.com/goptics/vizb/actions/workflows/rust-examples.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/rust-examples.yml) | [Open](https://vizb.goptics.org/examples/rust/) |
 
 ## Adding an example
 
 Same steps for every topic — see [examples/README.MD](https://github.com/goptics/vizb/blob/main/examples/README.MD):
 
 1. Add the file under `examples/{category}/` (CSV recipes stay under `examples/csv/`)
-2. Add a matrix entry in the matching `.github/workflows/prepare-*-examples.yml` (or `prepare-github-legends.yml`)
+2. Add a matrix entry in the matching `.github/workflows/*-examples.yml` (or `github-legends.yml`)
 3. Push to `main` — CI rebuilds that dashboard
 
 For contribution skylines, only add a user row to the GitHub Legends matrix — no repo file required.

--- a/docs/src/content/docs/examples/math-and-3d.mdx
+++ b/docs/src/content/docs/examples/math-and-3d.mdx
@@ -5,6 +5,8 @@ description: All-numeric auto-value examples — spirals, noise surfaces, and vo
 
 import { Aside, LinkCard } from '@astrojs/starlight/components';
 
+[![Math and 3D examples workflow status](https://github.com/goptics/vizb/actions/workflows/math-and-3d-examples.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/math-and-3d-examples.yml)
+
 All-numeric CSV → **auto-value** mode (continuous `x` / `y` / `z`, optional 4th metric for color/size). Parser: **CSV**. Source files under [`examples/csv/`](https://github.com/goptics/vizb/tree/main/examples/csv).
 
 **Live dashboard:** [vizb.goptics.org/examples/math-and-3d/](https://vizb.goptics.org/examples/math-and-3d/)

--- a/docs/src/content/docs/examples/tabular-data.mdx
+++ b/docs/src/content/docs/examples/tabular-data.mdx
@@ -5,6 +5,8 @@ description: Business and mixed categorical + numeric CSV examples — auto-grou
 
 import { Aside, LinkCard } from '@astrojs/starlight/components';
 
+[![Tabular Data examples workflow status](https://github.com/goptics/vizb/actions/workflows/tabular-data-examples.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/tabular-data-examples.yml)
+
 Mixed **categorical + numeric** tables: sales orders, house prices, and life expectancy. Parser: **CSV**. Source files live under [`examples/csv/`](https://github.com/goptics/vizb/tree/main/examples/csv); live recipes are listed in [examples/csv/README.md](https://github.com/goptics/vizb/blob/main/examples/csv/README.md).
 
 **Live dashboard:** [vizb.goptics.org/examples/tabular-data/](https://vizb.goptics.org/examples/tabular-data/)

--- a/examples/README.MD
+++ b/examples/README.MD
@@ -6,13 +6,13 @@ Sample inputs for the live dashboards on [vizb.goptics.org/examples/](https://vi
 
 | Topic | Source folder | Workflow | Live dashboard |
 |-------|---------------|----------|----------------|
-| Tabular data | `examples/csv/` | [prepare-tabular-data-examples.yml](../.github/workflows/prepare-tabular-data-examples.yml) | [tabular-data](https://vizb.goptics.org/examples/tabular-data/) |
-| Math & 3D | `examples/csv/` | [prepare-math-and-3d-examples.yml](../.github/workflows/prepare-math-and-3d-examples.yml) | [math-and-3d](https://vizb.goptics.org/examples/math-and-3d/) |
-| Comparisons | `examples/csv/` | [prepare-comparisons-examples.yml](../.github/workflows/prepare-comparisons-examples.yml) | [comparisons](https://vizb.goptics.org/examples/comparisons/) |
-| GitHub Legends | _(API-fetched in CI)_ | [prepare-github-legends.yml](../.github/workflows/prepare-github-legends.yml) | [github-legends](https://vizb.goptics.org/examples/github-legends/) |
-| Go | `examples/go/` | [prepare-go-examples.yml](../.github/workflows/prepare-go-examples.yml) | [go](https://vizb.goptics.org/examples/go/) |
-| JavaScript | `examples/javascript/` | [prepare-javascript-examples.yml](../.github/workflows/prepare-javascript-examples.yml) | [javascript](https://vizb.goptics.org/examples/javascript/) |
-| Rust | `examples/rust/` | [prepare-rust-examples.yml](../.github/workflows/prepare-rust-examples.yml) | [rust](https://vizb.goptics.org/examples/rust/) |
+| Tabular data | `examples/csv/` | [tabular-data-examples.yml](../.github/workflows/tabular-data-examples.yml) | [tabular-data](https://vizb.goptics.org/examples/tabular-data/) |
+| Math & 3D | `examples/csv/` | [math-and-3d-examples.yml](../.github/workflows/math-and-3d-examples.yml) | [math-and-3d](https://vizb.goptics.org/examples/math-and-3d/) |
+| Comparisons | `examples/csv/` | [comparisons-examples.yml](../.github/workflows/comparisons-examples.yml) | [comparisons](https://vizb.goptics.org/examples/comparisons/) |
+| GitHub Legends | _(API-fetched in CI)_ | [github-legends.yml](../.github/workflows/github-legends.yml) | [github-legends](https://vizb.goptics.org/examples/github-legends/) |
+| Go | `examples/go/` | [go-examples.yml](../.github/workflows/go-examples.yml) | [go](https://vizb.goptics.org/examples/go/) |
+| JavaScript | `examples/javascript/` | [javascript-examples.yml](../.github/workflows/javascript-examples.yml) | [javascript](https://vizb.goptics.org/examples/javascript/) |
+| Rust | `examples/rust/` | [rust-examples.yml](../.github/workflows/rust-examples.yml) | [rust](https://vizb.goptics.org/examples/rust/) |
 
 CSV input files stay under `examples/csv/`; live HTML is split by **purpose** (tabular vs math vs comparisons), not by parser name.
 
@@ -26,7 +26,7 @@ Open a specific chart with `?id=<id>` — each matrix entry sets a numbered id v
 
 ### GitHub Legends (contribution skylines)
 
-No repo file to add. Append one row to the matrix in [prepare-github-legends.yml](../.github/workflows/prepare-github-legends.yml) — only `id` and `user`:
+No repo file to add. Append one row to the matrix in [github-legends.yml](../.github/workflows/github-legends.yml) — only `id` and `user`:
 
 ```yaml
 - id: 07-octocat        # numbered ?id= deep link; prefix matches ?d=7 in matrix order
@@ -41,9 +41,9 @@ Optionally add a row to [docs/src/content/docs/examples/github-legends.mdx](../d
 
 1. **Add the file** — `examples/csv/my-data.csv`
 2. **Add a matrix entry** — in the matching workflow:
-   - Business / mixed tables → [prepare-tabular-data-examples.yml](../.github/workflows/prepare-tabular-data-examples.yml)
-   - All-numeric 3D / surfaces → [prepare-math-and-3d-examples.yml](../.github/workflows/prepare-math-and-3d-examples.yml)
-   - Wide competitor tables → [prepare-comparisons-examples.yml](../.github/workflows/prepare-comparisons-examples.yml)
+   - Business / mixed tables → [tabular-data-examples.yml](../.github/workflows/tabular-data-examples.yml)
+   - All-numeric 3D / surfaces → [math-and-3d-examples.yml](../.github/workflows/math-and-3d-examples.yml)
+   - Wide competitor tables → [comparisons-examples.yml](../.github/workflows/comparisons-examples.yml)
 3. **Push** — CI rebuilds that dashboard on [vizb.goptics.org](https://vizb.goptics.org)
 
 ### Go / JavaScript / Rust

--- a/examples/csv/README.md
+++ b/examples/csv/README.md
@@ -33,7 +33,7 @@ Use a chart subcommand (`bar`, `line`, `scatter`, `pie`, …) or the root comman
 | Sales by date + category | `vizb bar examples/csv/sales.csv -g order_date,category -p "[n{Year}-y{Month}-x{Date}],z{Category}"` |
 | Line / scatter on same data | `vizb line examples/csv/sales.csv` · `vizb scatter examples/csv/sales.csv` |
 
-These variants are also built in CI as `00-sales-auto-group`, `01-sales-grouped`, and `02-sales-by-date` on the **tabular-data** dashboard (see `.github/workflows/prepare-tabular-data-examples.yml`).
+These variants are also built in CI as `00-sales-auto-group`, `01-sales-grouped`, and `02-sales-by-date` on the **tabular-data** dashboard (see `.github/workflows/tabular-data-examples.yml`).
 
 ---
 
@@ -144,7 +144,7 @@ Use `noise-grid.csv` for faster loads; use this file when you need the complete 
 | Frameworks on X, load as series | `vizb bar examples/csv/concurrency.csv -g load -p y -A x` |
 | Load on X, frameworks as series | `vizb bar examples/csv/concurrency.csv -g load -p x -A y` |
 
-CI id: `00-concurrency-frameworks` on the **comparisons** dashboard (see `.github/workflows/prepare-comparisons-examples.yml`).
+CI id: `00-concurrency-frameworks` on the **comparisons** dashboard (see `.github/workflows/comparisons-examples.yml`).
 
 ---
 

--- a/scripts/act-examples.sh
+++ b/scripts/act-examples.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-# Topic slugs match dist/examples/<topic>/ and prepare workflow names
-# (github-legends uses prepare-github-legends.yml without the -examples suffix).
+# Topic slugs match dist/examples/<topic>/ and example workflow names
+# (github-legends uses github-legends.yml without the -examples suffix).
 ALL_TOPICS=(tabular-data math-and-3d comparisons github-legends go rust javascript)
 ONLY_TOPICS=()
 NO_OPEN=false
@@ -33,10 +33,10 @@ workflow_for() {
   local topic="$1"
   case "$topic" in
     github-legends)
-      echo ".github/workflows/prepare-github-legends.yml"
+      echo ".github/workflows/github-legends.yml"
       ;;
     *)
-      echo ".github/workflows/prepare-${topic}-examples.yml"
+      echo ".github/workflows/${topic}-examples.yml"
       ;;
   esac
 }


### PR DESCRIPTION
## Summary

- rename example workflows and group their display names under `Examples:`
- add workflow status badges to the examples overview and topic pages
- add the release status badge to the README

## Validation

- `task format:check`
- `pnpm build` in `docs/`
- `bash -n scripts/act-examples.sh`
- verified reusable workflow references and removed stale filenames

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added workflow status badges across example documentation pages.
  * Expanded live dashboard listings to include Go, JavaScript, and Rust examples.
  * Updated workflow references and setup instructions to reflect the streamlined naming.

* **Chores**
  * Standardized example workflow names and references.
  * Added a release workflow badge to the README.
  * Updated local example automation to use the renamed workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->