### PR TITLE
feat(ui): support direct data-url dataset paths

### DIFF
--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -47,6 +47,8 @@ When --data-url is set, no input file is needed. The generated HTML will fetch
 DataSet JSON from the provided URL at runtime instead of embedding it. The base
 response may also be an id/name catalog; selected details are then fetched from
 <data-url>/dataset/<encoded-id>. Both endpoints must satisfy CORS requirements.
+On HTTP(S), /<id> skips the catalog and fetches that detail directly. The host
+must serve the generated HTML as a fallback for those dataset paths.
 Note: hosts should serve Access-Control-Allow-Origin: * for file:// access.`,
 	Args: cobra.MaximumNArgs(1),
 	Run:  runUI,

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -47,8 +47,9 @@ When --data-url is set, no input file is needed. The generated HTML will fetch
 DataSet JSON from the provided URL at runtime instead of embedding it. The base
 response may also be an id/name catalog; selected details are then fetched from
 <data-url>/dataset/<encoded-id>. Both endpoints must satisfy CORS requirements.
-On HTTP(S), /<encoded-id> skips the catalog and fetches that detail directly. The host
-must serve the generated HTML as a fallback for those dataset paths.
+When the data URL ends in /dataset, HTTP(S) /<encoded-id> paths skip the catalog and
+fetch <data-url>/<encoded-id> directly. Other data URLs disable path mode. The host must
+serve the generated HTML as a fallback for enabled dataset paths.
 Note: hosts should serve Access-Control-Allow-Origin: * for file:// access.`,
 	Args: cobra.MaximumNArgs(1),
 	Run:  runUI,

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -47,7 +47,7 @@ When --data-url is set, no input file is needed. The generated HTML will fetch
 DataSet JSON from the provided URL at runtime instead of embedding it. The base
 response may also be an id/name catalog; selected details are then fetched from
 <data-url>/dataset/<encoded-id>. Both endpoints must satisfy CORS requirements.
-On HTTP(S), /<id> skips the catalog and fetches that detail directly. The host
+On HTTP(S), /<encoded-id> skips the catalog and fetches that detail directly. The host
 must serve the generated HTML as a fallback for those dataset paths.
 Note: hosts should serve Access-Control-Allow-Origin: * for file:// access.`,
 	Args: cobra.MaximumNArgs(1),

--- a/docs/src/content/docs/ci-cd/github-action.mdx
+++ b/docs/src/content/docs/ci-cd/github-action.mdx
@@ -138,14 +138,16 @@ lazy catalog such as:
 
 Catalog IDs must be non-empty and unique, and catalog entries must omit `data` and
 `settings`. When an entry is selected, the dashboard requests one complete dataset from
-`<data-url>/dataset/<encoded-id>`. The detail may omit its `id`; an included ID must match
-the catalog ID. Base query parameters are preserved for detail requests. The base and
-detail endpoints must both satisfy the existing CORS requirement (normally
+`<data-url>/dataset/<encoded-id>`, or `<data-url>/<encoded-id>` when the data URL already
+ends in `/dataset`. The detail may omit its `id`; an included ID must match the catalog ID.
+Base query parameters are preserved for detail requests. The base and detail endpoints
+must both satisfy the existing CORS requirement (normally
 `Access-Control-Allow-Origin: *` for a `file://` dashboard). Details are cached only in
 memory for the current page session, and failed requests expose a Retry action.
 
-For a single-dataset deep link, serve the generated HTML as the fallback for `/*` and open
-`/<encoded-id>`. Vizb then skips the catalog and fetches only that dataset's detail URL.
+When `data-url` ends in `/dataset`, you can serve the generated HTML as the fallback for
+`/*` and open `/<encoded-id>`. Vizb then skips the catalog and fetches only
+`<data-url>/<encoded-id>`. Other data URLs disable this path mode.
 
 ### Merge and generate
 

--- a/docs/src/content/docs/ci-cd/github-action.mdx
+++ b/docs/src/content/docs/ci-cd/github-action.mdx
@@ -144,6 +144,9 @@ detail endpoints must both satisfy the existing CORS requirement (normally
 `Access-Control-Allow-Origin: *` for a `file://` dashboard). Details are cached only in
 memory for the current page session, and failed requests expose a Retry action.
 
+For a single-dataset deep link, serve the generated HTML as the fallback for `/*` and open
+`/<encoded-id>`. Vizb then skips the catalog and fetches only that dataset's detail URL.
+
 ### Merge and generate
 
 ```yaml

--- a/docs/src/content/docs/commands/ui.mdx
+++ b/docs/src/content/docs/commands/ui.mdx
@@ -72,7 +72,7 @@ vizb ui data.json -o report.html -c bar
 vizb ui data.json -o report.html -c bar,line
 
 # Pie only via remote data
-vizb ui --data-url https://example.com/bench.json -o report.html -c pie // 375K
+vizb ui --data-url https://example.com/dataset.json -o report.html -c pie // 375K
 ```
 
 <Aside type="note">
@@ -81,80 +81,121 @@ vizb ui --data-url https://example.com/bench.json -o report.html -c pie // 375K
 
 ### Remote data via `--data-url`
 
-The default embed mode inlines the dataset JSON directly into the HTML file. For small datasets this is ideal — one file, works offline, no dependencies. But as dataset history grows (many merged runs, many benchmarks), the JSON can exceed 10 MB and the output file becomes unwieldy to share or store.
+By default, Vizb puts the dataset inside the generated HTML. This gives you one portable
+file that works offline. With `--data-url`, Vizb generates a smaller HTML file and loads
+the data from an HTTP endpoint when someone opens the dashboard.
 
-Use `--data-url` to decouple the UI layer from the data layer: the HTML stays a lean dashboard shell and fetches the JSON from a URL at load time. The JSON file is hosted separately and can be updated without regenerating the HTML.
-
-Instead of embedding the JSON inside the HTML, point the dashboard at a hosted URL.
-dataset is fetched at load time; only the chart renderers you select are bundled.
+Use `--data-url` when the data is large, changes often, or already comes from an API. You
+can update the response without generating the HTML again.
 
 ```bash
-vizb ui --data-url https://example.com/bench.json -o report.html
+vizb ui --data-url https://example.com/dataset.json -o report.html
 ```
 
-Upload `bench.json` to the URL separately (GitHub raw, S3, GitHub Pages, etc.), then open `report.html` in any browser.
-
-The remote JSON may list more chart types in `settings` than were bundled — the UI intersects against `VIZB_CHARTS` at load time, so only shipped renderers appear as tabs.
-
-When the dashboard is served over HTTP(S), a dataset path such as
-`/go-1.25?c=line&g=1` skips the base response and requests
-`<data-url>/dataset/go-1.25` directly. The final path segment is the encoded dataset ID;
-query parameters continue to control charts and groups, and `id`/`d` are ignored in this
-mode. Root, `index.html`, and other HTML paths keep the existing base/catalog flow.
-
-Configure the host to serve the same generated HTML for unmatched paths (`/*`) so direct
-links and refreshes reach the dashboard. Path mode is disabled for `file://` pages; use the
-base/catalog URL flow there.
-
-The base URL supports three response shapes:
+The URL can return any of these JSON shapes:
 
 - One complete vizb dataset object.
 - An array of complete vizb dataset objects.
-- A lightweight catalog array whose entries contain non-empty, unique `id` and `name` strings and omit both `data` and `settings`.
+- A catalog containing only an `id` and `name` for each dataset. Vizb fetches the full
+  dataset when the user selects it.
 
-For example, a catalog response can be:
+The first two shapes load all data when the page opens. A catalog keeps the initial request
+small and loads one dataset at a time.
+
+#### Lazy catalog
+
+A catalog response looks like this:
 
 ```json
 [
-  { "id": "go-1.24", "name": "Go 1.24" },
-  { "id": "go-1.25/amd64", "name": "Go 1.25 (amd64)" }
+  { "id": "dataset-1", "name": "Dataset 1" },
+  { "id": "dataset/2", "name": "Dataset 2" }
 ]
 ```
 
-Vizb detects this shape automatically. It initially requests only the active dataset from
-`<data-url>/dataset/<encoded-id>`; the ID is encoded as one path segment. Trailing slashes
-on the base path are normalized, existing query parameters are preserved, and any fragment
-is discarded. With `https://api.example.com/vizb/?token=abc#latest`, the second entry above
-is requested from `https://api.example.com/vizb/dataset/go-1.25%2Famd64?token=abc`.
+Vizb recognizes this response and requests the selected dataset from:
 
-The detail endpoint must return one complete dataset object with `name`, `data`, and
-`settings`. It may omit `id`, in which case Vizb uses the catalog ID in memory; if it
-includes `id`, it must match the requested catalog ID. Loaded details are kept in memory
-for the current page session, failed requests remain retryable, and no browser storage is
-written. Deep links through `?id=` select by catalog ID before the first detail request;
-legacy `?d=` indexes remain supported.
+```text
+<data-url>/dataset/<encoded-id>
+```
 
-Do not mix catalog entries with complete datasets in one array. Vizb reports missing or
-duplicate catalog IDs, mixed response shapes, malformed detail objects, and mismatched
-detail IDs as load errors.
+For example, selecting `dataset/2` from `https://api.example.com/vizb` requests:
+
+```text
+https://api.example.com/vizb/dataset/dataset%2F2
+```
+
+The detail response must contain one complete dataset with `name`, `data`, and `settings`.
+It may omit `id`; if it includes one, it must match the catalog ID. Vizb keeps loaded
+details in memory for the current page and lets the user retry failed requests.
+
+You can link to a catalog entry with `?id=`:
+
+```text
+https://charts.example.com/?id=dataset%2F2
+```
+
+Vizb also supports the older `?d=` index parameter.
+
+#### Direct dataset paths
+
+Use a data URL ending in `/dataset` to enable short dashboard URLs such as `/<id>`:
+
+```bash
+vizb ui --data-url https://api.example.com/vizb/dataset -o report.html
+```
+
+Opening this dashboard URL:
+
+```text
+https://charts.example.com/dataset-1
+```
+
+skips the catalog request and fetches:
+
+```text
+https://api.example.com/vizb/dataset/dataset-1
+```
+
+Only data URLs ending in `/dataset` enable this behavior. Other data URLs ignore the page
+path and use the normal response flow. A trailing slash, query string, or fragment on the
+data URL does not change the rule.
+
+Your web host must serve the generated HTML for unmatched paths so direct links and page
+refreshes reach Vizb. Direct paths work on HTTP and HTTPS pages, not when opening the HTML
+through `file://`. Chart and group query parameters still work with a direct path:
+
+```text
+https://charts.example.com/dataset-1?c=line&g=1
+```
+
+#### Response rules
+
+Catalog IDs must be non-empty and unique. Do not mix catalog entries and complete datasets
+in the same array. Vizb shows a load error for invalid response shapes, duplicate IDs,
+malformed details, and detail IDs that do not match the request.
+
+Vizb preserves query parameters from the data URL when it builds a detail URL and removes
+the fragment. The dashboard only shows chart types included when you generated the HTML,
+even if the remote dataset contains settings for other chart types.
 
 Because the remote data shape is unknown at build time, the 3D engine is **not** bundled unless you pass `--3d`:
 
 ```bash
-# Remote data might have a z-axis — opt in to the 3D chunk
-vizb ui --data-url https://example.com/bench.json --3d -o report.html
+# Remote data might have a z-axis; include the 3D renderer
+vizb ui --data-url https://example.com/dataset.json --3d -o report.html
 ```
 
 With an embedded JSON file, 3D is still detected automatically from the data (no `--3d` needed).
 
 <Aside type="note">
-  The default (no `--data-url`) produces a fully self-contained file with no external dependencies — open it directly in any browser, even offline.
+  Without `--data-url`, Vizb produces a self-contained file that works offline.
 </Aside>
 
 <Aside type="caution">
-  When using `--data-url`, every requested base or detail response must satisfy the same
-  CORS requirements. For `file://` dashboards, this normally means
-  responding with `Access-Control-Allow-Origin: *`.
-  Most static hosts (GitHub raw, public S3, GitHub Pages, Cloudflare Pages) already do this.
-  The HTML can be re-used indefinitely — update the data at the URL to refresh results without regenerating the HTML.
+  Vizb embeds `--data-url` in the generated HTML. Do not put passwords, API keys, access
+  tokens, or other secrets in the URL.
+
+  The data server must allow requests from the dashboard's origin. For dashboards opened
+  through `file://`, this usually requires `Access-Control-Allow-Origin: *`.
 </Aside>

--- a/docs/src/content/docs/commands/ui.mdx
+++ b/docs/src/content/docs/commands/ui.mdx
@@ -98,7 +98,7 @@ The remote JSON may list more chart types in `settings` than were bundled — th
 
 When the dashboard is served over HTTP(S), a dataset path such as
 `/go-1.25?c=line&g=1` skips the base response and requests
-`<data-url>/dataset/go-1.25` directly. The final path segment is the decoded dataset ID;
+`<data-url>/dataset/go-1.25` directly. The final path segment is the encoded dataset ID;
 query parameters continue to control charts and groups, and `id`/`d` are ignored in this
 mode. Root, `index.html`, and other HTML paths keep the existing base/catalog flow.
 

--- a/docs/src/content/docs/commands/ui.mdx
+++ b/docs/src/content/docs/commands/ui.mdx
@@ -96,6 +96,16 @@ Upload `bench.json` to the URL separately (GitHub raw, S3, GitHub Pages, etc.), 
 
 The remote JSON may list more chart types in `settings` than were bundled — the UI intersects against `VIZB_CHARTS` at load time, so only shipped renderers appear as tabs.
 
+When the dashboard is served over HTTP(S), a dataset path such as
+`/go-1.25?c=line&g=1` skips the base response and requests
+`<data-url>/dataset/go-1.25` directly. The final path segment is the decoded dataset ID;
+query parameters continue to control charts and groups, and `id`/`d` are ignored in this
+mode. Root, `index.html`, and other HTML paths keep the existing base/catalog flow.
+
+Configure the host to serve the same generated HTML for unmatched paths (`/*`) so direct
+links and refreshes reach the dashboard. Path mode is disabled for `file://` pages; use the
+base/catalog URL flow there.
+
 The base URL supports three response shapes:
 
 - One complete vizb dataset object.
@@ -142,8 +152,8 @@ With an embedded JSON file, 3D is still detected automatically from the data (no
 </Aside>
 
 <Aside type="caution">
-  When using `--data-url`, both the catalog/base response and every detail response must
-  satisfy the same CORS requirements. For `file://` dashboards, this normally means
+  When using `--data-url`, every requested base or detail response must satisfy the same
+  CORS requirements. For `file://` dashboards, this normally means
   responding with `Access-Control-Allow-Origin: *`.
   Most static hosts (GitHub raw, public S3, GitHub Pages, Cloudflare Pages) already do this.
   The HTML can be re-used indefinitely — update the data at the URL to refresh results without regenerating the HTML.

--- a/ui/src/composables/useDataPoint.test.ts
+++ b/ui/src/composables/useDataPoint.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const detail = {
+  name: 'Go amd64',
+  data: [],
+  settings: [{ type: 'bar' as const }],
+}
+
+describe('useDataPoint path loading', () => {
+  beforeEach(() => vi.resetModules())
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('fetches only the encoded detail URL in path mode', async () => {
+    const fetcher = vi.fn(async () => new Response(JSON.stringify(detail), { status: 200 }))
+    vi.stubGlobal('fetch', fetcher)
+    vi.stubGlobal('window', {
+      location: { pathname: '/go-1.25%2Famd64', protocol: 'https:' },
+      VIZB_DATA_URL: 'https://api.example.com/catalog',
+      VIZB_DATA: [],
+    })
+
+    const { useDataPoint } = await import('./useDataPoint')
+    const state = useDataPoint()
+
+    await vi.waitFor(() => expect(state.loading.value).toBe(false))
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(fetcher).toHaveBeenCalledWith('https://api.example.com/catalog/dataset/go-1.25%2Famd64')
+    expect(state.datasets.value).toHaveLength(1)
+    expect(state.datasets.value[0]?.id).toBe('go-1.25/amd64')
+    expect(state.lazyCatalog.value).toBe(false)
+  })
+
+  it('retries a failed path detail request', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 404, statusText: 'Not Found' }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(detail), { status: 200 }))
+    vi.stubGlobal('fetch', fetcher)
+    vi.stubGlobal('window', {
+      location: { pathname: '/my-id', protocol: 'https:' },
+      VIZB_DATA_URL: 'https://api.example.com/catalog',
+      VIZB_DATA: [],
+    })
+
+    const { useDataPoint } = await import('./useDataPoint')
+    const state = useDataPoint()
+
+    await vi.waitFor(() => expect(state.loadError.value).toContain('404 Not Found'))
+    await state.retryActiveDataset()
+    expect(fetcher).toHaveBeenCalledTimes(2)
+    expect(state.loadError.value).toBeNull()
+    expect(state.datasets.value[0]?.id).toBe('my-id')
+  })
+
+  it('uses the base URL instead of path mode for file pages', async () => {
+    const fetcher = vi.fn(async () => new Response(JSON.stringify(detail), { status: 200 }))
+    vi.stubGlobal('fetch', fetcher)
+    vi.stubGlobal('window', {
+      location: { pathname: '/my-id', protocol: 'file:' },
+      VIZB_DATA_URL: 'https://api.example.com/catalog',
+      VIZB_DATA: [],
+    })
+
+    const { useDataPoint } = await import('./useDataPoint')
+    const state = useDataPoint()
+
+    await vi.waitFor(() => expect(state.loading.value).toBe(false))
+    expect(state.pathDatasetId).toBeNull()
+    expect(fetcher).toHaveBeenCalledOnce()
+    expect(fetcher).toHaveBeenCalledWith('https://api.example.com/catalog')
+  })
+
+  it('uses the base URL for a trailing-slash mount root', async () => {
+    const fetcher = vi.fn(async () => new Response(JSON.stringify(detail), { status: 200 }))
+    vi.stubGlobal('fetch', fetcher)
+    vi.stubGlobal('window', {
+      location: { pathname: '/repo/', protocol: 'https:' },
+      VIZB_DATA_URL: 'https://api.example.com/catalog',
+      VIZB_DATA: [],
+    })
+
+    const { useDataPoint } = await import('./useDataPoint')
+    const state = useDataPoint()
+
+    await vi.waitFor(() => expect(state.loading.value).toBe(false))
+    expect(state.pathDatasetId).toBeNull()
+    expect(fetcher).toHaveBeenCalledWith('https://api.example.com/catalog')
+  })
+
+  it('ignores the path without a data URL', async () => {
+    const fetcher = vi.fn()
+    vi.stubGlobal('fetch', fetcher)
+    vi.stubGlobal('window', {
+      location: { pathname: '/ignored-id', protocol: 'https:' },
+      VIZB_DATA: [detail],
+    })
+
+    const { useDataPoint } = await import('./useDataPoint')
+    const state = useDataPoint()
+
+    await vi.waitFor(() => expect(state.loading.value).toBe(false))
+    expect(state.pathDatasetId).toBeNull()
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+})

--- a/ui/src/composables/useDataPoint.test.ts
+++ b/ui/src/composables/useDataPoint.test.ts
@@ -1,20 +1,77 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const detail = {
-  name: 'Go amd64',
+  name: 'Dataset 2',
   data: [],
   settings: [{ type: 'bar' as const }],
 }
 
-describe('useDataPoint path loading', () => {
+describe('useDataPoint remote loading', () => {
   beforeEach(() => vi.resetModules())
   afterEach(() => vi.unstubAllGlobals())
 
-  it('fetches only the encoded detail URL in path mode', async () => {
-    const fetcher = vi.fn(async () => new Response(JSON.stringify(detail), { status: 200 }))
+  it('loads a catalog entry on selection and reuses its detail', async () => {
+    const catalog = [
+      { id: 'dataset-1', name: 'Dataset 1' },
+      { id: 'dataset/2', name: 'Dataset 2' },
+    ]
+    const selectedDetail = {
+      id: 'dataset/2',
+      name: 'Dataset 2',
+      data: [{ name: 'value', value: 2 }],
+      settings: [{ type: 'bar' as const }],
+    }
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(catalog), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(selectedDetail), { status: 200 }))
     vi.stubGlobal('fetch', fetcher)
     vi.stubGlobal('window', {
-      location: { pathname: '/go-1.25%2Famd64', protocol: 'https:' },
+      location: { pathname: '/', protocol: 'https:' },
+      VIZB_DATA_URL: 'https://api.example.com/catalog?format=full',
+      VIZB_DATA: [],
+    })
+
+    const { useDataPoint } = await import('./useDataPoint')
+    const state = useDataPoint()
+
+    await vi.waitFor(() => expect(state.loading.value).toBe(false))
+    expect(state.lazyCatalog.value).toBe(true)
+    expect(state.datasets.value).toMatchObject([
+      { id: 'dataset-1', name: 'Dataset 1', data: [], settings: [] },
+      { id: 'dataset/2', name: 'Dataset 2', data: [], settings: [] },
+    ])
+
+    await expect(state.selectDataset(1)).resolves.toBe(true)
+    expect(fetcher).toHaveBeenNthCalledWith(1, 'https://api.example.com/catalog?format=full')
+    expect(fetcher).toHaveBeenNthCalledWith(
+      2,
+      'https://api.example.com/catalog/dataset/dataset%2F2?format=full'
+    )
+    expect(state.activeDatasetId.value).toBe(1)
+    expect(state.activeDataset.value).toMatchObject(selectedDetail)
+
+    await state.selectDataset(1)
+    expect(fetcher).toHaveBeenCalledTimes(2)
+    expect(state.activeDataset.value).toMatchObject(selectedDetail)
+  })
+
+  it('retries a failed catalog detail request and replaces the summary', async () => {
+    const catalog = [{ id: 'dataset-1', name: 'Dataset 1' }]
+    const selectedDetail = {
+      id: 'dataset-1',
+      name: 'Dataset 1',
+      data: [{ name: 'value', value: 1 }],
+      settings: [{ type: 'line' as const }],
+    }
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(catalog), { status: 200 }))
+      .mockResolvedValueOnce(new Response('', { status: 503, statusText: 'Service Unavailable' }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(selectedDetail), { status: 200 }))
+    vi.stubGlobal('fetch', fetcher)
+    vi.stubGlobal('window', {
+      location: { pathname: '/', protocol: 'https:' },
       VIZB_DATA_URL: 'https://api.example.com/catalog',
       VIZB_DATA: [],
     })
@@ -23,10 +80,40 @@ describe('useDataPoint path loading', () => {
     const state = useDataPoint()
 
     await vi.waitFor(() => expect(state.loading.value).toBe(false))
+    await expect(state.selectDataset(0)).resolves.toBe(false)
+    expect(state.detailError.value).toContain('503 Service Unavailable')
+    expect(state.activeDataset.value).toMatchObject({
+      id: 'dataset-1',
+      data: [],
+      settings: [],
+    })
+
+    await expect(state.retryActiveDataset()).resolves.toBe(true)
+    expect(state.detailError.value).toBeNull()
+    expect(state.detailLoading.value).toBe(false)
+    expect(state.activeDataset.value).toMatchObject(selectedDetail)
+    expect(fetcher).toHaveBeenCalledTimes(3)
+  })
+
+  it('fetches only the encoded detail URL in path mode', async () => {
+    const fetcher = vi.fn(async () => new Response(JSON.stringify(detail), { status: 200 }))
+    vi.stubGlobal('fetch', fetcher)
+    vi.stubGlobal('window', {
+      location: { pathname: '/dataset%2F2', protocol: 'https:' },
+      VIZB_DATA_URL: 'https://api.example.com/dataset/?format=full#latest',
+      VIZB_DATA: [],
+    })
+
+    const { useDataPoint } = await import('./useDataPoint')
+    const state = useDataPoint()
+
+    await vi.waitFor(() => expect(state.loading.value).toBe(false))
     expect(fetcher).toHaveBeenCalledTimes(1)
-    expect(fetcher).toHaveBeenCalledWith('https://api.example.com/catalog/dataset/go-1.25%2Famd64')
+    expect(fetcher).toHaveBeenCalledWith('https://api.example.com/dataset/dataset%2F2?format=full')
+    expect(state.pathDatasetId).toBe('dataset/2')
+    expect(state.loadError.value).toBeNull()
     expect(state.datasets.value).toHaveLength(1)
-    expect(state.datasets.value[0]?.id).toBe('go-1.25/amd64')
+    expect(state.datasets.value[0]?.id).toBe('dataset/2')
     expect(state.lazyCatalog.value).toBe(false)
   })
 
@@ -38,7 +125,7 @@ describe('useDataPoint path loading', () => {
     vi.stubGlobal('fetch', fetcher)
     vi.stubGlobal('window', {
       location: { pathname: '/my-id', protocol: 'https:' },
-      VIZB_DATA_URL: 'https://api.example.com/catalog',
+      VIZB_DATA_URL: 'https://api.example.com/dataset',
       VIZB_DATA: [],
     })
 
@@ -52,11 +139,11 @@ describe('useDataPoint path loading', () => {
     expect(state.datasets.value[0]?.id).toBe('my-id')
   })
 
-  it('uses the base URL instead of path mode for file pages', async () => {
+  it('disables path mode when the data URL does not end in dataset', async () => {
     const fetcher = vi.fn(async () => new Response(JSON.stringify(detail), { status: 200 }))
     vi.stubGlobal('fetch', fetcher)
     vi.stubGlobal('window', {
-      location: { pathname: '/my-id', protocol: 'file:' },
+      location: { pathname: '/ignored-id', protocol: 'https:' },
       VIZB_DATA_URL: 'https://api.example.com/catalog',
       VIZB_DATA: [],
     })
@@ -70,12 +157,12 @@ describe('useDataPoint path loading', () => {
     expect(fetcher).toHaveBeenCalledWith('https://api.example.com/catalog')
   })
 
-  it('uses the base URL for a trailing-slash mount root', async () => {
+  it('uses the base URL instead of path mode for file pages', async () => {
     const fetcher = vi.fn(async () => new Response(JSON.stringify(detail), { status: 200 }))
     vi.stubGlobal('fetch', fetcher)
     vi.stubGlobal('window', {
-      location: { pathname: '/repo/', protocol: 'https:' },
-      VIZB_DATA_URL: 'https://api.example.com/catalog',
+      location: { pathname: '/my-id', protocol: 'file:' },
+      VIZB_DATA_URL: 'https://api.example.com/dataset',
       VIZB_DATA: [],
     })
 
@@ -84,7 +171,25 @@ describe('useDataPoint path loading', () => {
 
     await vi.waitFor(() => expect(state.loading.value).toBe(false))
     expect(state.pathDatasetId).toBeNull()
-    expect(fetcher).toHaveBeenCalledWith('https://api.example.com/catalog')
+    expect(fetcher).toHaveBeenCalledOnce()
+    expect(fetcher).toHaveBeenCalledWith('https://api.example.com/dataset')
+  })
+
+  it('uses the base URL for a trailing-slash mount root', async () => {
+    const fetcher = vi.fn(async () => new Response(JSON.stringify(detail), { status: 200 }))
+    vi.stubGlobal('fetch', fetcher)
+    vi.stubGlobal('window', {
+      location: { pathname: '/repo/', protocol: 'https:' },
+      VIZB_DATA_URL: 'https://api.example.com/dataset',
+      VIZB_DATA: [],
+    })
+
+    const { useDataPoint } = await import('./useDataPoint')
+    const state = useDataPoint()
+
+    await vi.waitFor(() => expect(state.loading.value).toBe(false))
+    expect(state.pathDatasetId).toBeNull()
+    expect(fetcher).toHaveBeenCalledWith('https://api.example.com/dataset')
   })
 
   it('ignores the path without a data URL', async () => {

--- a/ui/src/composables/useDataPoint.ts
+++ b/ui/src/composables/useDataPoint.ts
@@ -11,13 +11,21 @@ import {
 } from '../lib/utils'
 import { presentAxisString } from '../lib/swap'
 import { useSettingsStore } from './useSettingsStore'
-import { classifyPayload, fetchDatasetDetail, type DataPayload } from '../lib/remoteData'
+import {
+  classifyPayload,
+  fetchDatasetDetail,
+  isDatasetCollectionUrl,
+  type DataPayload,
+} from '../lib/remoteData'
 import { extractPathDatasetId } from '../lib/pathRoute'
 
 const dataUrl = window.VIZB_DATA_URL
 const pathname = window.location.pathname
 const pathDatasetId =
-  dataUrl && window.location.protocol !== 'file:' && !pathname.endsWith('/')
+  dataUrl &&
+  isDatasetCollectionUrl(dataUrl) &&
+  window.location.protocol !== 'file:' &&
+  !pathname.endsWith('/')
     ? extractPathDatasetId(pathname)
     : null
 const getDatasets = async (): Promise<DataPayload> => {

--- a/ui/src/composables/useDataPoint.ts
+++ b/ui/src/composables/useDataPoint.ts
@@ -12,12 +12,21 @@ import {
 import { presentAxisString } from '../lib/swap'
 import { useSettingsStore } from './useSettingsStore'
 import { classifyPayload, fetchDatasetDetail, type DataPayload } from '../lib/remoteData'
+import { extractPathDatasetId } from '../lib/pathRoute'
 
 const dataUrl = window.VIZB_DATA_URL
+const pathname = window.location.pathname
+const pathDatasetId =
+  dataUrl && window.location.protocol !== 'file:' && !pathname.endsWith('/')
+    ? extractPathDatasetId(pathname)
+    : null
 const getDatasets = async (): Promise<DataPayload> => {
-  const url = window.VIZB_DATA_URL
-  if (url) {
-    const res = await fetch(url)
+  if (dataUrl && pathDatasetId) {
+    return { mode: 'full', datasets: [await fetchDatasetDetail(dataUrl, pathDatasetId)] }
+  }
+
+  if (dataUrl) {
+    const res = await fetch(dataUrl)
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
     return classifyPayload(await res.json())
   }
@@ -78,8 +87,11 @@ const setArrangement = (datasetId: number, ct: ChartType, targetString: string) 
   arrangementMap.set(`${datasetId}:${ct}`, targetString)
 }
 
-getDatasets()
-  .then((payload) => {
+const loadDatasets = async () => {
+  loading.value = true
+  loadError.value = null
+  try {
+    const payload = await getDatasets()
     // Each Dataset is wrapped in reactive() so settings mutations (sort/scale/
     // showLabels/threeDRotate/swap) propagate to the chart pipeline's watchers.
     // The `data` field (raw rows) is markRaw'd so it stays proxy-free: the
@@ -93,15 +105,17 @@ getDatasets()
         prepareDataset({ ...entry, data: [], settings: [] })
       )
     } else {
+      lazyCatalog.value = false
       datasets.value = payload.datasets.map(prepareDataset)
     }
-  })
-  .catch((err: unknown) => {
+  } catch (err: unknown) {
     loadError.value = err instanceof Error ? err.message : String(err)
-  })
-  .finally(() => {
+  } finally {
     loading.value = false
-  })
+  }
+}
+
+void loadDatasets()
 
 // Values are normalized once at load (see `normalize`); this just guards the
 // array shape.
@@ -221,7 +235,8 @@ const selectDataset = async (id: number): Promise<boolean> => {
   return true
 }
 
-const retryActiveDataset = () => selectDataset(activeDatasetId.value)
+const retryActiveDataset = () =>
+  loadError.value ? loadDatasets() : selectDataset(activeDatasetId.value)
 
 const selectGroup = (id: number) => {
   if (isValidIndex(id, groupNames.value.length)) {
@@ -257,6 +272,7 @@ export function useDataPoint() {
     detailLoading,
     detailError,
     retryActiveDataset,
+    pathDatasetId,
 
     chartMode,
     isValueMode,

--- a/ui/src/composables/useUrlRouter.test.ts
+++ b/ui/src/composables/useUrlRouter.test.ts
@@ -12,6 +12,7 @@ const holder = vi.hoisted(() => ({
   setArrangement: vi.fn(),
   setChartType: vi.fn(),
   resultGroups: { value: [{ name: 'first' }, { name: 'second' }] },
+  pathDatasetId: null as string | null,
   activeDatasetRef: {
     get value() {
       return holder.datasets?.value[holder.activeDatasetId.value]
@@ -38,6 +39,7 @@ vi.mock('./useDataPoint', () => ({
     selectGroup: holder.selectGroup,
     setArrangement: holder.setArrangement,
     arrangementMap: new Map<string, string>(),
+    pathDatasetId: holder.pathDatasetId,
   }),
 }))
 
@@ -55,10 +57,10 @@ const ds = (settings: Dataset['settings']): Dataset => ({
   data: [],
 })
 
-function mockWindow(search: string) {
+function mockWindow(search: string, pathname = '/') {
   const replaceState = vi.fn()
   vi.stubGlobal('window', {
-    location: { pathname: '/', search },
+    location: { pathname, search, protocol: 'https:' },
     history: { replaceState },
   })
   return replaceState
@@ -74,6 +76,7 @@ describe('useUrlRouter', () => {
     holder.activeChartIndex.value = 0
     holder.activeDatasetId.value = 0
     holder.chartType.value = 'bar'
+    holder.pathDatasetId = null
     holder.selectDataset.mockReset()
     holder.selectDataset.mockImplementation(async (id: number) => {
       holder.activeDatasetId.value = id
@@ -145,6 +148,25 @@ describe('useUrlRouter', () => {
     const { initFromUrl } = useUrlRouter()
     await initFromUrl()
     expect(holder.selectDataset).toHaveBeenCalledWith(2)
+  })
+
+  it('uses path identity while applying the shared chart and group parameters', async () => {
+    holder.pathDatasetId = 'my-id'
+    holder.datasets = ref([
+      ds([
+        { type: 'bar', threeD: false },
+        { type: 'line', sort: { enabled: false, order: 'asc' } },
+      ]),
+      { ...ds([{ type: 'bar' }]), id: 'query-id' },
+    ])
+    mockWindow('?id=query-id&d=1&c=line&g=1&bar.3d=true', '/my-id')
+    const { useUrlRouter } = await import('./useUrlRouter')
+    await useUrlRouter().initFromUrl()
+
+    expect(holder.selectDataset).toHaveBeenCalledWith(0)
+    expect(holder.selectGroup).toHaveBeenCalledWith(1)
+    expect(holder.setChartType).toHaveBeenCalledWith('line')
+    expect((holder.datasets.value[0]!.settings[0] as BarConfig).threeD).toBe(true)
   })
 
   it('applies chart parameters only after the selected detail has loaded', async () => {
@@ -243,6 +265,21 @@ describe('useUrlRouter', () => {
     const { syncUrlToState } = useUrlRouter()
     syncUrlToState()
     expect(replaceState).toHaveBeenCalledWith(null, '', '/?d=1')
+  })
+
+  it('keeps the path identity and omits id/d while syncing chart parameters', async () => {
+    holder.pathDatasetId = 'my-id'
+    holder.datasets = ref([
+      {
+        ...ds([{ type: 'bar', threeD: true }]),
+        id: 'my-id',
+      },
+    ])
+    const replaceState = mockWindow('?id=query-id&d=1', '/my-id')
+    const { useUrlRouter } = await import('./useUrlRouter')
+    useUrlRouter().syncUrlToState()
+
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/my-id?bar.3d=true')
   })
 
   it('syncs 3D settings to bar.3d / bar.3d-vm in the URL', async () => {

--- a/ui/src/composables/useUrlRouter.test.ts
+++ b/ui/src/composables/useUrlRouter.test.ts
@@ -150,6 +150,15 @@ describe('useUrlRouter', () => {
     expect(holder.selectDataset).toHaveBeenCalledWith(2)
   })
 
+  it('syncs the URL immediately after successful initialization', async () => {
+    holder.datasets = ref([ds([])])
+    const replaceState = mockWindow('?d=0')
+    const { useUrlRouter } = await import('./useUrlRouter')
+    await useUrlRouter().initFromUrl()
+
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/')
+  })
+
   it('uses path identity while applying the shared chart and group parameters', async () => {
     holder.pathDatasetId = 'my-id'
     holder.datasets = ref([
@@ -219,9 +228,11 @@ describe('useUrlRouter', () => {
         holder.activeDatasetId.value = id
         return true
       })
-    mockWindow('?id=two&bar.h=true')
+    const replaceState = mockWindow('?id=two&bar.h=true')
     const { useUrlRouter } = await import('./useUrlRouter')
     await useUrlRouter().initFromUrl()
+
+    expect(replaceState).not.toHaveBeenCalled()
 
     holder.datasets.value = [
       holder.datasets.value[0]!,

--- a/ui/src/composables/useUrlRouter.ts
+++ b/ui/src/composables/useUrlRouter.ts
@@ -317,6 +317,7 @@ export function useUrlRouter() {
       }),
       () => syncUrlToState()
     )
+    if (applied) syncUrlToState()
     return applied
   }
 

--- a/ui/src/composables/useUrlRouter.ts
+++ b/ui/src/composables/useUrlRouter.ts
@@ -39,8 +39,10 @@ const applyIndexParam = (
 
 const resolveDatasetIndex = (
   params: Record<string, string | undefined>,
-  datasets: Dataset[]
+  datasets: Dataset[],
+  pathDatasetId: string | null
 ): number => {
+  if (pathDatasetId) return 0
   const idParam = params.id?.trim()
   if (idParam) {
     const idx = datasets.findIndex((ds) => ds.id === idParam)
@@ -109,6 +111,7 @@ export function useUrlRouter() {
     selectGroup,
     setArrangement,
     arrangementMap,
+    pathDatasetId,
   } = useDataPoint()
 
   // Chart-type list for the active dataset, derived from its `settings` array.
@@ -126,8 +129,8 @@ export function useUrlRouter() {
   }
 
   const applyParams = async (params: Record<string, string | undefined>) => {
-    // 1. Dataset selection (?id= wins over ?d=)
-    const datasetId = resolveDatasetIndex(params, datasets.value)
+    // 1. Dataset selection (path identity wins, otherwise ?id= wins over ?d=)
+    const datasetId = resolveDatasetIndex(params, datasets.value, pathDatasetId)
     const catalogShell = datasets.value[datasetId]
     const selected = await selectDataset(datasetId)
     if (!selected) {
@@ -248,11 +251,13 @@ export function useUrlRouter() {
     }
 
     // Dataset / group
-    const datasetId = activeDataset.value?.id?.trim()
-    if (datasetId) {
-      params.id = datasetId
-    } else if (activeDatasetId.value > 0) {
-      params.d = activeDatasetId.value.toString()
+    if (!pathDatasetId) {
+      const datasetId = activeDataset.value?.id?.trim()
+      if (datasetId) {
+        params.id = datasetId
+      } else if (activeDatasetId.value > 0) {
+        params.d = activeDatasetId.value.toString()
+      }
     }
     if (activeGroupId.value > 0) params.g = activeGroupId.value.toString()
 

--- a/ui/src/lib/pathRoute.test.ts
+++ b/ui/src/lib/pathRoute.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { extractPathDatasetId } from './pathRoute'
+
+describe('extractPathDatasetId', () => {
+  it.each([
+    ['/', null],
+    ['/index', null],
+    ['/report.html', null],
+    ['/assets/app.js', null],
+    ['/go-1.25', 'go-1.25'],
+    ['/apps/vizb/go-1.25%2Famd64', 'go-1.25/amd64'],
+  ])('extracts the dataset identity from %s', (pathname, expected) => {
+    expect(extractPathDatasetId(pathname)).toBe(expected)
+  })
+})

--- a/ui/src/lib/pathRoute.ts
+++ b/ui/src/lib/pathRoute.ts
@@ -1,0 +1,15 @@
+const STATIC_ASSET =
+  /\.(?:html?|css|m?js|cjs|map|json|wasm|xml|txt|ico|png|jpe?g|gif|svg|webp|avif|woff2?|ttf|otf)$/i
+
+export const extractPathDatasetId = (pathname: string): string | null => {
+  const segment = pathname.split('/').filter(Boolean).at(-1)
+  if (!segment) return null
+
+  try {
+    const decoded = decodeURIComponent(segment)
+    if (!decoded || decoded.toLowerCase() === 'index' || STATIC_ASSET.test(decoded)) return null
+    return decoded
+  } catch {
+    return null
+  }
+}

--- a/ui/src/lib/remoteData.test.ts
+++ b/ui/src/lib/remoteData.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Dataset } from '../types'
-import { buildDatasetDetailUrl, classifyPayload, fetchDatasetDetail } from './remoteData'
+import {
+  buildDatasetDetailUrl,
+  classifyPayload,
+  fetchDatasetDetail,
+  isDatasetCollectionUrl,
+} from './remoteData'
 
 const detail = (id?: string): Dataset => ({
   ...(id === undefined ? {} : { id }),
@@ -77,16 +82,27 @@ describe('remote data payloads', () => {
     expect(() => classifyPayload(payload)).toThrow('Expected one full dataset object')
   })
 
+  it('detects only data URLs whose path ends in the dataset collection', () => {
+    expect(isDatasetCollectionUrl('https://example.com/api/dataset')).toBe(true)
+    expect(isDatasetCollectionUrl('https://example.com/api/dataset/?format=full#latest')).toBe(true)
+    expect(isDatasetCollectionUrl('https://example.com/api/datasets')).toBe(false)
+    expect(isDatasetCollectionUrl('https://example.com/api/dataset.json')).toBe(false)
+    expect(isDatasetCollectionUrl('not a URL')).toBe(false)
+  })
+
   it('builds one encoded detail path segment and preserves only the query', () => {
     expect(
       buildDatasetDetailUrl(
-        'https://example.com/api/catalog///?token=a%20b#section',
+        'https://example.com/api/catalog///?filter=a%20b#section',
         'suite/hello world?'
       )
-    ).toBe('https://example.com/api/catalog/dataset/suite%2Fhello%20world%3F?token=a%20b')
+    ).toBe('https://example.com/api/catalog/dataset/suite%2Fhello%20world%3F?filter=a%20b')
     expect(buildDatasetDetailUrl('https://example.com/', 'one')).toBe(
       'https://example.com/dataset/one'
     )
+    expect(
+      buildDatasetDetailUrl('https://example.com/api/dataset/?format=full#latest', 'suite/one')
+    ).toBe('https://example.com/api/dataset/suite%2Fone?format=full')
   })
 
   it('fills an omitted detail ID', async () => {

--- a/ui/src/lib/remoteData.ts
+++ b/ui/src/lib/remoteData.ts
@@ -78,10 +78,24 @@ export const classifyPayload = (payload: unknown): DataPayload => {
   return { mode: 'catalog', entries }
 }
 
+const datasetCollectionPath = (pathname: string): string | null => {
+  const normalized = pathname.replace(/\/+$/, '')
+  return normalized.endsWith('/dataset') ? normalized : null
+}
+
+export const isDatasetCollectionUrl = (rawUrl: string): boolean => {
+  try {
+    return datasetCollectionPath(new URL(rawUrl).pathname) !== null
+  } catch {
+    return false
+  }
+}
+
 export const buildDatasetDetailUrl = (baseUrl: string, id: string): string => {
   const url = new URL(baseUrl)
   const basePath = url.pathname.replace(/\/+$/, '')
-  url.pathname = `${basePath}/dataset/${encodeURIComponent(id)}`
+  const collectionPath = datasetCollectionPath(basePath) ?? `${basePath}/dataset`
+  url.pathname = `${collectionPath}/${encodeURIComponent(id)}`
   url.hash = ''
   return url.toString()
 }

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -144,7 +144,7 @@ useDashboardInit()
     </IconButton>
   </nav>
 
-  <LoadError v-if="loadError" :message="loadError" />
+  <LoadError v-if="loadError" :message="loadError" :retry="retryActiveDataset" />
 
   <LoadingSkeleton v-else-if="showSkeleton" />
 


### PR DESCRIPTION
## Related Issue
Closes #244 

## Changes
- Add direct dataset deep links via /<encoded-id> when --data-url is set.
- Fetch only <data-url>/dataset/<encoded-id> without loading the catalog
  first.

- Preserve existing root, HTML/static asset, trailing-slash,
  embedded-data, and file:// behavior.

- Reuse existing query handling for chart, group, legacy, and per-chart
  settings.

- Ignore and omit ?id=/?d= in path mode while preserving the pathname.
- Show full-page load errors with retry for failed direct-detail requests.
- Add coverage for path parsing, encoded IDs, one-call loading, retry, URL
  apply/sync, and regressions.

- Document SPA fallback requirements in CLI help and user documentation.

## Test Result
```bash
# mock backend
from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
  from pathlib import Path
  from urllib.parse import unquote, urlparse
  import json

  payload = json.loads(Path("ui/src/data/sample.json").read_text())
  detail = payload[0] if isinstance(payload, list) else payload
  detail = {**detail, "id": "my-id", "name": "Local test"}

  class Handler(BaseHTTPRequestHandler):
      def send_json(self, status, payload):
          body = json.dumps(payload).encode()
          self.send_response(status)
          self.send_header("Content-Type", "application/json")
          self.send_header("Access-Control-Allow-Origin", "*")
          self.send_header("Content-Length", str(len(body)))
          self.end_headers()
          self.wfile.write(body)

      def do_GET(self):
          path = urlparse(self.path).path

          if path == "/datasets":
              self.send_json(200, [{"id": "my-id", "name": "Local test"}])
              return

          prefix = "/datasets/dataset/"
          if path.startswith(prefix) and unquote(path[len(prefix):]) == "my-id":
              self.send_json(200, detail)
              return

          self.send_json(404, {"error": "not found"})

  print("Backend: http://localhost:8080")
  ThreadingHTTPServer(("localhost", 8080), Handler).serve_forever()
```
### Case 1
```bash
# Terminal 1: backend
python3 /tmp/vizb_mock_backend.py

# Terminal 2: frontend with SPA fallback
cd ui && pnpm vite ../site --host 127.0.0.1 --port 4173

# Open the path-mode test
open "http://127.0.0.1:4173/my-id?c=line&g=1&bar.3d=true"
```
<img width="2242" height="6212" alt="screencapture-127-0-0-1-4173-my-id-2026-07-20-19_42_47" src="https://github.com/user-attachments/assets/85b2c9ee-eda6-42a0-9c48-07ce91adb7c3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added single-dataset deep links using URL paths (`/<dataset-id>`), with path identity taking precedence over `id`/`d`.
  - When using `--data-url` over HTTP(S), special “dataset-path mode” activates for collection URLs ending in `/dataset`, bypassing the catalog to load only the selected dataset details (and using generated HTML as fallback for deep links).
- **Bug Fixes**
  - Full-page load error state now includes retry support to reload the active dataset.
- **Documentation**
  - Expanded `--data-url` documentation for runtime behavior, caching/error expectations, CORS guidance, and help text examples.
- **Tests**
  - Added/updated unit tests covering path-mode activation, retries, and URL sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->