### PR TITLE
test(serve): strengthen POST /ui contract coverage

### DIFF
--- a/api/openapi_test.go
+++ b/api/openapi_test.go
@@ -148,6 +148,34 @@ func (s *OpenAPISuite) TestDatasetSettingsRequireUniqueChartTypes() {
 	s.ErrorContains(validateSchema(contract, datasetSchema, dataset, "dataset"), "want at most 1")
 }
 
+func (s *OpenAPISuite) TestUIContractRejectsRemoteInputAndReturnsHTML() {
+	contract := readContract(s.T())
+	paths := mustMap(s.T(), contract["paths"], "paths")
+	operation := mustMap(s.T(), mustMap(s.T(), paths["/ui"], "paths./ui")["post"], "paths./ui.post")
+
+	requestBody, err := dereference(contract, operation["requestBody"])
+	s.Require().NoError(err)
+	requestContent := mustMap(s.T(), mustMap(s.T(), requestBody, "UI request body")["content"], "UI request content")
+	requestSchema := mustMap(s.T(), requestContent["application/json"], "UI JSON request")["schema"]
+	request := map[string]any{
+		"datasets": map[string]any{
+			"name":     "Bench",
+			"axes":     []any{},
+			"settings": []any{},
+			"data":     []any{},
+		},
+		"dataUrl": "https://example.com/data.json",
+	}
+	s.ErrorContains(validateSchema(contract, requestSchema, request, "UI request"), `unknown property "dataUrl"`)
+
+	responses := mustMap(s.T(), operation["responses"], "paths./ui.post.responses")
+	success, err := dereference(contract, responses["200"])
+	s.Require().NoError(err)
+	successContent := mustMap(s.T(), mustMap(s.T(), success, "UI success response")["content"], "UI success content")
+	s.Len(successContent, 1)
+	s.NotNil(successContent["text/html"])
+}
+
 func TestOpenAPISuite(t *testing.T) {
 	suite.Run(t, new(OpenAPISuite))
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -587,8 +587,11 @@ func (s *ServeSuite) TestUIEndpoint() {
 	valid := `{"datasets":` + validDatasetJSON + `}`
 	recorder := s.apiRequest(handler, "/ui", valid, "application/json", "text/html")
 	s.Equal(http.StatusOK, recorder.Code)
-	s.Contains(recorder.Header().Get("Content-Type"), "text/html")
+	s.Equal("text/html; charset=utf-8", recorder.Header().Get("Content-Type"))
 	s.Contains(recorder.Body.String(), "VIZB_DATA")
+
+	recorder = s.apiRequest(handler, "/ui", `{"datasets":[`+validDatasetJSON+`]}`, "application/json", "text/html")
+	s.Equal(http.StatusOK, recorder.Code)
 
 	for _, test := range []struct {
 		name       string
@@ -603,11 +606,15 @@ func (s *ServeSuite) TestUIEndpoint() {
 		{name: "invalid datasets", body: `{"datasets":true}`, accept: "text/html", wantStatus: http.StatusUnprocessableEntity},
 		{name: "incomplete dataset", body: `{"datasets":{"name":"Bench"}}`, accept: "text/html", wantStatus: http.StatusUnprocessableEntity},
 		{name: "unknown nested field", body: `{"datasets":` + validDatasetJSON[:len(validDatasetJSON)-1] + `,"extra":true}}`, accept: "text/html", wantStatus: http.StatusUnprocessableEntity},
+		{name: "remote request input", body: `{"datasets":` + validDatasetJSON + `,"dataUrl":"https://example.com/data.json"}`, accept: "text/html", wantStatus: http.StatusUnprocessableEntity},
+		{name: "remote dataset input", body: `{"datasets":` + validDatasetJSON[:len(validDatasetJSON)-1] + `,"dataUrl":"https://example.com/data.json"}}`, accept: "text/html", wantStatus: http.StatusUnprocessableEntity},
 		{name: "invalid chart type", body: `{"datasets":` + validDatasetJSON + `,"charts":{"types":["unknown"]}}`, accept: "text/html", wantStatus: http.StatusUnprocessableEntity},
 	} {
 		s.Run(test.name, func() {
 			recorder := s.apiRequest(handler, "/ui", test.body, "application/json", test.accept)
 			s.Equal(test.wantStatus, recorder.Code)
+			s.Equal("application/problem+json", recorder.Header().Get("Content-Type"))
+			s.Equal(float64(test.wantStatus), s.problemStatus(recorder))
 		})
 	}
 }
@@ -620,6 +627,11 @@ func (s *ServeSuite) TestUIEndpointAcceptsConfigsStatisticsAndMediaRanges() {
 			s.Require().Len(datasets[0].Settings, 1)
 			s.True(datasets[0].Settings[0].StatEnabled())
 			s.Equal([]string{"counts"}, datasets[0].Settings[0].StatMath())
+			raw, err := json.Marshal(datasets[0].Settings[0])
+			s.Require().NoError(err)
+			var config map[string]any
+			s.Require().NoError(json.Unmarshal(raw, &config))
+			s.Equal(true, config["showLabels"])
 			return "<html>ok</html>", nil
 		})
 	})
@@ -687,6 +699,7 @@ func (s *ServeSuite) TestUIEndpointReportsGenerationFailure() {
 	body := `{"datasets":` + validDatasetJSON + `}`
 	recorder := s.apiRequest(handler, "/ui", body, "application/json", "text/html")
 	s.Equal(http.StatusInternalServerError, recorder.Code)
+	s.Equal("application/problem+json", recorder.Header().Get("Content-Type"))
 	s.Equal(float64(http.StatusInternalServerError), s.problemStatus(recorder))
 	s.NotContains(recorder.Body.String(), "template failed")
 	s.Contains(recorder.Body.String(), "could not generate the response")


### PR DESCRIPTION
## Related Issue
Closes #216 

## Changes
- Add POST /ui contract coverage for HTML responses and Dataset arrays.
- Verify exact text/html; charset=utf-8 content type.
- Confirm typed chart overrides and statistics reach UI generation.
- Test structured validation and template-generation errors.
- Reject dataUrl at both request and Dataset levels.
- Validate OpenAPI remote-input rejection and HTML-only success responses.

## Test Result
```bash
# start server
task build:ui
task build:cli
./bin/vizb serve
```
### Case 1
```bash
curl -sS http://127.0.0.1:8080/ui \
          -H 'Content-Type: application/json' \
          -H 'Accept: text/html' \
          --data '{
        "datasets": {
          "name": "Local UI test",
          "axes": [
            {"key":"x","label":"Region"},
            {"key":"y","label":"Latency","type":"value"}
          ],
          "settings": [{"type":"line","smooth":false}],
          "data": [
            {"xAxis":"west","yAxis":"12"},

            {"xAxis":"east","yAxis":"18"}
          ]
        },
        "charts": {
          "types": ["line"],
          "configs": [{"type":"line","smooth":true,"showLabels":true}]                      }
      }' \
          -o /tmp/vizb-report.html
```
<img width="1134" height="846" alt="Screenshot 2026-07-19 at 9 04 48 AM" src="https://github.com/user-attachments/assets/fed698bd-420a-4016-a484-b97b6e262ff3" />

### Case 2
```bash
curl -i http://127.0.0.1:8080/ui \
          -H 'Content-Type: application/json' \
          -H 'Accept: text/html' \
          --data '{
        "datasets": {
          "name": "Remote test",
          "axes": [],
          "settings": [],
          "data": []
        },
        "dataUrl": "https://example.com/data.json"
      }'
HTTP/1.1 422 Unprocessable Entity
Content-Type: application/problem+json
Date: Sun, 19 Jul 2026 16:06:07 GMT
Content-Length: 264

{"detail":"Request validation failed.","errors":[{"location":"body","path":"/","code":"invalid_json","message":"json: unknown field \"dataUrl\""}],"instance":"/ui","status":422,"title":"Unprocessable content","type":"https://vizb.goptics.org/problems/validation"}
```
### Case 3
```bash
curl -i http://127.0.0.1:8080/ui \
          -H 'Content-Type: application/json' \

          -H 'Accept: application/json' \
          --data '{
        "datasets": {
          "name": "Accept test",
          "axes": [],
          "settings": [],
          "data": []
        }
      }'
\HTTP/1.1 406 Not Acceptable
Content-Type: application/problem+json
Date: Sun, 19 Jul 2026 16:06:46 GMT
Content-Length: 154

{"detail":"Accept must allow text/html","instance":"/ui","status":406,"title":"Not acceptable","type":"https://vizb.goptics.org/problems/not-acceptable"}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for the UI endpoint’s request and response contracts.
  * Verified that unsupported remote data inputs are rejected with structured error responses.
  * Confirmed successful UI responses return HTML with the expected content type.
  * Added validation for supported dataset payload formats and chart configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->