### PR TITLE
ci: separate merge and publish for release prepare-only builds

### DIFF
--- a/.github/workflows/comparisons-examples.yml
+++ b/.github/workflows/comparisons-examples.yml
@@ -13,14 +13,14 @@ on:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated comparisons examples immediately"
+        description: "Publish after merge (default true; set false to prepare-only)"
   workflow_dispatch:
     inputs:
       publish:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated comparisons examples immediately"
+        description: "Publish after merge (default true; set false to prepare-only)"
 
 jobs:
   convert:
@@ -70,8 +70,18 @@ jobs:
     name: Merge Comparisons Data
     needs: convert
     permissions:
-      contents: write
+      contents: read
     uses: ./.github/workflows/merge-examples.yml
     with:
       example_category: comparisons
-      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish == true }}
+
+  publish:
+    name: Publish Comparisons examples
+    needs: merge
+    if: ${{ inputs.publish != false }}  # default on; release/dispatch pass false to skip
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-site.yml
+    with:
+      artifact_pattern: site-examples-comparisons
+      keep_files: true

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -49,8 +49,9 @@ jobs:
           path: docs/dist
           if-no-files-found: error
 
+  # Deploy is a separate job (not nested in build) so callers can prepare-only.
   publish:
-    if: inputs.publish
+    if: ${{ inputs.publish }}
     needs: build
     permissions:
       contents: write

--- a/.github/workflows/github-legends.yml
+++ b/.github/workflows/github-legends.yml
@@ -15,14 +15,14 @@ on:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated GitHub Legends examples immediately"
+        description: "Publish after merge (default true; set false to prepare-only)"
   workflow_dispatch:
     inputs:
       publish:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated GitHub Legends examples immediately"
+        description: "Publish after merge (default true; set false to prepare-only)"
 
 jobs:
   convert:
@@ -86,9 +86,18 @@ jobs:
     name: Merge GitHub Legends
     needs: convert
     permissions:
-      contents: write
+      contents: read
     uses: ./.github/workflows/merge-examples.yml
     with:
       example_category: github-legends
-      # Schedule always publishes; call/dispatch/push use a boolean (empty input → false).
-      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish == true }}
+
+  publish:
+    name: Publish GitHub Legends examples
+    needs: merge
+    if: ${{ inputs.publish != false }}  # default on; release/dispatch pass false to skip
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-site.yml
+    with:
+      artifact_pattern: site-examples-github-legends
+      keep_files: true

--- a/.github/workflows/go-examples.yml
+++ b/.github/workflows/go-examples.yml
@@ -13,14 +13,14 @@ on:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated Go examples immediately"
+        description: "Publish after merge (default true; set false to prepare-only)"
   workflow_dispatch:
     inputs:
       publish:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated Go examples immediately"
+        description: "Publish after merge (default true; set false to prepare-only)"
 
 jobs:
   convert:
@@ -128,8 +128,18 @@ jobs:
     name: Merge Go Benchmarks
     needs: convert
     permissions:
-      contents: write
+      contents: read
     uses: ./.github/workflows/merge-examples.yml
     with:
       example_category: go
-      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish == true }}
+
+  publish:
+    name: Publish Go examples
+    needs: merge
+    if: ${{ inputs.publish != false }}  # default on; release/dispatch pass false to skip
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-site.yml
+    with:
+      artifact_pattern: site-examples-go
+      keep_files: true

--- a/.github/workflows/javascript-examples.yml
+++ b/.github/workflows/javascript-examples.yml
@@ -13,14 +13,14 @@ on:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated JavaScript examples immediately"
+        description: "Publish after merge (default true; set false to prepare-only)"
   workflow_dispatch:
     inputs:
       publish:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated JavaScript examples immediately"
+        description: "Publish after merge (default true; set false to prepare-only)"
 
 jobs:
   convert:
@@ -38,7 +38,6 @@ jobs:
             name: "Bubble Vs Insertion Sort (vitest)"
             description: "Vitest bench output — benchmark name and case from regex groups"
             group-regex: "n=(?<y>.*)/(?<x>.*)"
-
 
     runs-on: ubuntu-latest
     steps:
@@ -75,8 +74,18 @@ jobs:
     name: Merge JavaScript Benchmarks
     needs: convert
     permissions:
-      contents: write
+      contents: read
     uses: ./.github/workflows/merge-examples.yml
     with:
       example_category: javascript
-      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish == true }}
+
+  publish:
+    name: Publish JavaScript examples
+    needs: merge
+    if: ${{ inputs.publish != false }}  # default on; release/dispatch pass false to skip
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-site.yml
+    with:
+      artifact_pattern: site-examples-javascript
+      keep_files: true

--- a/.github/workflows/math-and-3d-examples.yml
+++ b/.github/workflows/math-and-3d-examples.yml
@@ -13,14 +13,14 @@ on:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated math-and-3d examples immediately"
+        description: "Publish after merge (default true; set false to prepare-only)"
   workflow_dispatch:
     inputs:
       publish:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated math-and-3d examples immediately"
+        description: "Publish after merge (default true; set false to prepare-only)"
 
 jobs:
   convert:
@@ -94,8 +94,18 @@ jobs:
     name: Merge Math & 3D Data
     needs: convert
     permissions:
-      contents: write
+      contents: read
     uses: ./.github/workflows/merge-examples.yml
     with:
       example_category: math-and-3d
-      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish == true }}
+
+  publish:
+    name: Publish Math & 3D examples
+    needs: merge
+    if: ${{ inputs.publish != false }}  # default on; release/dispatch pass false to skip
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-site.yml
+    with:
+      artifact_pattern: site-examples-math-and-3d
+      keep_files: true

--- a/.github/workflows/merge-examples.yml
+++ b/.github/workflows/merge-examples.yml
@@ -6,11 +6,6 @@ on:
         required: true
         type: string
         description: "Example category subdirectory under examples/ (e.g. go, tabular-data, github-legends)"
-      publish:
-        required: false
-        type: boolean
-        default: false
-        description: "Publish the generated example page immediately"
 
 jobs:
   merge:
@@ -56,14 +51,3 @@ jobs:
           name: site-examples-${{ inputs.example_category }}
           path: dist
           if-no-files-found: error
-
-  publish:
-    name: Publish ${{ inputs.example_category }} examples
-    if: inputs.publish
-    needs: merge
-    permissions:
-      contents: write
-    uses: ./.github/workflows/publish-site.yml
-    with:
-      artifact_pattern: site-examples-${{ inputs.example_category }}
-      keep_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,12 +107,15 @@ jobs:
     permissions:
       contents: write
 
+  # prepare-only (publish: false); final publish-site deploys all site-* artifacts together
   tabular-data-examples:
     name: "Examples: Tabular Data"
     needs: goreleaser
     uses: ./.github/workflows/tabular-data-examples.yml
     permissions:
       contents: write
+    with:
+      publish: false
 
   math-and-3d-examples:
     name: "Examples: Math & 3D"
@@ -120,6 +123,8 @@ jobs:
     uses: ./.github/workflows/math-and-3d-examples.yml
     permissions:
       contents: write
+    with:
+      publish: false
 
   comparisons-examples:
     name: "Examples: Comparisons"
@@ -127,6 +132,8 @@ jobs:
     uses: ./.github/workflows/comparisons-examples.yml
     permissions:
       contents: write
+    with:
+      publish: false
 
   github-legends:
     name: "Examples: GitHub Legends"
@@ -134,6 +141,8 @@ jobs:
     uses: ./.github/workflows/github-legends.yml
     permissions:
       contents: write
+    with:
+      publish: false
 
   go-examples:
     name: "Examples: Go"
@@ -141,6 +150,8 @@ jobs:
     uses: ./.github/workflows/go-examples.yml
     permissions:
       contents: write
+    with:
+      publish: false
 
   javascript-examples:
     name: "Examples: JavaScript"
@@ -148,6 +159,8 @@ jobs:
     uses: ./.github/workflows/javascript-examples.yml
     permissions:
       contents: write
+    with:
+      publish: false
 
   rust-examples:
     name: "Examples: Rust"
@@ -155,6 +168,8 @@ jobs:
     uses: ./.github/workflows/rust-examples.yml
     permissions:
       contents: write
+    with:
+      publish: false
 
   publish-site:
     name: Publish Site

--- a/.github/workflows/rust-examples.yml
+++ b/.github/workflows/rust-examples.yml
@@ -13,14 +13,14 @@ on:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated Rust examples immediately"
+        description: "Publish after merge (default true; set false to prepare-only)"
   workflow_dispatch:
     inputs:
       publish:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated Rust examples immediately"
+        description: "Publish after merge (default true; set false to prepare-only)"
 
 jobs:
   convert:
@@ -75,8 +75,18 @@ jobs:
     name: Merge Rust Benchmarks
     needs: convert
     permissions:
-      contents: write
+      contents: read
     uses: ./.github/workflows/merge-examples.yml
     with:
       example_category: rust
-      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish == true }}
+
+  publish:
+    name: Publish Rust examples
+    needs: merge
+    if: ${{ inputs.publish != false }}  # default on; release/dispatch pass false to skip
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-site.yml
+    with:
+      artifact_pattern: site-examples-rust
+      keep_files: true

--- a/.github/workflows/tabular-data-examples.yml
+++ b/.github/workflows/tabular-data-examples.yml
@@ -13,14 +13,14 @@ on:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated tabular-data examples immediately"
+        description: "Publish after merge (default true; set false to prepare-only)"
   workflow_dispatch:
     inputs:
       publish:
         required: false
         type: boolean
         default: true
-        description: "Publish the generated tabular-data examples immediately"
+        description: "Publish after merge (default true; set false to prepare-only)"
 
 jobs:
   convert:
@@ -98,8 +98,18 @@ jobs:
     name: Merge Tabular Data
     needs: convert
     permissions:
-      contents: write
+      contents: read
     uses: ./.github/workflows/merge-examples.yml
     with:
       example_category: tabular-data
-      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish == true }}
+
+  publish:
+    name: Publish Tabular Data examples
+    needs: merge
+    if: ${{ inputs.publish != false }}  # default on; release/dispatch pass false to skip
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-site.yml
+    with:
+      artifact_pattern: site-examples-tabular-data
+      keep_files: true

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <p>
     <a href="https://github.com/avelino/awesome-go?tab=readme-ov-file#benchmarks"><img src="https://awesome.re/mentioned-badge-flat.svg" alt="Mentioned in Awesome Go" /></a>
     <a href="https://vizb.goptics.org"><img src="https://img.shields.io/badge/Docs-00ADD8?style=for&logo=readthedocs" alt="Docs" /></a>
+    <a href="https://vizb.goptics.org/api/"><img src="https://img.shields.io/badge/API-OpenAPI-7B42BC?style=for&logo=openapiinitiative&logoColor=white" alt="API" /></a>
     <a href="https://vizb.goptics.org/examples"><img src="https://img.shields.io/badge/Live-Examples-orange?style=for" alt="Examples" /></a>
     <a href="https://github.com/goptics/vizb/actions/workflows/cli.yml"><img src="https://github.com/goptics/vizb/actions/workflows/cli.yml/badge.svg" alt="CLI" /></a>
     <a href="https://github.com/goptics/vizb/actions/workflows/ui.yml"><img src="https://github.com/goptics/vizb/actions/workflows/ui.yml/badge.svg" alt="UI" /></a>
@@ -29,6 +30,7 @@
   <p>
     <a href="https://vizb.goptics.org/getting-started/">Getting Started</a> ·
     <a href="https://vizb.goptics.org/commands/root/">Commands</a> ·
+    <a href="https://vizb.goptics.org/api/">API</a> ·
     <a href="https://vizb.goptics.org/charts/">Charts</a> ·
     <a href="https://vizb.goptics.org/guides/parsers/">Parsers</a> ·
     <a href="https://vizb.goptics.org/guides/group/">Grouping</a> ·


### PR DESCRIPTION
## Summary
- Split **merge** and **publish** into independent steps: `merge-examples.yml` only merges and uploads `site-examples-*` artifacts (no nested publish).
- Each examples workflow (and docs) owns an optional sibling **publish** job that calls `publish-site.yml`.
- Gate with `if: ${{ inputs.publish != false }}` — publish by default; pass `false` for prepare-only.
- **Release** passes `publish: false` on every examples call and still deploys once via final **Publish Site** (`site-*`, `keep_files: false`).

This removes ~7 mid-pipeline per-category gh-pages publishes on release (the extra jobs that inflated the run from ~58 toward ~65) and avoids racing the final site publish.

## Test plan
- [ ] On a main path push under `examples/go/**`, workflow runs convert → merge → publish
- [ ] Manual dispatch with publish unchecked skips the publish job
- [ ] On a release tag (or dry-run inspection of the graph): examples jobs skip intermediate publish; only final Publish Site deploys
- [ ] Docs prepare-only on release; manual Deploy Docs with publish still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a prepare-only option for example generation workflows.
  * Publishing now runs as a dedicated step after examples are merged.
  * Added clearer workflow controls showing that publishing occurs after merge and can be disabled.

* **Bug Fixes**
  * Improved release coordination by preparing all example artifacts first, then publishing the complete site together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->