### PR TITLE
feat(cli): add title override for col-axis charts

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -135,6 +135,19 @@ components:
                       showLabels: true
                 output:
                   format: dataset
+            columnAxisConversion:
+              summary: Convert wide competitor columns into one titled chart.
+              value:
+                input: "load,default,chi\n100,3103.62,3103.73\n1000,32423.67,32421.28\n"
+                name: Q1 release
+                title: Framework throughput
+                parser: csv
+                grouping:
+                  pattern: y
+                  columns: [load]
+                  colAxis: x
+                charts:
+                  types: [bar]
             jsonHTMLConversion:
               summary: Convert native JSON input into self-contained HTML.
               value:
@@ -313,6 +326,9 @@ components:
           type: string
           default: Comparisons
           description: Dataset display name.
+        title:
+          type: string
+          description: Chart title used only when grouping.colAxis produces one chart; independent of name.
         description:
           type: string
           description: Dataset description.
@@ -361,6 +377,10 @@ components:
           type: array
           items: { type: string, minLength: 1 }
         filter: { type: string }
+        colAxis:
+          type: string
+          enum: [n, x, y, z]
+          description: Place grouped numeric column names on this free axis so they share one chart.
     UnitOptions:
       type: object
       additionalProperties: false

--- a/api/openapi_test.go
+++ b/api/openapi_test.go
@@ -198,7 +198,7 @@ func (s *OpenAPISuite) TestRootConversionContract() {
 	schemas := mustMap(t, components["schemas"], "components.schemas")
 	request := mustMap(t, schemas["ConvertRequest"], "components.schemas.ConvertRequest")
 	s.Equal(
-		[]string{"charts", "description", "grouping", "id", "input", "jsonPath", "name", "output", "parser", "select", "tag", "theme", "units"},
+		[]string{"charts", "description", "grouping", "id", "input", "jsonPath", "name", "output", "parser", "select", "tag", "theme", "title", "units"},
 		propertyNames(t, request, "ConvertRequest"),
 	)
 	s.Equal([]string{"input"}, stringSliceValue(request["required"]))

--- a/cmd/cli/dataflags.go
+++ b/cmd/cli/dataflags.go
@@ -16,7 +16,7 @@ import (
 // the former CommonOptions hand-written Bind + validationRules.
 var DataFlags = []flags.Flag{
 	{Name: "name", Shorthand: "n", Default: "Comparisons", Usage: "Name of the comparison", Kind: flags.KindString},
-	{Name: "title", Usage: "Override the chart title when --col-axis produces one chart", Kind: flags.KindString},
+	{Name: "title", Usage: "Override the chart title when --col-axis produces one chart; independent of -n/--name, otherwise ignored", Kind: flags.KindString},
 	{Name: "theme", Usage: "Initial series color theme (a built-in name or comma-separated hex palette)", Kind: flags.KindString, Default: "default", Normalizer: style.NormalizeTheme, SoftValidate: style.ValidateTheme},
 	{Name: "description", Shorthand: "d", Usage: "Description of the comparison", Kind: flags.KindString},
 	{Name: "output", Shorthand: "o", Usage: "Output file path/name", Kind: flags.KindString},

--- a/cmd/cli/dataflags.go
+++ b/cmd/cli/dataflags.go
@@ -16,6 +16,7 @@ import (
 // the former CommonOptions hand-written Bind + validationRules.
 var DataFlags = []flags.Flag{
 	{Name: "name", Shorthand: "n", Default: "Comparisons", Usage: "Name of the comparison", Kind: flags.KindString},
+	{Name: "title", Usage: "Override the chart title when --col-axis produces one chart", Kind: flags.KindString},
 	{Name: "theme", Usage: "Initial series color theme (a built-in name or comma-separated hex palette)", Kind: flags.KindString, Default: "default", Normalizer: style.NormalizeTheme, SoftValidate: style.ValidateTheme},
 	{Name: "description", Shorthand: "d", Usage: "Description of the comparison", Kind: flags.KindString},
 	{Name: "output", Shorthand: "o", Usage: "Output file path/name", Kind: flags.KindString},

--- a/cmd/cli/flagbag.go
+++ b/cmd/cli/flagbag.go
@@ -345,6 +345,7 @@ func (b *FlagBag) Meta() RunMeta {
 	return RunMeta{
 		ID:          b.String("id"),
 		Name:        b.String("name"),
+		Title:       b.String("title"),
 		Theme:       b.String("theme"),
 		Description: b.String("description"),
 		Tag:         b.String("tag"),

--- a/cmd/cli/flagbag_test.go
+++ b/cmd/cli/flagbag_test.go
@@ -84,6 +84,12 @@ func (s *FlagBagSuite) TestParseConfigMapsSelectGrouped() {
 	s.Equal("count", cfg.Select[1].Source)
 }
 
+func (s *FlagBagSuite) TestMetaIncludesTitle() {
+	cmd, bag := s.newCmdBag(slices.Clone(DataFlags))
+	s.Require().NoError(cmd.Flags().Set("title", "Framework throughput"))
+	s.Equal("Framework throughput", bag.Meta().Title)
+}
+
 func (s *FlagBagSuite) TestParseConfigMapsSelectSoloAxisMode() {
 	cmd, bag := s.newCmdBag(slices.Clone(DataFlags))
 	s.Require().NoError(cmd.Flags().Set("select", "region,latency"))

--- a/cmd/cli/pipeline.go
+++ b/cmd/cli/pipeline.go
@@ -70,6 +70,7 @@ func RunLinear(cmd *cobra.Command, args []string, meta RunMeta, cfg parser.Confi
 	var datasets []*shared.Dataset
 	if cfg.JSONPath == "" {
 		if ds := convertToDataset(target); ds != nil {
+			warnTitleIgnored(meta.Title)
 			datasets = []*shared.Dataset{ds}
 		}
 	}
@@ -78,7 +79,7 @@ func RunLinear(cmd *cobra.Command, args []string, meta RunMeta, cfg parser.Confi
 		if meta.Parser == "json" && cfg.JSONPath != "" {
 			target = applyJSONPath(target, cfg.JSONPath)
 		}
-		results, effectiveCfg, system := prepareData(target, meta.Parser, cfg)
+		results, effectiveCfg, system := prepareData(target, meta.Parser, cfg, meta.Title)
 		datasets = []*shared.Dataset{assembleDataset(results, meta, configs, effectiveCfg, system)}
 		// Validate swap only for chart subcommands (applyOnPassthrough true).
 		// The root command stores swap as-is, trusting the UI to handle it.
@@ -140,6 +141,7 @@ func RunSingleChart(cmd *cobra.Command, args []string, meta RunMeta, cfg parser.
 type RunMeta struct {
 	ID          string
 	Name        string
+	Title       string
 	Theme       string
 	Description string
 	Tag         string
@@ -246,7 +248,11 @@ func applyJSONPath(filePath, path string) string {
 // prepareData parses input into data points, aggregating grouped csv/json rows.
 // The returned Config is the parser's effective config (auto-group/auto-value
 // mutations included) for aggregation and dataset assembly.
-func prepareData(filePath, parserKey string, cfg parser.Config) ([]shared.DataPoint, parser.Config, *shared.Meta) {
+func prepareData(filePath, parserKey string, cfg parser.Config, titles ...string) ([]shared.DataPoint, parser.Config, *shared.Meta) {
+	title := ""
+	if len(titles) > 0 {
+		title = titles[0]
+	}
 	parseFn, err := parser.GetParser(parserKey)
 	if err != nil {
 		shared.ExitWithError(err.Error(), nil)
@@ -291,7 +297,7 @@ func prepareData(filePath, parserKey string, cfg parser.Config) ([]shared.DataPo
 		logAggregationResult(before, len(data), effectiveCfg)
 	}
 
-	data, effectiveCfg = applyColAxis(data, effectiveCfg, parserKey)
+	data, effectiveCfg = applyColAxis(data, effectiveCfg, parserKey, title)
 
 	if len(data) == 0 {
 		shared.ExitWithError("No dataset found", nil)
@@ -304,12 +310,16 @@ func prepareData(filePath, parserKey string, cfg parser.Config) ([]shared.DataPo
 // Requires csv/json + active grouping; otherwise warns, clears ColAxis, and skips.
 // Fatals when the target axis already exists in the group pattern or when z is
 // used without x+y. On success ColAxis stays set so core.Assemble can EnsureAxis.
-func applyColAxis(data []shared.DataPoint, cfg parser.Config, parserKey string) ([]shared.DataPoint, parser.Config) {
+func applyColAxis(data []shared.DataPoint, cfg parser.Config, parserKey, title string) ([]shared.DataPoint, parser.Config) {
 	if cfg.ColAxis == "" {
+		warnTitleIgnored(title)
 		return data, cfg
 	}
 
 	skip := func(msg string) ([]shared.DataPoint, parser.Config) {
+		if title != "" {
+			msg += "; --title ignored"
+		}
 		fmt.Fprintln(os.Stderr, style.Warning.Render(msg))
 		cfg.ColAxis = ""
 		return data, cfg
@@ -356,7 +366,21 @@ func applyColAxis(data []shared.DataPoint, cfg parser.Config, parserKey string) 
 		}
 	}
 
-	return shared.ExpandStatsOntoAxis(data, dim), cfg
+	data = shared.ExpandStatsOntoAxis(data, dim)
+	if title != "" {
+		for i := range data {
+			for j := range data[i].Stats {
+				data[i].Stats[j].Type = title
+			}
+		}
+	}
+	return data, cfg
+}
+
+func warnTitleIgnored(title string) {
+	if title != "" {
+		fmt.Fprintln(os.Stderr, style.Warning.Render("warning: --title only applies when --col-axis produces one chart; ignoring (use --select … (Title) for multi-stat charts)"))
+	}
 }
 
 // logAggregationResult prints CLI feedback after summing grouped CSV/JSON rows.

--- a/cmd/cli/pipeline.go
+++ b/cmd/cli/pipeline.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -297,84 +298,21 @@ func prepareData(filePath, parserKey string, cfg parser.Config, titles ...string
 		logAggregationResult(before, len(data), effectiveCfg)
 	}
 
-	data, effectiveCfg = applyColAxis(data, effectiveCfg, parserKey, title)
+	data, effectiveCfg, err = core.ApplyColAxis(data, effectiveCfg, parserKey, title)
+	if err != nil {
+		var optionErr *core.OptionError
+		if errors.As(err, &optionErr) && optionErr.Ignored {
+			fmt.Fprintln(os.Stderr, style.Warning.Render("warning: "+err.Error()))
+		} else {
+			shared.ExitWithError(err.Error(), nil)
+		}
+	}
 
 	if len(data) == 0 {
 		shared.ExitWithError("No dataset found", nil)
 	}
 
 	return data, effectiveCfg, system
-}
-
-// applyColAxis expands multi-stat points onto cfg.ColAxis when the flag is set.
-// Requires csv/json + active grouping; otherwise warns, clears ColAxis, and skips.
-// Fatals when the target axis already exists in the group pattern or when z is
-// used without x+y. On success ColAxis stays set so core.Assemble can EnsureAxis.
-func applyColAxis(data []shared.DataPoint, cfg parser.Config, parserKey, title string) ([]shared.DataPoint, parser.Config) {
-	if cfg.ColAxis == "" {
-		warnTitleIgnored(title)
-		return data, cfg
-	}
-
-	skip := func(msg string) ([]shared.DataPoint, parser.Config) {
-		if title != "" {
-			msg += "; --title ignored"
-		}
-		fmt.Fprintln(os.Stderr, style.Warning.Render(msg))
-		cfg.ColAxis = ""
-		return data, cfg
-	}
-
-	if !tabularParser(parserKey) {
-		return skip("warning: --col-axis is only supported for csv/json parsers; ignoring")
-	}
-
-	// Solo value/mixed --select has no multi-column stats path.
-	if cfg.Mode.IsSelectAxis() && !cfg.Mode.IsMultiStat() {
-		return skip("warning: --col-axis requires grouped multi-column stats; ignoring")
-	}
-
-	// Grouping must be active (explicit -g/-r/-p or auto-group that filled Group).
-	if len(cfg.Group) == 0 && !parser.IsExplicitGrouping(cfg) {
-		return skip("warning: --col-axis requires grouping (-g/-r/-p or auto-group); ignoring")
-	}
-
-	dim := shared.Dimension(cfg.ColAxis)
-	injectKey := dim.AxisKey()
-	groupAxes := parser.GroupAxes(cfg)
-	for _, ax := range groupAxes {
-		if ax.Key == injectKey {
-			shared.ExitWithError(
-				fmt.Sprintf("--col-axis %q conflicts with group dimension (already used by --group-pattern)", cfg.ColAxis),
-				nil,
-			)
-		}
-	}
-
-	if dim == shared.DimensionZAxis {
-		hasX, hasY := false, false
-		for _, ax := range groupAxes {
-			switch ax.Key {
-			case "x":
-				hasX = true
-			case "y":
-				hasY = true
-			}
-		}
-		if !hasX || !hasY {
-			shared.ExitWithError("--col-axis z requires both x and y group dimensions", nil)
-		}
-	}
-
-	data = shared.ExpandStatsOntoAxis(data, dim)
-	if title != "" {
-		for i := range data {
-			for j := range data[i].Stats {
-				data[i].Stats[j].Type = title
-			}
-		}
-	}
-	return data, cfg
 }
 
 func warnTitleIgnored(title string) {

--- a/cmd/cli/pipeline_test.go
+++ b/cmd/cli/pipeline_test.go
@@ -1217,19 +1217,22 @@ func (s *PipelineSuite) TestPrepareDataColAxisSelectModeSkips() {
 	s.NotEmpty(results)
 }
 
-func (s *PipelineSuite) TestPrepareDataMultiStatTitleWarnsAndKeepsSelectTitles() {
+func (s *PipelineSuite) TestPrepareDataMultiStatColAxisAndTitleWarnsAndKeepsSelectTitles() {
 	csvFile := s.writeFile("stats.csv", "region,latency,sales\nWest,10,100\n")
-	cfg := parser.Config{SelectViews: []parser.SelectView{
+	cfg := parser.Config{ColAxis: "x", SelectViews: []parser.SelectView{
 		{Columns: []parser.ColumnSpec{{Source: "region", AxisKey: "x"}, {Source: "latency", AxisKey: "y"}}, TypeLabel: "Latency by Region"},
 		{Columns: []parser.ColumnSpec{{Source: "region", AxisKey: "x"}, {Source: "sales", AxisKey: "y"}}, TypeLabel: "Sales by Region"},
 	}}
 	cfg.Mode = parser.ResolveMode(cfg)
 
 	var results []shared.DataPoint
+	var effective parser.Config
 	errOut := testutil.CaptureStderr(func() {
-		results, _, _ = prepareData(csvFile, "csv", cfg, "Ignored title")
+		results, effective, _ = prepareData(csvFile, "csv", cfg, "Ignored title")
 	})
-	s.Contains(errOut, "--title only applies")
+	s.Contains(errOut, "--col-axis requires grouped multi-column stats")
+	s.Contains(errOut, "--title ignored")
+	s.Empty(effective.ColAxis)
 	s.Require().Len(results, 1)
 	s.ElementsMatch([]string{"Latency by Region", "Sales by Region"}, []string{results[0].Stats[0].Type, results[0].Stats[1].Type})
 }

--- a/cmd/cli/pipeline_test.go
+++ b/cmd/cli/pipeline_test.go
@@ -363,6 +363,18 @@ func (s *PipelineSuite) TestRunLinearDatasetPassthrough() {
 	s.Equal("log", typed.Scale)
 }
 
+func (s *PipelineSuite) TestRunLinearDatasetPassthroughTitleWarns() {
+	dir := s.T().TempDir()
+	input := filepath.Join(dir, "baked.json")
+	testutil.WriteJSON(s.T(), input, shared.Dataset{Name: "Baked", Data: []shared.DataPoint{{Name: "P1"}}})
+	out := filepath.Join(dir, "out.json")
+
+	errOut := testutil.CaptureStderr(func() {
+		RunLinear(&cobra.Command{}, []string{input}, RunMeta{Title: "Ignored", Parser: "go", OutputFile: out}, parser.Config{}, nil, false)
+	})
+	s.Contains(errOut, "--title only applies")
+}
+
 func (s *PipelineSuite) TestRunLinearPreservesDatasetOnRoot() {
 	dir := s.T().TempDir()
 	input := filepath.Join(dir, "baked.json")
@@ -1088,6 +1100,48 @@ func (s *PipelineSuite) TestPrepareDataColAxisExpandsOntoX() {
 	s.ElementsMatch([]string{"x", "y"}, axisKeyList(ds.Axes))
 }
 
+func (s *PipelineSuite) TestPrepareDataColAxisAppliesTitle() {
+	csvFile := s.writeFile("concurrency.csv", "load,default,chi\n100,1,2\n")
+	cfg, err := parser.ResolveGroupConfig(parser.Config{GroupPattern: "y", Group: []string{"load"}, ColAxis: "x"})
+	s.Require().NoError(err)
+
+	results, _, _ := prepareData(csvFile, "csv", cfg, "Framework throughput")
+	for _, dp := range results {
+		s.Require().Len(dp.Stats, 1)
+		s.Equal("Framework throughput", dp.Stats[0].Type)
+	}
+}
+
+func (s *PipelineSuite) TestRunLinearColAxisTitleKeepsDatasetName() {
+	csvFile := s.writeFile("concurrency.csv", "load,default,chi\n100,1,2\n")
+	out := filepath.Join(s.T().TempDir(), "out.json")
+	meta := RunMeta{Name: "Q1 release", Title: "Framework throughput", Parser: "csv", OutputFile: out}
+	cfg, err := parser.ResolveGroupConfig(parser.Config{GroupPattern: "y", Group: []string{"load"}, ColAxis: "x"})
+	s.Require().NoError(err)
+
+	RunLinear(&cobra.Command{}, []string{csvFile}, meta, cfg, []internal_charts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}}, false)
+
+	ds := testutil.ReadDataset(s.T(), out)
+	s.Equal("Q1 release", ds.Name)
+	for _, dp := range ds.Data {
+		s.Require().Len(dp.Stats, 1)
+		s.Equal("Framework throughput", dp.Stats[0].Type)
+	}
+}
+
+func (s *PipelineSuite) TestPrepareDataTitleWithoutColAxisWarnsAndKeepsTypes() {
+	csvFile := s.writeFile("wide.csv", "load,default,chi\n100,1,2\n")
+	cfg, err := parser.ResolveGroupConfig(parser.Config{GroupPattern: "y", Group: []string{"load"}})
+	s.Require().NoError(err)
+
+	var results []shared.DataPoint
+	errOut := testutil.CaptureStderr(func() {
+		results, _, _ = prepareData(csvFile, "csv", cfg, "Framework throughput")
+	})
+	s.Contains(errOut, "--title only applies")
+	s.NotEmpty(results[0].Stats[0].Type)
+}
+
 func (s *PipelineSuite) TestPrepareDataColAxisSameAxisFatals() {
 	csvFile := s.writeFile("concurrency.csv",
 		"load,default,chi\n100,1,2\n")
@@ -1111,9 +1165,10 @@ func (s *PipelineSuite) TestPrepareDataColAxisWithoutGroupWarnsAndSkips() {
 	var results []shared.DataPoint
 	var effective parser.Config
 	errOut := testutil.CaptureStderr(func() {
-		results, effective, _ = prepareData(csvFile, "csv", cfg)
+		results, effective, _ = prepareData(csvFile, "csv", cfg, "Framework throughput")
 	})
 	s.Contains(errOut, "--col-axis requires grouping")
+	s.Contains(errOut, "--title ignored")
 	s.Empty(effective.ColAxis) // cleared on skip
 	s.NotEmpty(results)
 	// Unexpanded: still multi-stat column types, not empty-type long form
@@ -1160,6 +1215,23 @@ func (s *PipelineSuite) TestPrepareDataColAxisSelectModeSkips() {
 	s.Contains(errOut, "requires grouped multi-column stats")
 	s.Empty(effective.ColAxis)
 	s.NotEmpty(results)
+}
+
+func (s *PipelineSuite) TestPrepareDataMultiStatTitleWarnsAndKeepsSelectTitles() {
+	csvFile := s.writeFile("stats.csv", "region,latency,sales\nWest,10,100\n")
+	cfg := parser.Config{SelectViews: []parser.SelectView{
+		{Columns: []parser.ColumnSpec{{Source: "region", AxisKey: "x"}, {Source: "latency", AxisKey: "y"}}, TypeLabel: "Latency by Region"},
+		{Columns: []parser.ColumnSpec{{Source: "region", AxisKey: "x"}, {Source: "sales", AxisKey: "y"}}, TypeLabel: "Sales by Region"},
+	}}
+	cfg.Mode = parser.ResolveMode(cfg)
+
+	var results []shared.DataPoint
+	errOut := testutil.CaptureStderr(func() {
+		results, _, _ = prepareData(csvFile, "csv", cfg, "Ignored title")
+	})
+	s.Contains(errOut, "--title only applies")
+	s.Require().Len(results, 1)
+	s.ElementsMatch([]string{"Latency by Region", "Sales by Region"}, []string{results[0].Stats[0].Type, results[0].Stats[1].Type})
 }
 
 func (s *PipelineSuite) TestPrepareDataColAxisZWithoutXYFatals() {

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -23,6 +23,7 @@ type groupingOptions struct {
 	Regex   string   `json:"regex"`
 	Columns []string `json:"columns"`
 	Filter  string   `json:"filter"`
+	ColAxis *string  `json:"colAxis"`
 }
 
 type unitOptions struct {
@@ -60,6 +61,7 @@ type convertRequest struct {
 	Input       json.RawMessage  `json:"input"`
 	ID          *string          `json:"id"`
 	Name        *string          `json:"name"`
+	Title       *string          `json:"title"`
 	Theme       *string          `json:"theme"`
 	Description *string          `json:"description"`
 	Tag         *string          `json:"tag"`
@@ -78,7 +80,7 @@ type convertOutput struct {
 
 func (r *convertRequest) UnmarshalJSON(data []byte) error {
 	if err := rejectNullFields(data, "/", map[string]string{
-		"id": "/id", "name": "/name", "theme": "/theme", "description": "/description",
+		"id": "/id", "name": "/name", "title": "/title", "theme": "/theme", "description": "/description",
 		"tag": "/tag", "parser": "/parser", "grouping": "/grouping", "units": "/units",
 		"select": "/select", "jsonPath": "/jsonPath", "charts": "/charts", "output": "/output",
 	}); err != nil {
@@ -96,7 +98,7 @@ func (r *convertRequest) UnmarshalJSON(data []byte) error {
 func (o *groupingOptions) UnmarshalJSON(data []byte) error {
 	if err := rejectNullFields(data, "/grouping", map[string]string{
 		"pattern": "/grouping/pattern", "regex": "/grouping/regex",
-		"columns": "/grouping/columns", "filter": "/grouping/filter",
+		"columns": "/grouping/columns", "filter": "/grouping/filter", "colAxis": "/grouping/colAxis",
 	}); err != nil {
 		return err
 	}
@@ -260,10 +262,14 @@ func conversionOptionValidationError(selection chartSelection, optionErr *core.O
 		path = "/grouping/filter"
 	case "grouping":
 		path = "/grouping"
+	case "colAxis":
+		path = "/grouping/colAxis"
 	case "jsonPath":
 		path = "/jsonPath"
 	case "select":
 		path = "/select"
+	case "title":
+		path = "/title"
 	case "swap":
 		path = chartConfigFieldPath(selection, "swap", 0)
 	default:
@@ -351,13 +357,17 @@ func buildConvertInput(request convertRequest, input []byte) (core.ConvertInput,
 		return core.ConvertInput{}, nil, validationErr
 	}
 
-	return core.ConvertInput{
+	convertInput := core.ConvertInput{
 		Input:    input,
 		Parser:   key,
 		Config:   cfg,
 		Metadata: metadata,
 		Charts:   configs,
-	}, types, nil
+	}
+	if request.Title != nil {
+		convertInput.Title = *request.Title
+	}
+	return convertInput, types, nil
 }
 
 func buildConvertMetadata(request convertRequest) (core.Metadata, *apiValidationError) {
@@ -394,6 +404,13 @@ func buildParserConfig(request convertRequest, key string) (parser.Config, *apiV
 		cfg.GroupRegex = request.Grouping.Regex
 		cfg.Group = slices.Clone(request.Grouping.Columns)
 		cfg.Filter = request.Grouping.Filter
+		if request.Grouping.ColAxis != nil {
+			if !slices.Contains([]string{"n", "x", "y", "z"}, *request.Grouping.ColAxis) {
+				validationErr := bodyValidationError("/grouping/colAxis", "invalid_enum", "grouping colAxis must be one of n, x, y, or z")
+				return cfg, &validationErr
+			}
+			cfg.ColAxis = *request.Grouping.ColAxis
+		}
 	}
 	if err := parser.ValidateGroupPattern(cfg.GroupPattern); err != nil {
 		validationErr := bodyValidationError("/grouping/pattern", "invalid_value", err.Error())

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -417,6 +417,21 @@ func (s *ServeSuite) TestConvertEndpoint() {
 	)
 	s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
 
+	recorder = s.apiRequest(
+		handler,
+		"/",
+		`{"input":"load,default,chi\n100,1,2\n","name":"Q1 release","title":"Framework throughput","parser":"csv","grouping":{"pattern":"y","columns":["load"],"colAxis":"x"},"charts":{"types":["bar"]}}`,
+		"application/json",
+		"application/json",
+	)
+	s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+	s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &dataset))
+	s.Equal("Q1 release", dataset["name"])
+	for _, point := range dataset["data"].([]any) {
+		stats := point.(map[string]any)["stats"].([]any)
+		s.Equal("Framework throughput", stats[0].(map[string]any)["type"])
+	}
+
 	documented := `{
 		"input":{"data":[{"region":"west","latency":12},{"region":"east","latency":18}]},
 		"parser":"auto",
@@ -531,6 +546,8 @@ func (s *ServeSuite) TestConvertEndpointValidatesStructuredOptions() {
 		{name: "duplicate grouped select", body: `{"input":"region,value\nwest,1\n","parser":"csv","grouping":{"pattern":"x","columns":["region"]},"select":["value","value"]}`},
 		{name: "group select conflict", body: `{"input":"region,value\nwest,1\n","parser":"csv","grouping":{"pattern":"x","columns":["region"]},"select":["region"]}`},
 		{name: "structured grouping separator mismatch", body: `{"input":"a,b,c\nx,y,1\n","grouping":{"pattern":"x,y,z","columns":["a/b/c"]}}`},
+		{name: "invalid col axis", body: `{"input":"load,a,b\n100,1,2\n","parser":"csv","grouping":{"pattern":"y","columns":["load"],"colAxis":"value"}}`},
+		{name: "title without col axis", body: `{"input":"load,a,b\n100,1,2\n","parser":"csv","title":"Ignored"}`},
 		{name: "empty chart types", body: `{"input":"x,y\na,1\n","charts":{"types":[]}}`},
 		{name: "duplicate chart types", body: `{"input":"x,y\na,1\n","charts":{"types":["bar","bar"]}}`},
 		{name: "missing config type", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"showLabels":true}]}}`},
@@ -944,8 +961,10 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 		}{
 			{name: "filter", path: "/grouping/filter"},
 			{name: "grouping", path: "/grouping"},
+			{name: "colAxis", path: "/grouping/colAxis"},
 			{name: "jsonPath", path: "/jsonPath"},
 			{name: "select", path: "/select"},
+			{name: "title", path: "/title"},
 			{name: "swap", path: "/charts/configs/1/swap"},
 			{name: "other", path: "/charts/configs"},
 		} {
@@ -986,6 +1005,8 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 			path   string
 		}{
 			{name: "null convert field", raw: `{"theme":null}`, target: new(convertRequest), path: "/theme"},
+			{name: "null title", raw: `{"title":null}`, target: new(convertRequest), path: "/title"},
+			{name: "null col axis", raw: `{"colAxis":null}`, target: new(groupingOptions), path: "/grouping/colAxis"},
 			{name: "unknown grouping field", raw: `{"unexpected":true}`, target: new(groupingOptions), path: "/grouping/unexpected"},
 			{name: "null unit field", raw: `{"memory":null}`, target: new(unitOptions), path: "/units/memory"},
 			{name: "unknown unit field", raw: `{"unexpected":true}`, target: new(unitOptions), path: "/units/unexpected"},

--- a/examples/csv/README.md
+++ b/examples/csv/README.md
@@ -135,13 +135,14 @@ Use `noise-grid.csv` for faster loads; use this file when you need the complete 
 
 **Shape:** Wide competitor table — one category column (`load`) and several numeric framework columns (`default`, `chi`, `echo`, `gin`, `goframe`, `httpz`). Throughput-style values at three load levels.
 
-**What vizb does:** With `-g load -p y --col-axis x`, load becomes the Y series dimension and **framework column names land on X** as categories. All competitors share **one chart** (instead of one chart per numeric column). Chart title falls back to the dataset name (`-n`) because expanded stats omit `type`.
+**What vizb does:** With `-g load -p y --col-axis x`, load becomes the Y series dimension and **framework column names land on X** as categories. All competitors share **one chart** (instead of one chart per numeric column). Chart title falls back to the dataset name (`-n`) because expanded stats omit `type`; use `--title` to override just that chart title.
 
 **Good for:** Side-by-side library / framework comparison from wide CSV.
 
 | Goal | Command |
 |------|---------|
 | Frameworks on X, load as series | `vizb bar examples/csv/concurrency.csv -g load -p y -A x` |
+| Separate page and chart titles | `vizb bar examples/csv/concurrency.csv -g load -p y -A x -n 'Q1 release' --title 'Framework throughput'` |
 | Load on X, frameworks as series | `vizb bar examples/csv/concurrency.csv -g load -p x -A y` |
 
 CI id: `00-concurrency-frameworks` on the **comparisons** dashboard (see `.github/workflows/comparisons-examples.yml`).

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -219,7 +219,7 @@ func ApplyColAxis(data []shared.DataPoint, cfg parser.Config, parserKey, title s
 	if parserKey != "csv" && parserKey != "json" {
 		return ignored("colAxis", "--col-axis is only supported for csv/json parsers; ignoring")
 	}
-	if cfg.Mode.IsSelectAxis() && !cfg.Mode.IsMultiStat() {
+	if cfg.Mode.IsSelectAxis() {
 		return ignored("colAxis", "--col-axis requires grouped multi-column stats; ignoring")
 	}
 	if len(cfg.Group) == 0 && !parser.IsExplicitGrouping(cfg) {

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -52,6 +52,7 @@ type ConvertInput struct {
 	Input    []byte
 	Parser   string
 	Config   parser.Config
+	Title    string
 	Metadata Metadata
 	Charts   []internalcharts.ChartConfig
 }
@@ -66,8 +67,9 @@ type ConvertResult struct {
 // applied. Transport adapters use it to distinguish request validation from
 // malformed or otherwise unprocessable input.
 type OptionError struct {
-	Name string
-	Err  error
+	Name    string
+	Err     error
+	Ignored bool
 }
 
 func (e *OptionError) Error() string {
@@ -162,6 +164,10 @@ func Convert(in ConvertInput) (ConvertResult, error) {
 			points = shared.AggregateDataPoints(points)
 		}
 	}
+	points, effectiveCfg, err = ApplyColAxis(points, effectiveCfg, key, in.Title)
+	if err != nil {
+		return ConvertResult{}, err
+	}
 	if len(points) == 0 {
 		return ConvertResult{}, fmt.Errorf("no dataset found")
 	}
@@ -187,6 +193,66 @@ func Convert(in ConvertInput) (ConvertResult, error) {
 		return ConvertResult{}, err
 	}
 	return ConvertResult{Dataset: dataset, Warnings: warnings}, nil
+}
+
+// ApplyColAxis expands grouped multi-column stats onto a free axis and applies
+// the optional single-chart title. Ignored errors are warnings at the CLI
+// boundary and validation errors for strict callers such as the REST API.
+func ApplyColAxis(data []shared.DataPoint, cfg parser.Config, parserKey, title string) ([]shared.DataPoint, parser.Config, error) {
+	ignored := func(name, message string) ([]shared.DataPoint, parser.Config, error) {
+		cfg.ColAxis = ""
+		if title != "" && name != "title" {
+			message += "; --title ignored"
+		}
+		return data, cfg, &OptionError{Name: name, Err: fmt.Errorf("%s", message), Ignored: true}
+	}
+
+	if cfg.ColAxis == "" {
+		if title != "" {
+			return ignored("title", "--title only applies when --col-axis produces one chart; ignoring (use --select … (Title) for multi-stat charts)")
+		}
+		return data, cfg, nil
+	}
+	if !slices.Contains([]string{"n", "x", "y", "z"}, cfg.ColAxis) {
+		return data, cfg, &OptionError{Name: "colAxis", Err: fmt.Errorf("invalid col axis %q; expected n, x, y, or z", cfg.ColAxis)}
+	}
+	if parserKey != "csv" && parserKey != "json" {
+		return ignored("colAxis", "--col-axis is only supported for csv/json parsers; ignoring")
+	}
+	if cfg.Mode.IsSelectAxis() && !cfg.Mode.IsMultiStat() {
+		return ignored("colAxis", "--col-axis requires grouped multi-column stats; ignoring")
+	}
+	if len(cfg.Group) == 0 && !parser.IsExplicitGrouping(cfg) {
+		return ignored("colAxis", "--col-axis requires grouping (-g/-r/-p or auto-group); ignoring")
+	}
+
+	dim := shared.Dimension(cfg.ColAxis)
+	groupAxes := parser.GroupAxes(cfg)
+	for _, axis := range groupAxes {
+		if axis.Key == dim.AxisKey() {
+			return data, cfg, &OptionError{
+				Name: "colAxis",
+				Err:  fmt.Errorf("--col-axis %q conflicts with group dimension (already used by --group-pattern)", cfg.ColAxis),
+			}
+		}
+	}
+	if dim == shared.DimensionZAxis {
+		hasX := slices.ContainsFunc(groupAxes, func(axis shared.Axis) bool { return axis.Key == "x" })
+		hasY := slices.ContainsFunc(groupAxes, func(axis shared.Axis) bool { return axis.Key == "y" })
+		if !hasX || !hasY {
+			return data, cfg, &OptionError{Name: "colAxis", Err: fmt.Errorf("--col-axis z requires both x and y group dimensions")}
+		}
+	}
+
+	data = shared.ExpandStatsOntoAxis(data, dim)
+	if title != "" {
+		for i := range data {
+			for j := range data[i].Stats {
+				data[i].Stats[j].Type = title
+			}
+		}
+	}
+	return data, cfg, nil
 }
 
 // Merge combines complete request datasets atomically. It intentionally accepts

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -33,6 +33,41 @@ func (s *CoreSuite) TestConvertCSV() {
 	s.Equal([]string{"x"}, []string{result.Dataset.Axes[0].Key})
 }
 
+func (s *CoreSuite) TestConvertColAxisTitle() {
+	result, err := Convert(ConvertInput{
+		Input:  []byte("load,default,chi\n100,1,2\n"),
+		Parser: "csv",
+		Config: parser.Config{GroupPattern: "y", Group: []string{"load"}, ColAxis: "x"},
+		Title:  "Framework throughput",
+		Metadata: Metadata{
+			Name: "Q1 release",
+		},
+		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
+	})
+	s.Require().NoError(err)
+	s.Equal("Q1 release", result.Dataset.Name)
+	s.Len(result.Dataset.Data, 2)
+	for _, point := range result.Dataset.Data {
+		s.Require().Len(point.Stats, 1)
+		s.Equal("Framework throughput", point.Stats[0].Type)
+	}
+
+	_, err = Convert(ConvertInput{
+		Input:  []byte("load,default,chi\n100,1,2\n"),
+		Parser: "csv",
+		Title:  "Ignored",
+		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
+	})
+	var optionErr *OptionError
+	s.Require().ErrorAs(err, &optionErr)
+	s.Equal("title", optionErr.Name)
+	s.True(optionErr.Ignored)
+
+	_, _, err = ApplyColAxis(nil, parser.Config{ColAxis: "value"}, "csv", "")
+	s.Require().ErrorAs(err, &optionErr)
+	s.Equal("colAxis", optionErr.Name)
+}
+
 func (s *CoreSuite) TestConvertJSONAndValidationFailures() {
 	result, err := Convert(ConvertInput{
 		Input:  []byte(`[{"region":"west","latency":12},{"region":"east","latency":18}]`),


### PR DESCRIPTION
## Related Issue
Closes #237 

## Changes
- Added --title (no shorthand) for group + --col-axis
  charts.

- Keeps -n as the dataset/page name; --title sets
  expanded stats[].type.

- Successful col-axis output stays one chart; JSON
  emits the custom stat type.

- Without --title, behavior is unchanged: empty type
  falls back to -n.

- Unsupported uses warn once and do not alter existing
  types.

- Multi-stat --select … (Title) behavior remains
  unchanged.

- Added pipeline/flag tests and concurrency example
  documentation.
  
## Test Result
```bash
# before test initial
task init
task lint:cli
task test:cli
```
### Case 1
```bash
go run . bar examples/csv/concurrency.csv -g load -p y -A x \
          -n 'Q1 release' \
          --title 'Framework throughput' \
          -o /tmp/title.json
jq -r '.name, (.data[].stats[].type)' /tmp/title.json

# result
Q1 release
Framework throughput
Framework throughput
Framework throughput                                     Framework throughput                                     Framework throughput                                     Framework throughput                                     Framework throughput                                     Framework throughput                                     Framework throughput                                     Framework throughput                                     Framework throughput                                     Framework throughput                                     Framework throughput                                     Framework throughput                                     Framework throughput                                     Framework throughput                                     Framework throughput                                     Framework throughput
```

### Case 2
```bash
# Default remains unchanged: title falls back to -n;
  JSON type is null/omitted.
go run . bar examples/csv/concurrency.csv -g load -p y
  -A x \
    -n 'Q1 release' -o /tmp/default.json
  jq '[.data[].stats[].type] | unique' /tmp/default.json

# result
[
  null
]
```

### Case 3
```bash
# No --col-axis: --title is ignored with one warning;
  column types stay distinct.
go run . bar examples/csv/concurrency.csv -g load -p y --title 'Ignored' -o /tmp/no-axis.json
jq -r '[.data[].stats[].type] | unique[]' /tmp/no-axis.json

# result
chi
default
echo                                                     
gin                                                      
goframe                                                  
httpz
```

### Case 4
```bash
# Existing conflict remains fatal.
go run . bar examples/csv/concurrency.csv -g load -p x
  -A x -o /tmp/conflict.json

# result
{"timestamp":"2026-07-20T15:34:41Z","name":"Comparisons","theme":"default","axes":[{"key":"x"},{"key":"y","label":"load"}],"settings":[{"type":"bar","scale":"linear"}],"data":[{"xAxis":"default","yAxis":"100","stats":[{"value":3103.62}]},{"xAxis":"chi","yAxis":"100","stats":[{"value":3103.73}]},{"xAxis":"echo","yAxis":"100","stats":[{"value":3104.59}]},{"xAxis":"gin","yAxis":"100","stats":[{"value":3103.72}]},{"xAxis":"goframe","yAxis":"100","stats":[{"value":3114.2}]},{"xAxis":"httpz","yAxis":"100","stats":[{"value":3105.1}]},{"xAxis":"default","yAxis":"1000","stats":[{"value":32423.67}]},{"xAxis":"chi","yAxis":"1000","stats":[{"value":32421.28}]},{"xAxis":"echo","yAxis":"1000","stats":[{"value":32413.72}]},{"xAxis":"gin","yAxis":"1000","stats":[{"value":32408.85}]},{"xAxis":"goframe","yAxis":"1000","stats":[{"value":32411.78}]},{"xAxis":"httpz","yAxis":"1000","stats":[{"value":32413.1}]},{"xAxis":"default","yAxis":"5000","stats":[{"value":120057.1}]},{"xAxis":"chi","yAxis":"5000","stats":[{"value":111899.8}]},{"xAxis":"echo","yAxis":"5000","stats":[{"value":114180.37}]},{"xAxis":"gin","yAxis":"5000","stats":[{"value":114503.28}]},{"xAxis":"goframe","yAxis":"5000","stats":[{"value":108866.64}]},{"xAxis":"httpz","yAxis":"5000","stats":[{"value":113671.85}]}]}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--title` CLI option to control chart titles for eligible column-axis outputs.
  * Extended REST conversion with optional top-level `title` and structured `grouping.colAxis`, including updated conversion examples.
* **Bug Fixes**
  * Ensure `title` flows through conversion correctly, including “applies” vs “ignored” warnings, and improved column-axis validation/behavior.
* **Documentation**
  * Updated the CSV `concurrency.csv` example to document separate page and chart titles.
* **Tests**
  * Added/expanded CLI, core, and REST tests covering `title` and `colAxis` behavior and validation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->