### PR TITLE
fix(ci): coerce examples publish input to boolean on push

### DIFF
--- a/.github/workflows/comparisons-examples.yml
+++ b/.github/workflows/comparisons-examples.yml
@@ -74,4 +74,4 @@ jobs:
     uses: ./.github/workflows/merge-examples.yml
     with:
       example_category: comparisons
-      publish: ${{ inputs.publish }}
+      publish: ${{ inputs.publish == true }}

--- a/.github/workflows/github-legends.yml
+++ b/.github/workflows/github-legends.yml
@@ -90,4 +90,5 @@ jobs:
     uses: ./.github/workflows/merge-examples.yml
     with:
       example_category: github-legends
-      publish: ${{ github.event_name == 'schedule' || inputs.publish }}
+      # Schedule always publishes; call/dispatch/push use a boolean (empty input → false).
+      publish: ${{ github.event_name == 'schedule' || inputs.publish == true }}

--- a/.github/workflows/go-examples.yml
+++ b/.github/workflows/go-examples.yml
@@ -132,4 +132,4 @@ jobs:
     uses: ./.github/workflows/merge-examples.yml
     with:
       example_category: go
-      publish: ${{ inputs.publish }}
+      publish: ${{ inputs.publish == true }}

--- a/.github/workflows/javascript-examples.yml
+++ b/.github/workflows/javascript-examples.yml
@@ -79,4 +79,4 @@ jobs:
     uses: ./.github/workflows/merge-examples.yml
     with:
       example_category: javascript
-      publish: ${{ inputs.publish }}
+      publish: ${{ inputs.publish == true }}

--- a/.github/workflows/math-and-3d-examples.yml
+++ b/.github/workflows/math-and-3d-examples.yml
@@ -98,4 +98,4 @@ jobs:
     uses: ./.github/workflows/merge-examples.yml
     with:
       example_category: math-and-3d
-      publish: ${{ inputs.publish }}
+      publish: ${{ inputs.publish == true }}

--- a/.github/workflows/rust-examples.yml
+++ b/.github/workflows/rust-examples.yml
@@ -79,4 +79,4 @@ jobs:
     uses: ./.github/workflows/merge-examples.yml
     with:
       example_category: rust
-      publish: ${{ inputs.publish }}
+      publish: ${{ inputs.publish == true }}

--- a/.github/workflows/tabular-data-examples.yml
+++ b/.github/workflows/tabular-data-examples.yml
@@ -102,4 +102,4 @@ jobs:
     uses: ./.github/workflows/merge-examples.yml
     with:
       example_category: tabular-data
-      publish: ${{ inputs.publish }}
+      publish: ${{ inputs.publish == true }}


### PR DESCRIPTION
## Summary

- On `push`, `inputs.publish` is unset and evaluates to `''`.
- Passing that into `merge-examples.yml`'s boolean `publish` input fails: `Unexpected value ''`.
- Use `inputs.publish == true` so the value is always a boolean (`false` when unset).
- GitHub Legends: `schedule || inputs.publish == true` (schedule still publishes).

## Test plan

- [ ] Re-run a failed Examples workflow (e.g. Rust) on the failed `push` commit or push a no-op to main after merge
- [ ] Confirm merge job starts without input evaluation errors
- [ ] Manual dispatch with publish=true still publishes
- [ ] Release `workflow_call` still gets publish=false