### PR TITLE
fix(action): support title override for col-axis charts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
   name:
     description: "Dataset/benchmark name (-n flag)"
     default: "Comparisons"
+  title:
+    description: "Override the chart title when --col-axis produces one chart; independent of -n/--name, otherwise ignored (--title flag)"
+    default: ""
   description:
     description: "Dataset/benchmark description (-d flag)"
     default: ""
@@ -257,6 +260,7 @@ runs:
         [ -n "${{ inputs.tag }}" ] && VIZB_ARGS+=(--tag "${{ inputs.tag }}")
         [ -n "${{ inputs.id }}" ] && VIZB_ARGS+=(--id "${{ inputs.id }}")
         [ -n "${{ inputs.name }}" ] && VIZB_ARGS+=(-n "${{ inputs.name }}")
+        [ -n "${{ inputs.title }}" ] && VIZB_ARGS+=(--title "${{ inputs.title }}")
         [ -n "${{ inputs.description }}" ] && VIZB_ARGS+=(-d "${{ inputs.description }}")
         [ -n "${{ inputs.group }}" ] && VIZB_ARGS+=(-g "${{ inputs.group }}")
         [ -n "${{ inputs.group-pattern }}" ] && VIZB_ARGS+=(-p "${{ inputs.group-pattern }}")

--- a/docs/src/content/docs/ci-cd/github-action.mdx
+++ b/docs/src/content/docs/ci-cd/github-action.mdx
@@ -46,6 +46,7 @@ The action:
 | `bench-cmd` | `""` | **Deprecated:** use `cmd`. Honored only when `cmd` is empty. |
 | `bench-file` | `""` | **Deprecated:** use `file`. Honored only when `file` is empty. |
 | `name` | `"Comparisons"` | Dataset/benchmark name (`-n` flag). |
+| `title` | `""` | Override the chart title when `col-axis` produces one chart; independent of `name` (`--title` flag). |
 | `description` | `""` | Dataset/benchmark description (`-d` flag). |
 | `tag` | `""` | Tag/identifier for the dataset (`-t` flag). |
 | `group` | `""` | Column/field names merged into the group name; forwarded as `-g` (accepts space- or comma-separated, e.g. `name category region` or `name,category/region`); parsed by `-p`/`-r`. |


### PR DESCRIPTION
## Related Issue
Fixes #237 
Related PR #245

## Changes
- Added title input to action.yml
- Forwarded it as --title
- Documented it in the action reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `title` input to the GitHub Action for overriding the chart title when a single chart is generated.

* **Documentation**
  * Documented the new `title` input and clarified its distinction from the existing `name` input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->