### PR TITLE
ci: add cross-platform installer smoke tests

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -1,0 +1,70 @@
+name: Installers
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - install.sh
+      - install.ps1
+      - docs/public/install.sh
+      - docs/public/install.ps1
+
+permissions:
+  contents: read
+
+jobs:
+  linux-install:
+    name: Linux installer
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install vizb
+        run: bash docs/public/install.sh
+
+      - name: Verify installation
+        run: |
+          test -x "${HOME}/.local/bin/vizb"
+          "${HOME}/.local/bin/vizb" --version
+
+  macos-install:
+    name: macOS installer
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install vizb
+        run: bash docs/public/install.sh
+
+      - name: Verify installation
+        run: |
+          test -x "${HOME}/.local/bin/vizb"
+          "${HOME}/.local/bin/vizb" --version
+
+  windows-install:
+    name: Windows installer
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install vizb
+        shell: pwsh
+        run: ./docs/public/install.ps1
+
+      - name: Verify installation
+        shell: pwsh
+        run: |
+          $VizbPath = Join-Path $env:LOCALAPPDATA "vizb\vizb.exe"
+          if (-not (Test-Path -Path $VizbPath -PathType Leaf)) {
+              throw "vizb was not installed at $VizbPath"
+          }
+
+          & $VizbPath --version
+          if ($LASTEXITCODE -ne 0) {
+              throw "vizb --version failed with exit code $LASTEXITCODE"
+          }

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -2,7 +2,17 @@ name: Installers
 
 on:
   workflow_call:
+    inputs:
+      release_tag:
+        description: Release tag to install instead of the latest release
+        required: false
+        type: string
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to install instead of the latest release
+        required: false
+        type: string
   push:
     branches: [main]
     paths:
@@ -23,6 +33,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install vizb
+        env:
+          VIZB_RELEASE_TAG: ${{ inputs.release_tag }}
         run: bash docs/public/install.sh
 
       - name: Verify installation
@@ -38,6 +50,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install vizb
+        env:
+          VIZB_RELEASE_TAG: ${{ inputs.release_tag }}
         run: bash docs/public/install.sh
 
       - name: Verify installation
@@ -53,6 +67,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install vizb
+        env:
+          VIZB_RELEASE_TAG: ${{ inputs.release_tag }}
         shell: pwsh
         run: ./docs/public/install.ps1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
     uses: ./.github/workflows/installers.yml
     permissions:
       contents: read
+    with:
+      release_tag: ${{ github.ref_name }}
 
   winget:
     needs: goreleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
             **What will happen after approval:**
             - GoReleaser builds binaries for linux/darwin/windows (amd64 + arm64)
             - Release is published to GitHub Releases
+            - Linux, macOS, and Windows installers smoke-test the published release
             - A PR is auto-submitted to microsoft/winget-pkgs
             - Docs and live examples at https://vizb.goptics.org/examples/live/ are rebuilt and published
 
@@ -87,6 +88,13 @@ jobs:
           # lacks release scope (403 on POST /releases). Releases created with the
           # default token do not re-fire `on: release` workflows, so winget runs below.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  installers:
+    name: Installers
+    needs: goreleaser
+    uses: ./.github/workflows/installers.yml
+    permissions:
+      contents: read
 
   winget:
     needs: goreleaser

--- a/docs/public/install.ps1
+++ b/docs/public/install.ps1
@@ -25,19 +25,26 @@ $Bin = "vizb.exe"
 
 $ArchName = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { "arm64" }
 Log "detected windows/$ArchName"
-Log "fetching latest release..."
+$VersionTag = $env:VIZB_RELEASE_TAG
 
-$LatestUrl = "https://github.com/$Repo/releases/latest"
-$Request = [System.Net.WebRequest]::Create($LatestUrl)
-$Request.AllowAutoRedirect = $false
-$Response = $Request.GetResponse()
-$Redirect = $Response.GetResponseHeader("Location")
-$Response.Close()
-$VersionTag = $Redirect -replace '.*/', ''
+if (-not $VersionTag) {
+    Log "fetching latest release..."
+    $LatestUrl = "https://github.com/$Repo/releases/latest"
+    $Request = [System.Net.WebRequest]::Create($LatestUrl)
+    $Request.AllowAutoRedirect = $false
+    $Response = $Request.GetResponse()
+    $Redirect = $Response.GetResponseHeader("Location")
+    $Response.Close()
+    $VersionTag = $Redirect -replace '.*/', ''
+}
+
 $Version = $VersionTag -replace '^v', ''
 
 if (-not $Version) {
     LogError "failed to determine latest version"
+}
+if ($VersionTag -notmatch '^[A-Za-z0-9._+-]+$') {
+    LogError "invalid release tag: $VersionTag"
 }
 
 $Arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { "arm64" }

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -47,9 +47,10 @@ command -v tar >/dev/null 2>&1 || die "tar is required but not installed"
 
 # ----- fetch latest version -----
 log "fetching latest release..."
-LATEST=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
-  "https://github.com/${REPO}/releases/latest" \
-  | grep -oP '[^/]+(?=/?$)')
+LATEST_URL=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+  "https://github.com/${REPO}/releases/latest")
+LATEST_URL="${LATEST_URL%/}"
+LATEST="${LATEST_URL##*/}"
 if [[ -z "$LATEST" ]]; then
   die "failed to determine latest version"
 fi

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -46,19 +46,25 @@ command -v curl >/dev/null 2>&1 || die "curl is required but not installed"
 command -v tar >/dev/null 2>&1 || die "tar is required but not installed"
 
 # ----- fetch latest version -----
-log "fetching latest release..."
-LATEST_URL=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
-  "https://github.com/${REPO}/releases/latest")
-LATEST_URL="${LATEST_URL%/}"
-LATEST="${LATEST_URL##*/}"
-if [[ -z "$LATEST" ]]; then
+RELEASE_TAG="${VIZB_RELEASE_TAG:-}"
+if [[ -z "$RELEASE_TAG" ]]; then
+  log "fetching latest release..."
+  LATEST_URL=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+    "https://github.com/${REPO}/releases/latest")
+  LATEST_URL="${LATEST_URL%/}"
+  RELEASE_TAG="${LATEST_URL##*/}"
+fi
+if [[ -z "$RELEASE_TAG" ]]; then
   die "failed to determine latest version"
 fi
-VERSION="${LATEST#v}"
+case "$RELEASE_TAG" in
+  *[!A-Za-z0-9._+-]*) die "invalid release tag: $RELEASE_TAG" ;;
+esac
+VERSION="${RELEASE_TAG#v}"
 
 # ----- download & extract -----
 ARCHIVE="vizb@${VERSION}-${OS}-${ARCH}.tar.gz"
-URL="https://github.com/${REPO}/releases/download/${LATEST}/${ARCHIVE}"
+URL="https://github.com/${REPO}/releases/download/${RELEASE_TAG}/${ARCHIVE}"
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT


### PR DESCRIPTION
## Summary

- add a reusable installer workflow with independent Linux, macOS, and Windows jobs
- run the workflow manually, on installer-only pushes to `main`, and after GoReleaser publishes an approved release
- pass the exact release tag from the release pipeline so smoke tests verify the newly published artifacts
- execute the checked-in canonical installer on each OS and verify the installed binary with `--version`
- replace GNU-only `grep -P` parsing so `install.sh` works with the default macOS toolchain

## Validation

- `task format:check`
- `task test` — Go suite and 503 UI tests passed
- `task lint` — Go and UI lint/type checks passed
- `actionlint` on both changed workflows (ignoring the repository custom `ubuntu-slim` runner label)
- `act workflow_dispatch --input release_tag=v0.16.1 -W .github/workflows/installers.yml --job linux-install` — installed and verified vizb v0.16.1
- invalid release-tag path input is rejected before download
- `act` parsed the installer workflow as three independent jobs and placed the release installer call after GoReleaser

Closes #264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-platform installer smoke tests for Linux, macOS, and Windows during the release process.
  * Installer scripts now support pinning a specific release tag via `VIZB_RELEASE_TAG`.
* **Bug Fixes**
  * Improved “latest release” detection and validation to ensure downloads use the correct release tag.
  * Enhanced post-install verification with clearer failure reporting if the binary is missing or version checks fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->