### PR TITLE
fix(ui): center labels inside stacked bars

### DIFF
--- a/ui/src/composables/charts/shared/chartConfig.ts
+++ b/ui/src/composables/charts/shared/chartConfig.ts
@@ -840,10 +840,15 @@ export function createGridConfig(seriesLength = 1, hasDataZoom = false): any {
 export const createLabelConfig = (
   showLabels: boolean,
   styling: ChartStyling,
-  orient?: 'horizontal' | 'vertical'
+  orient?: 'horizontal' | 'vertical',
+  stacked = false
 ) => ({
   show: showLabels,
-  position: orient === 'horizontal' ? ('right' as const) : ('top' as const),
+  position: stacked
+    ? ('inside' as const)
+    : orient === 'horizontal'
+      ? ('right' as const)
+      : ('top' as const),
   formatter: '{c}',
   fontSize,
   color: styling.textColor,

--- a/ui/src/composables/charts/shared/chartConfig.ts
+++ b/ui/src/composables/charts/shared/chartConfig.ts
@@ -851,5 +851,6 @@ export const createLabelConfig = (
       : ('top' as const),
   formatter: '{c}',
   fontSize,
-  color: styling.textColor,
+  color: stacked ? '#fff' : styling.textColor,
+  ...(stacked ? { textBorderColor: 'rgba(0,0,0,0.5)', textBorderWidth: 2 } : {}),
 })

--- a/ui/src/composables/charts/useBarChartOptions.test.ts
+++ b/ui/src/composables/charts/useBarChartOptions.test.ts
@@ -56,13 +56,18 @@ const makeStackedGroupedChartData = (): ChartData => ({
   axisLabels: { x: 'region', y: 'category' },
 })
 
-const makeStackedGroupedConfig = (stack = false): BaseChartConfig => ({
+const makeStackedGroupedConfig = (
+  stack = false,
+  horizontal = false,
+  showLabels = true
+): BaseChartConfig => ({
   chartData: ref(makeStackedGroupedChartData()),
   sort: ref({ enabled: false, order: 'asc' }),
-  showLabels: ref(false),
+  showLabels: ref(showLabels),
   isDark: ref(false),
   scale: ref<'linear' | 'log'>('linear'),
   stack: ref(stack),
+  horizontal: ref(horizontal),
 })
 
 describe('useBarChartOptions — grouped mode', () => {
@@ -77,6 +82,32 @@ describe('useBarChartOptions — grouped mode', () => {
     const { options } = useBarChartOptions(makeStackedGroupedConfig(false))
     const series = options.value.series as { stack?: string }[]
     expect(series.every((s) => s.stack === undefined)).toBe(true)
+  })
+
+  it.each([false, true])('centers labels inside %s stacked bars', (horizontal) => {
+    const { options } = useBarChartOptions(makeStackedGroupedConfig(true, horizontal))
+    const series = options.value.series as { label: { show: boolean; position: string } }[]
+
+    expect(series.every((s) => s.label.show)).toBe(true)
+    expect(series.every((s) => s.label.position === 'inside')).toBe(true)
+  })
+
+  it.each([
+    [false, 'top'],
+    [true, 'right'],
+  ])('keeps labels at the bar tip when horizontal is %s', (horizontal, position) => {
+    const { options } = useBarChartOptions(makeStackedGroupedConfig(false, horizontal))
+    const series = options.value.series as { label: { position: string } }[]
+
+    expect(series.every((s) => s.label.position === position)).toBe(true)
+  })
+
+  it('keeps labels hidden when stacking is enabled and show labels is off', () => {
+    const { options } = useBarChartOptions(makeStackedGroupedConfig(true, false, false))
+    const series = options.value.series as { label: { show: boolean; position: string } }[]
+
+    expect(series.every((s) => !s.label.show)).toBe(true)
+    expect(series.every((s) => s.label.position === 'inside')).toBe(true)
   })
 })
 

--- a/ui/src/composables/charts/useBarChartOptions.test.ts
+++ b/ui/src/composables/charts/useBarChartOptions.test.ts
@@ -59,12 +59,13 @@ const makeStackedGroupedChartData = (): ChartData => ({
 const makeStackedGroupedConfig = (
   stack = false,
   horizontal = false,
-  showLabels = true
+  showLabels = true,
+  isDark = false
 ): BaseChartConfig => ({
   chartData: ref(makeStackedGroupedChartData()),
   sort: ref({ enabled: false, order: 'asc' }),
   showLabels: ref(showLabels),
-  isDark: ref(false),
+  isDark: ref(isDark),
   scale: ref<'linear' | 'log'>('linear'),
   stack: ref(stack),
   horizontal: ref(horizontal),
@@ -84,22 +85,45 @@ describe('useBarChartOptions — grouped mode', () => {
     expect(series.every((s) => s.stack === undefined)).toBe(true)
   })
 
-  it.each([false, true])('centers labels inside %s stacked bars', (horizontal) => {
-    const { options } = useBarChartOptions(makeStackedGroupedConfig(true, horizontal))
-    const series = options.value.series as { label: { show: boolean; position: string } }[]
+  it.each([
+    [false, false],
+    [true, true],
+  ])(
+    'centers readable labels inside stacked bars when horizontal is %s and dark mode is %s',
+    (horizontal, isDark) => {
+      const { options } = useBarChartOptions(
+        makeStackedGroupedConfig(true, horizontal, true, isDark)
+      )
+      const series = options.value.series as {
+        label: {
+          show: boolean
+          position: string
+          color: string
+          textBorderColor?: string
+          textBorderWidth?: number
+        }
+      }[]
 
-    expect(series.every((s) => s.label.show)).toBe(true)
-    expect(series.every((s) => s.label.position === 'inside')).toBe(true)
-  })
+      expect(series.every((s) => s.label.show)).toBe(true)
+      expect(series.every((s) => s.label.position === 'inside')).toBe(true)
+      expect(series.every((s) => s.label.color === '#fff')).toBe(true)
+      expect(series.every((s) => s.label.textBorderColor === 'rgba(0,0,0,0.5)')).toBe(true)
+      expect(series.every((s) => s.label.textBorderWidth === 2)).toBe(true)
+    }
+  )
 
   it.each([
     [false, 'top'],
     [true, 'right'],
   ])('keeps labels at the bar tip when horizontal is %s', (horizontal, position) => {
     const { options } = useBarChartOptions(makeStackedGroupedConfig(false, horizontal))
-    const series = options.value.series as { label: { position: string } }[]
+    const series = options.value.series as {
+      label: { position: string; color: string; textBorderWidth?: number }
+    }[]
 
     expect(series.every((s) => s.label.position === position)).toBe(true)
+    expect(series.every((s) => s.label.color === '#374151')).toBe(true)
+    expect(series.every((s) => s.label.textBorderWidth === undefined)).toBe(true)
   })
 
   it('keeps labels hidden when stacking is enabled and show labels is off', () => {

--- a/ui/src/composables/charts/useBarChartOptions.ts
+++ b/ui/src/composables/charts/useBarChartOptions.ts
@@ -110,7 +110,12 @@ export function useBarChartOptions(config: BaseChartConfig) {
       name: yAxisLabel,
       type: 'bar' as const,
       data: series.map((s) => barNullable(s.values[yIndex] ?? null, effectiveScale)),
-      label: createLabelConfig(showLabels.value, styling, isHorizontal ? 'horizontal' : 'vertical'),
+      label: createLabelConfig(
+        showLabels.value,
+        styling,
+        isHorizontal ? 'horizontal' : 'vertical',
+        useStack
+      ),
       large: true,
       largeThreshold: LARGE_DATA_THRESHOLD,
       ...(useStack ? { stack: 'total' } : {}),


### PR DESCRIPTION
## Summary

- center value labels inside each segment of stacked 2D bar charts
- keep inside labels readable across light and dark series colors with the existing heatmap-style outline
- preserve the existing `top` and `right` positions for non-stacked vertical and horizontal bars
- cover both themes and stacked orientations, non-stacked placement, and the Show labels toggle with focused tests

## Checks

- `mkdir -p /tmp/vite-temp && /workspace/node_modules/.bin/vitest run --root ui --no-color src/composables/charts/useBarChartOptions.test.ts` — public PR head failed the amended contrast regression; corrected commit passed in the clean network-off verifier
- `pnpm test` — 32 files and 487 UI tests passed
- `pnpm typecheck`, `pnpm format:check`, and `EMBED_UI=True pnpm build` — passed
- browser matrix — vertical and horizontal stacked bars passed in light and dark themes; labels remained centered and readable with the contrast outline

Fixes #209

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1027:start -->
### Verification

[Northset proof-of-pass receipt M-1027](https://northset-oss.github.io/verification-pilot/receipts/M-1027/)  
This record covers Northset’s own contribution; it is not maintainer verification.
Maintainers can request a separate, private run for a PR already in their queue at oss@northset.ai.
For repositories already onboarded with Northset, adding `northset-verify` to a PR requests a run on that PR.
<!-- northset-receipt:M-1027:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Labels in stacked bar charts now appear centered inside their respective bars when enabled.
  * Label positioning remains optimized for horizontal and vertical non-stacked charts.

* **Bug Fixes**
  * Corrected label placement for stacked bar charts across orientations.
  * Labels remain hidden when chart label display is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
