### PR TITLE
docs: add Docker usage guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     <a href="https://github.com/avelino/awesome-go?tab=readme-ov-file#benchmarks"><img src="https://awesome.re/mentioned-badge-flat.svg" alt="Mentioned in Awesome Go" /></a>
     <a href="https://vizb.goptics.org"><img src="https://img.shields.io/badge/Docs-00ADD8?style=for&logo=readthedocs" alt="Docs" /></a>
     <a href="https://vizb.goptics.org/api/"><img src="https://img.shields.io/badge/API-OpenAPI-7B42BC?style=for&logo=openapiinitiative&logoColor=white" alt="API" /></a>
+    <a href="https://hub.docker.com/r/goptics/vizb"><img src="https://img.shields.io/docker/pulls/goptics/vizb?logo=docker&label=Docker" alt="Docker Hub" /></a>
     <a href="https://vizb.goptics.org/examples"><img src="https://img.shields.io/badge/Live-Examples-orange?style=for" alt="Examples" /></a>
     <a href="https://github.com/goptics/vizb/actions/workflows/cli.yml"><img src="https://github.com/goptics/vizb/actions/workflows/cli.yml/badge.svg" alt="CLI" /></a>
     <a href="https://github.com/goptics/vizb/actions/workflows/ui.yml"><img src="https://github.com/goptics/vizb/actions/workflows/ui.yml/badge.svg" alt="UI" /></a>
@@ -36,7 +37,8 @@
     <a href="https://vizb.goptics.org/guides/group/">Grouping</a> ·
     <a href="https://vizb.goptics.org/guides/select/">Select</a> ·
     <a href="https://vizb.goptics.org/guides/merging/">Merging</a> ·
-    <a href="https://vizb.goptics.org/ci-cd/github-action/">CI/CD</a>
+    <a href="https://vizb.goptics.org/ci-cd/github-action/">CI/CD</a> ·
+    <a href="https://vizb.goptics.org/installation/#docker">Docker</a>
     <br />
     <sub>Full documentation at <a href="https://vizb.goptics.org/"><strong>vizb.goptics.org</strong></a></sub>
   </p>
@@ -60,6 +62,24 @@ irm https://vizb.goptics.org/install.ps1 | iex
 ### Download Binary
 
 Pre-built binaries for Linux, macOS, and Windows are available on the [releases page](https://github.com/goptics/vizb/releases).
+
+### Docker
+
+Run the API directly or with the repository's Compose configuration:
+
+```bash
+docker run --rm -p 8080:8080 goptics/vizb
+docker compose up -d
+```
+
+Run the CLI against files in the current directory:
+
+```bash
+docker run --rm -v "$PWD:/data" -w /data goptics/vizb bar sales.csv -o out.html
+```
+
+The API has no built-in authentication. Keep it private or put authentication,
+TLS, and access controls in front of it. See the [Docker installation guide](https://vizb.goptics.org/installation/#docker).
 
 ## Quick Example
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,15 @@ Pre-built binaries for Linux, macOS, and Windows are available on the [releases 
 
 ### Docker
 
-Run the API directly or with the repository's Compose configuration:
+Run the API directly:
 
 ```bash
-docker run --rm -p 8080:8080 goptics/vizb
+docker run --rm -p 127.0.0.1:8080:8080 goptics/vizb
+```
+
+Alternatively, use the repository's Compose configuration:
+
+```bash
 docker compose up -d
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,9 +25,13 @@ CSV, and JSON. Treat all input as untrusted when embedding generated HTML in
 shared or hosted environments. Do not serve untrusted vizb output from the same
 origin as sensitive applications without reviewing the content first.
 
-The CLI itself runs locally and does not expose a network service. The primary
-risk surface is malicious or malformed input files processed by the parsers and
-rendered into HTML/JavaScript bundles.
+Most CLI commands run locally, but `vizb serve` exposes an unauthenticated HTTP
+API. The Docker image runs this API on `0.0.0.0:8080` inside the container. Do
+not publish it to an untrusted network without your own authentication, TLS,
+and access controls, such as a protected reverse proxy or firewall rules.
+
+The other primary risk surface is malicious or malformed input files processed
+by the parsers and rendered into HTML/JavaScript bundles.
 
 ## Supported Versions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,8 +27,9 @@ origin as sensitive applications without reviewing the content first.
 
 Most CLI commands run locally, but `vizb serve` exposes an unauthenticated HTTP
 API. The Docker image runs this API on `0.0.0.0:8080` inside the container. Do
-not publish it to an untrusted network without your own authentication, TLS,
-and access controls, such as a protected reverse proxy or firewall rules.
+not publish it on a non-loopback host address without your own authentication,
+TLS, and appropriate access controls, such as a protected reverse proxy or
+firewall rules.
 
 The other primary risk surface is malicious or malformed input files processed
 by the parsers and rendered into HTML/JavaScript bundles.

--- a/docs/src/content/docs/commands/serve.mdx
+++ b/docs/src/content/docs/commands/serve.mdx
@@ -28,10 +28,15 @@ that the server is not exposed to a network unintentionally.
 ## Docker and Compose
 
 The image starts `vizb serve` on `0.0.0.0:8080` inside the container. Publish it
-on the same host port or start the repository's Compose configuration:
+on the same host port:
 
 ```bash
-docker run --rm -p 8080:8080 goptics/vizb
+docker run --rm -p 127.0.0.1:8080:8080 goptics/vizb
+```
+
+Alternatively, start the repository's Compose configuration:
+
+```bash
 docker compose up -d
 ```
 
@@ -39,7 +44,7 @@ If host port 8080 is already in use, map another host port to container port
 8080:
 
 ```bash
-docker run --rm -p 7878:8080 goptics/vizb
+docker run --rm -p 127.0.0.1:7878:8080 goptics/vizb
 ```
 
 The remapped API is available at `http://127.0.0.1:7878`.

--- a/docs/src/content/docs/commands/serve.mdx
+++ b/docs/src/content/docs/commands/serve.mdx
@@ -3,6 +3,8 @@ title: vizb serve
 description: Run Vizb's local synchronous REST API.
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 `vizb serve` exposes Vizb conversion, Dataset merging, and UI generation through
 a local JSON API. It is synchronous and stateless: requests do not create jobs
 or persisted server-side artifacts.
@@ -22,6 +24,29 @@ vizb serve --host 0.0.0.0 --port 8080
 
 The host and port make up the API base URL. The default binding is loopback so
 that the server is not exposed to a network unintentionally.
+
+## Docker and Compose
+
+The image starts `vizb serve` on `0.0.0.0:8080` inside the container. Publish it
+on the same host port or start the repository's Compose configuration:
+
+```bash
+docker run --rm -p 8080:8080 goptics/vizb
+docker compose up -d
+```
+
+If host port 8080 is already in use, map another host port to container port
+8080:
+
+```bash
+docker run --rm -p 7878:8080 goptics/vizb
+```
+
+The remapped API is available at `http://127.0.0.1:7878`.
+
+<Aside type="caution">
+  The API has no built-in authentication. Do not expose it publicly without your own authentication, TLS, and access controls.
+</Aside>
 
 Each request body is limited to 10 MiB. The server uses a 5-second header read
 timeout, a 15-second request read timeout, and 60-second write and idle

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -20,7 +20,7 @@ Pull the image and start the API on port 8080:
 
 ```bash
 docker pull goptics/vizb
-docker run --rm -p 8080:8080 goptics/vizb
+docker run --rm -p 127.0.0.1:8080:8080 goptics/vizb
 ```
 
 The image starts `vizb serve` bound to `0.0.0.0` inside the container. You can

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Install vizb using a one-liner, Go toolchain, or download a pre-built binary.
+description: Install vizb using Docker, a one-liner, the Go toolchain, or a pre-built binary.
 ---
 
 import { Tabs, TabItem, Aside } from '@astrojs/starlight/components';
@@ -12,6 +12,39 @@ import QuickInstall from '../../components/QuickInstall.mdx';
 
 <Aside type="note">
   The installer downloads the latest binary from GitHub Releases to `~/.local/bin` on Linux/macOS or `%LOCALAPPDATA%\vizb` on Windows. No admin required.
+</Aside>
+
+## Docker
+
+Pull the image and start the API on port 8080:
+
+```bash
+docker pull goptics/vizb
+docker run --rm -p 8080:8080 goptics/vizb
+```
+
+The image starts `vizb serve` bound to `0.0.0.0` inside the container. You can
+also start it with the repository's Compose configuration:
+
+```bash
+docker compose up -d
+```
+
+For CLI use, mount the current directory so Vizb can read inputs and persist
+outputs:
+
+```bash
+docker run --rm -v "$PWD:/data" -w /data goptics/vizb bar sales.csv -o out.html
+```
+
+Pipe input with `-i`; the mounted directory still keeps the generated file:
+
+```bash
+cat sales.csv | docker run --rm -i -v "$PWD:/data" -w /data goptics/vizb bar -o out.html
+```
+
+<Aside type="caution">
+  The API has no built-in authentication. Do not expose it publicly without your own authentication, TLS, and access controls. See [`vizb serve`](/commands/serve/) for details and port remapping.
 </Aside>
 
 ## Go Install


### PR DESCRIPTION
## Related Issue
Closes #256 

## Changes
- Added Docker Hub badge and Docker install link to README.md.
- Added API, Compose, and CLI docker run examples.
- Documented Docker image pull, file mounting, and stdin usage.
- Added host-port remapping guidance (7878:8080).
- Documented 0.0.0.0:8080 container binding.
- Added warnings that the serve API has no authentication.
- Recommended authentication, TLS, reverse proxy, or firewall controls.
- Used goptics/vizb and port 8080 consistently.

## Test Result
### /commands/serve
<img width="913" height="893" alt="Screenshot 2026-07-21 at 10 27 46 PM" src="https://github.com/user-attachments/assets/8628c274-e03f-4d98-b262-7b2c71f08b82" />

### /installation
<img width="824" height="736" alt="Screenshot 2026-07-21 at 10 28 01 PM" src="https://github.com/user-attachments/assets/6fb23338-f1c1-49c2-818f-3b7ca2631996" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Docker installation and usage instructions, including Docker Hub badge references and Docker/Compose examples.
  * Documented running the API via Docker, including host port remapping and guidance for local CLI use with mounted volumes and piped input.
  * Clarified that the `vizb serve` API is unauthenticated and should not be exposed publicly without additional security controls.
  * Updated the security guidance to emphasize network exposure and safer deployment considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->