### PR TITLE
feat: replace auto-value with independent auto col-axis

### DIFF
--- a/.github/workflows/math-and-3d-examples.yml
+++ b/.github/workflows/math-and-3d-examples.yml
@@ -28,38 +28,44 @@ jobs:
     strategy:
       matrix:
         include:
+          # Continuous coordinates require solo --select (auto-value removed).
           - id: 00-spiral-3d
             file: spiral-3d
             name: "Spiral 3D"
-            description: "Auto-value 3D spiral from x, y, z coordinates"
+            description: "3D spiral from x, y, z coordinates via --select"
+            select: x,y,z
             charts: line
             chart: "line:3d-rotate,3d-visualmap"
 
           - id: 01-noise-surface
             file: noise-surface
             name: "Noise Surface"
-            description: "Simplex noise height field on a 2D grid as continuous 3D"
+            description: "Simplex noise height field on a 2D grid as continuous 3D via --select x,y,z"
+            select: x,y,z
             charts: bar
             chart: "bar:3d-visualmap"
 
           - id: 02-noise-grid
             file: noise-grid
             name: "Noise Grid 21³"
-            description: "Simplex noise on a 3D voxel grid (21³) — position from x,y,z, color/size from value column"
+            description: "Simplex noise on a 3D voxel grid (21³) — position from --select x,y,z"
+            select: x,y,z
             charts: scatter
             chart: "scatter:3d-visualmap,3d-rotate"
 
           - id: 03-noise-grid-41
             file: noise-grid-41
             name: "Noise Grid 41³"
-            description: "ECharts simplex-noise scatter3D demo — full 41³ grid (0–40), orthographic camera, visualMap on value"
+            description: "ECharts simplex-noise scatter3D demo — full 41³ grid via --select x,y,z"
+            select: x,y,z
             charts: scatter
             chart: "scatter:3d-visualmap,3d-rotate"
 
           - id: 04-clusters
             file: clusters
             name: "Clusters"
-            description: "2D scatter — auto-value x,y cluster points with visualMap and symbol size 10"
+            description: "2D scatter — --select x,y cluster points with visualMap and symbol size 10"
+            select: x,y
             charts: scatter
             chart: "scatter:visualmap,symbol-size=10"
 
@@ -74,6 +80,7 @@ jobs:
           id: ${{ matrix.id }}
           name: ${{ matrix.name }}
           description: ${{ matrix.description }}
+          select: ${{ matrix.select }}
           charts: ${{ matrix.charts }}
           chart: ${{ matrix.chart }}
           output-json: ${{ matrix.id }}.json

--- a/.github/workflows/math-and-3d-examples.yml
+++ b/.github/workflows/math-and-3d-examples.yml
@@ -48,16 +48,16 @@ jobs:
           - id: 02-noise-grid
             file: noise-grid
             name: "Noise Grid 21³"
-            description: "Simplex noise on a 3D voxel grid (21³) — position from --select x,y,z"
-            select: x,y,z
+            description: "Simplex noise on a 3D voxel grid (21³) — position + visualMap via --select x,y,z,value"
+            select: x,y,z,value
             charts: scatter
             chart: "scatter:3d-visualmap,3d-rotate"
 
           - id: 03-noise-grid-41
             file: noise-grid-41
             name: "Noise Grid 41³"
-            description: "ECharts simplex-noise scatter3D demo — full 41³ grid via --select x,y,z"
-            select: x,y,z
+            description: "ECharts simplex-noise scatter3D demo — full 41³ grid via --select x,y,z,value"
+            select: x,y,z,value
             charts: scatter
             chart: "scatter:3d-visualmap,3d-rotate"
 

--- a/.github/workflows/tabular-data-examples.yml
+++ b/.github/workflows/tabular-data-examples.yml
@@ -53,7 +53,8 @@ jobs:
           - id: 03-house-price-area2
             file: house-price-area2
             name: "House Price vs Area"
-            description: "2D scatter — auto-value area/price with visualMap gradient (16k points, ECharts house-price demo)"
+            description: "2D scatter — --select area,price with visualMap gradient (16k points, ECharts house-price demo)"
+            select: area,price
             charts: scatter
             chart: "scatter:visualmap"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Notable changes to Vizb documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased]
+
+### Breaking
+
+- **Remove auto-value** — all-numeric CSV/JSON with no flags no longer maps the first 2–3 columns to continuous coordinate axes (and no longer auto-enables 3D or a 4th-column visualMap metric). Use explicit solo `--select x,y` or `--select x,y,z` for coordinate / continuous 3D charts.
+- **Auto col-axis x** — all-numeric tables with no flags now place every numeric column name on the **x** axis as series (one chart), equivalent to implicit `--col-axis x`.
+- **`--col-axis` / `-A` without group** — works alone; only **numeric** columns become series (non-numeric columns are ignored when col-axis is used without group). Still composes with `-g` / `-p` (e.g. `-g load -p y -A x`).
+- **REST `colAxis`** — top-level field on the convert request body (no longer under `grouping`).
+
 # [v0.16.1] - 2026-07-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adhere
 - **`--col-axis` / `-A` without group** — works alone; only **numeric** columns become series (non-numeric columns are ignored when col-axis is used without group). Still composes with `-g` / `-p` (e.g. `-g load -p y -A x`).
 - **REST `colAxis`** — top-level field on the convert request body (no longer under `grouping`).
 
+### Added
+
+- **Solo `--select` 4th metric column** — `--select x,y,z,value` (or `metric:value`) sets the visualMap metric for continuous value mode (e.g. noise-grid color/size).
+
 # [v0.16.1] - 2026-07-21
 
 ### Fixed

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ inputs:
     description: "Number unit: K, M, B, T (-N flag)"
     default: ""
   select:
-    description: "csv/json only: select value columns; optional rename with {label} (e.g. 'price{Unit price},count') (--select flag)"
+    description: "csv/json only: select columns; solo mode 2–4 cols x,y[,z][,metric] (e.g. 'x,y,z,value'); grouped mode numeric stats with optional {label} (--select flag)"
     default: ""
   col-axis:
     description: "csv/json: place numeric column names on this axis (n, x, y, or z) so all columns share one chart (--col-axis / -A flag). Works without group; only numeric columns become series. With group, target axis must not already be used by group-pattern."

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ inputs:
     description: "csv/json only: select value columns; optional rename with {label} (e.g. 'price{Unit price},count') (--select flag)"
     default: ""
   col-axis:
-    description: "csv/json + group: place numeric column names on this axis (n, x, y, or z) so all columns share one chart (--col-axis / -A flag). Requires group; target axis must not already be used by group-pattern."
+    description: "csv/json: place numeric column names on this axis (n, x, y, or z) so all columns share one chart (--col-axis / -A flag). Works without group; only numeric columns become series. With group, target axis must not already be used by group-pattern."
     default: ""
   json-path:
     description: "json only: select a nested array to chart via a jq-like dot path (e.g. '.data.results') (--json-path flag)"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -355,10 +355,18 @@ components:
           $ref: '#/components/schemas/UnitOptions'
         select:
           type: array
-          description: Structured column selections; each item is one select expression.
+          description: >
+            Column selections (same as CLI --select). With grouping or colAxis: numeric
+            stat columns (optional {label}). Solo: one expression of 2–4 columns —
+            x,y[,z][,metric] for continuous value mode (4th is visualMap metric), or
+            mixed category+value; repeatable 2-column dim,metric pairs for multi-stat.
           items:
             type: string
             minLength: 1
+          examples:
+            - ["region,latency"]
+            - ["x,y,z,value"]
+            - ["x:x,y:y,z:z,metric:value"]
         jsonPath:
           type: string
           description: JSON-only path to a nested array.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -142,10 +142,10 @@ components:
                 name: Q1 release
                 title: Framework throughput
                 parser: csv
+                colAxis: x
                 grouping:
                   pattern: y
                   columns: [load]
-                  colAxis: x
                 charts:
                   types: [bar]
             jsonHTMLConversion:
@@ -328,7 +328,11 @@ components:
           description: Dataset display name.
         title:
           type: string
-          description: Chart title used only when grouping.colAxis produces one chart; independent of name.
+          description: Chart title used only when colAxis produces one chart; independent of name.
+        colAxis:
+          type: string
+          enum: [n, x, y, z]
+          description: Place grouped numeric column names on this free axis so they share one chart.
         description:
           type: string
           description: Dataset description.
@@ -377,10 +381,6 @@ components:
           type: array
           items: { type: string, minLength: 1 }
         filter: { type: string }
-        colAxis:
-          type: string
-          enum: [n, x, y, z]
-          description: Place grouped numeric column names on this free axis so they share one chart.
     UnitOptions:
       type: object
       additionalProperties: false

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -332,7 +332,7 @@ components:
         colAxis:
           type: string
           enum: [n, x, y, z]
-          description: Place grouped numeric column names on this free axis so they share one chart.
+          description: Place numeric column names on this axis (optionally alongside grouping) so they share one chart.
         description:
           type: string
           description: Dataset description.

--- a/api/openapi_test.go
+++ b/api/openapi_test.go
@@ -198,7 +198,7 @@ func (s *OpenAPISuite) TestRootConversionContract() {
 	schemas := mustMap(t, components["schemas"], "components.schemas")
 	request := mustMap(t, schemas["ConvertRequest"], "components.schemas.ConvertRequest")
 	s.Equal(
-		[]string{"charts", "description", "grouping", "id", "input", "jsonPath", "name", "output", "parser", "select", "tag", "theme", "title", "units"},
+		[]string{"charts", "colAxis", "description", "grouping", "id", "input", "jsonPath", "name", "output", "parser", "select", "tag", "theme", "title", "units"},
 		propertyNames(t, request, "ConvertRequest"),
 	)
 	s.Equal([]string{"input"}, stringSliceValue(request["required"]))

--- a/cmd/charts/bar/bar.go
+++ b/cmd/charts/bar/bar.go
@@ -21,13 +21,6 @@ func init() {
 		Type:  "bar",
 		Use:   "bar [target]",
 		Short: "Generate a bar chart from data",
-		Long: `Generate an interactive bar chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.
-
-Continuous coordinates (value axes) require solo --select, e.g.:
-  vizb bar data.csv --select x,y,z -o out.html
-  vizb bar data.csv --select x,y,z,value --3d-visualmap -o out.html
-
-All-numeric files with no flags use auto col-axis x (column names as series),
-not continuous coordinates. Use -A / --col-axis for series-on-axis without --select.`,
+		Long:  cli.ContinuousSelectLong("bar"),
 	})
 }

--- a/cmd/charts/bar/bar.go
+++ b/cmd/charts/bar/bar.go
@@ -21,6 +21,12 @@ func init() {
 		Type:  "bar",
 		Use:   "bar [target]",
 		Short: "Generate a bar chart from data",
-		Long:  "Generate an interactive bar chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.",
+		Long: `Generate an interactive bar chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.
+
+Continuous coordinates (value axes) require solo --select, e.g.:
+  vizb bar data.csv --select x,y,z -o out.html
+
+All-numeric files with no flags use auto col-axis x (column names as series),
+not continuous coordinates. Use -A / --col-axis for series-on-axis without --select.`,
 	})
 }

--- a/cmd/charts/bar/bar.go
+++ b/cmd/charts/bar/bar.go
@@ -25,6 +25,7 @@ func init() {
 
 Continuous coordinates (value axes) require solo --select, e.g.:
   vizb bar data.csv --select x,y,z -o out.html
+  vizb bar data.csv --select x,y,z,value --3d-visualmap -o out.html
 
 All-numeric files with no flags use auto col-axis x (column names as series),
 not continuous coordinates. Use -A / --col-axis for series-on-axis without --select.`,

--- a/cmd/charts/line/line.go
+++ b/cmd/charts/line/line.go
@@ -18,13 +18,6 @@ func init() {
 		Type:  "line",
 		Use:   "line [target]",
 		Short: "Generate a line chart from data",
-		Long: `Generate an interactive line chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.
-
-Continuous coordinates (value axes) require solo --select, e.g.:
-  vizb line data.csv --select x,y,z -o out.html
-  vizb line data.csv --select x,y,z,value --3d-visualmap -o out.html
-
-All-numeric files with no flags use auto col-axis x (column names as series),
-not continuous coordinates. Use -A / --col-axis for series-on-axis without --select.`,
+		Long:  cli.ContinuousSelectLong("line"),
 	})
 }

--- a/cmd/charts/line/line.go
+++ b/cmd/charts/line/line.go
@@ -22,6 +22,7 @@ func init() {
 
 Continuous coordinates (value axes) require solo --select, e.g.:
   vizb line data.csv --select x,y,z -o out.html
+  vizb line data.csv --select x,y,z,value --3d-visualmap -o out.html
 
 All-numeric files with no flags use auto col-axis x (column names as series),
 not continuous coordinates. Use -A / --col-axis for series-on-axis without --select.`,

--- a/cmd/charts/line/line.go
+++ b/cmd/charts/line/line.go
@@ -18,6 +18,12 @@ func init() {
 		Type:  "line",
 		Use:   "line [target]",
 		Short: "Generate a line chart from data",
-		Long:  "Generate an interactive line chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.",
+		Long: `Generate an interactive line chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.
+
+Continuous coordinates (value axes) require solo --select, e.g.:
+  vizb line data.csv --select x,y,z -o out.html
+
+All-numeric files with no flags use auto col-axis x (column names as series),
+not continuous coordinates. Use -A / --col-axis for series-on-axis without --select.`,
 	})
 }

--- a/cmd/charts/scatter/scatter.go
+++ b/cmd/charts/scatter/scatter.go
@@ -22,6 +22,7 @@ func init() {
 
 Continuous coordinates (value axes) require solo --select, e.g.:
   vizb scatter data.csv --select x,y,z -o out.html
+  vizb scatter data.csv --select x,y,z,value --3d-visualmap -o out.html
 
 All-numeric files with no flags use auto col-axis x (column names as series),
 not continuous coordinates. Use -A / --col-axis for series-on-axis without --select.`,

--- a/cmd/charts/scatter/scatter.go
+++ b/cmd/charts/scatter/scatter.go
@@ -18,6 +18,12 @@ func init() {
 		Type:  "scatter",
 		Use:   "scatter [target]",
 		Short: "Generate a scatter chart from data",
-		Long:  "Generate an interactive scatter chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.",
+		Long: `Generate an interactive scatter chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.
+
+Continuous coordinates (value axes) require solo --select, e.g.:
+  vizb scatter data.csv --select x,y,z -o out.html
+
+All-numeric files with no flags use auto col-axis x (column names as series),
+not continuous coordinates. Use -A / --col-axis for series-on-axis without --select.`,
 	})
 }

--- a/cmd/charts/scatter/scatter.go
+++ b/cmd/charts/scatter/scatter.go
@@ -18,13 +18,6 @@ func init() {
 		Type:  "scatter",
 		Use:   "scatter [target]",
 		Short: "Generate a scatter chart from data",
-		Long: `Generate an interactive scatter chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.
-
-Continuous coordinates (value axes) require solo --select, e.g.:
-  vizb scatter data.csv --select x,y,z -o out.html
-  vizb scatter data.csv --select x,y,z,value --3d-visualmap -o out.html
-
-All-numeric files with no flags use auto col-axis x (column names as series),
-not continuous coordinates. Use -A / --col-axis for series-on-axis without --select.`,
+		Long:  cli.ContinuousSelectLong("scatter"),
 	})
 }

--- a/cmd/cli/command.go
+++ b/cmd/cli/command.go
@@ -6,6 +6,7 @@
 package cli
 
 import (
+	"fmt"
 	"slices"
 
 	internal_charts "github.com/goptics/vizb/internal/charts"
@@ -21,6 +22,19 @@ type ChartMeta struct {
 	Use   string
 	Short string
 	Long  string
+}
+
+// ContinuousSelectLong is shared Long help for bar/line/scatter: value axes need
+// solo --select; all-numeric no-flag input uses auto col-axis x.
+func ContinuousSelectLong(chart string) string {
+	return fmt.Sprintf(`Generate an interactive %s chart (HTML or JSON) from benchmark output or tabular CSV/JSON data.
+
+Continuous coordinates (value axes) require solo --select, e.g.:
+  vizb %s data.csv --select x,y,z -o out.html
+  vizb %s data.csv --select x,y,z,value --3d-visualmap -o out.html
+
+All-numeric files with no flags use auto col-axis x (column names as series),
+not continuous coordinates. Use -A / --col-axis for series-on-axis without --select.`, chart, chart, chart)
 }
 
 // chartMetas maps chart type to its cobra metadata. Populated by

--- a/cmd/cli/dataflags.go
+++ b/cmd/cli/dataflags.go
@@ -60,7 +60,7 @@ var DataFlags = []flags.Flag{
 	{Name: "select", Usage: "csv/json only: select columns (repeatable); solo mode: 2–3 cols per view as x,y[,z] axes (e.g. --select region,latency); grouped mode: numeric stat columns with optional {label}", Kind: flags.KindStringArray},
 	{
 		Name: "col-axis", Shorthand: "A", Kind: flags.KindString,
-		Usage:    "csv/json + group: place numeric column names on this axis (n, x, y, or z) so all columns share one chart",
+		Usage:    "csv/json: place numeric column names on this axis (n, x, y, or z) so all columns share one chart; works without -g; only numeric columns become series",
 		Label:    "col-axis",
 		ValidSet: []string{"n", "x", "y", "z"},
 	},

--- a/cmd/cli/dataflags.go
+++ b/cmd/cli/dataflags.go
@@ -57,7 +57,7 @@ var DataFlags = []flags.Flag{
 		ValidSet:   []string{"K", "M", "B", "T"},
 		Normalizer: strings.ToUpper,
 	},
-	{Name: "select", Usage: "csv/json only: select columns (repeatable); solo mode: 2–3 cols per view as x,y[,z] axes (e.g. --select region,latency); grouped mode: numeric stat columns with optional {label}", Kind: flags.KindStringArray},
+	{Name: "select", Usage: "csv/json only: select columns (repeatable); solo mode: 2–4 cols as x,y[,z][,metric] (e.g. --select x,y,z,value); grouped mode: numeric stat columns with optional {label}", Kind: flags.KindStringArray},
 	{
 		Name: "col-axis", Shorthand: "A", Kind: flags.KindString,
 		Usage:    "csv/json: place numeric column names on this axis (n, x, y, or z) so all columns share one chart; works without -g; only numeric columns become series",

--- a/cmd/cli/flagbag.go
+++ b/cmd/cli/flagbag.go
@@ -296,7 +296,9 @@ func (b *FlagBag) ParseConfig() parser.Config {
 	cfg.ColAxis = b.String("col-axis")
 	selectRaws := b.StringArray("select")
 	if len(selectRaws) > 0 {
-		if parser.IsExplicitGrouping(cfg) {
+		// Explicit grouping or col-axis: --select picks stat columns (series filter).
+		// Otherwise solo --select is coordinate/multi-stat view mode.
+		if parser.IsExplicitGrouping(cfg) || cfg.ColAxis != "" {
 			seen := map[string]bool{}
 			for _, raw := range selectRaws {
 				selected, err := parser.ParseSelectFlag(raw)
@@ -311,13 +313,15 @@ func (b *FlagBag) ParseConfig() parser.Config {
 					cfg.Select = append(cfg.Select, col)
 				}
 			}
-			groupSet := map[string]bool{}
-			for _, g := range parser.EffectiveGroupColumns(cfg) {
-				groupSet[g] = true
-			}
-			for _, col := range cfg.Select {
-				if groupSet[col.Source] {
-					shared.ExitWithError("column '"+col.Source+"' cannot be in both --select and --group", nil)
+			if parser.IsExplicitGrouping(cfg) {
+				groupSet := map[string]bool{}
+				for _, g := range parser.EffectiveGroupColumns(cfg) {
+					groupSet[g] = true
+				}
+				for _, col := range cfg.Select {
+					if groupSet[col.Source] {
+						shared.ExitWithError("column '"+col.Source+"' cannot be in both --select and --group", nil)
+					}
 				}
 			}
 		} else {

--- a/cmd/cli/flagbag_test.go
+++ b/cmd/cli/flagbag_test.go
@@ -103,6 +103,19 @@ func (s *FlagBagSuite) TestParseConfigMapsSelectSoloAxisMode() {
 	s.Equal("y", cfg.SelectViews[0].Columns[1].AxisKey)
 }
 
+func (s *FlagBagSuite) TestParseConfigMapsSelectValueMetricFourthColumn() {
+	cmd, bag := s.newCmdBag(slices.Clone(DataFlags))
+	s.Require().NoError(cmd.Flags().Set("select", "x,y,z,value{Noise}"))
+	cfg := bag.ParseConfig()
+	s.Require().Len(cfg.SelectViews, 1)
+	view := cfg.SelectViews[0]
+	s.Len(view.Columns, 3)
+	s.Equal("x", view.Columns[0].Source)
+	s.Equal("z", view.Columns[2].Source)
+	s.Equal("value", view.MetricSource)
+	s.Equal("Noise", view.MetricLabel)
+	s.Empty(cfg.Select)
+}
 func (s *FlagBagSuite) TestParseConfigMapsSelectParenTypeLabel() {
 	cmd, bag := s.newCmdBag(slices.Clone(DataFlags))
 	s.Require().NoError(cmd.Flags().Set("select", "region{Region},latency (Latency by Region)"))

--- a/cmd/cli/pipeline.go
+++ b/cmd/cli/pipeline.go
@@ -289,9 +289,7 @@ func prepareData(filePath, parserKey string, cfg parser.Config, titles ...string
 		if len(effectiveCfg.Group) > 0 || effectiveCfg.ColAxis != "" {
 			before := len(data)
 			data = shared.AggregateDataPoints(data)
-			if len(effectiveCfg.Group) > 0 {
-				logAggregationResult(before, len(data), effectiveCfg)
-			}
+			logAggregationResult(before, len(data), effectiveCfg)
 		} else {
 			data = shared.CollapseDataPointsByKey(data)
 		}
@@ -336,10 +334,15 @@ func logAggregationResult(before, after int, cfg parser.Config) {
 	fmt.Println(style.Info.Render(fmt.Sprintf("✅ %d grouped rows — all unique (no duplicates to sum)", after)))
 }
 
-// formatAggregationGroup describes the --group columns and dimension keys used
-// when collapsing duplicate CSV/JSON rows.
+// formatAggregationGroup describes group columns / col-axis used when summing rows.
 func formatAggregationGroup(cfg parser.Config) string {
 	cols := parser.EffectiveGroupColumns(cfg)
+	if len(cols) == 0 {
+		if cfg.ColAxis != "" {
+			return "via col-axis " + cfg.ColAxis
+		}
+		return "by row key"
+	}
 	colList := strings.Join(cols, ", ")
 	colPhrase := "by columns: " + colList
 	if len(cols) == 1 {

--- a/cmd/cli/pipeline.go
+++ b/cmd/cli/pipeline.go
@@ -247,7 +247,7 @@ func applyJSONPath(filePath, path string) string {
 }
 
 // prepareData parses input into data points, aggregating grouped csv/json rows.
-// The returned Config is the parser's effective config (auto-group/auto-value
+// The returned Config is the parser's effective config (auto-group / auto col-axis
 // mutations included) for aggregation and dataset assembly.
 func prepareData(filePath, parserKey string, cfg parser.Config, titles ...string) ([]shared.DataPoint, parser.Config, *shared.Meta) {
 	title := ""
@@ -283,19 +283,18 @@ func prepareData(filePath, parserKey string, cfg parser.Config, titles ...string
 		shared.ExitWithError(err.Error(), nil)
 	}
 
-	// CSV/JSON emit one DataPoint per row; when grouping is inactive, collapse rows
-	// that share the same (name, x, y, z) by appending stats (no sum/average).
-	if tabularParser(parserKey) && len(effectiveCfg.Group) == 0 {
-		data = shared.CollapseDataPointsByKey(data)
-	}
-
-	// CSV/JSON emit one DataPoint per row; when grouping is active, multiple rows
-	// can share the same (name, xAxis, yAxis, zAxis) key. Collapse them by summing
-	// so the output isn't a row-per-record dump. Benchmark parsers are excluded.
-	if tabularParser(parserKey) && len(effectiveCfg.Group) > 0 {
-		before := len(data)
-		data = shared.AggregateDataPoints(data)
-		logAggregationResult(before, len(data), effectiveCfg)
+	// CSV/JSON emit one DataPoint per row. Grouped rows and col-axis multi-stat
+	// sum by key; plain flat multi-column collapses without summing.
+	if tabularParser(parserKey) {
+		if len(effectiveCfg.Group) > 0 || effectiveCfg.ColAxis != "" {
+			before := len(data)
+			data = shared.AggregateDataPoints(data)
+			if len(effectiveCfg.Group) > 0 {
+				logAggregationResult(before, len(data), effectiveCfg)
+			}
+		} else {
+			data = shared.CollapseDataPointsByKey(data)
+		}
 	}
 
 	data, effectiveCfg, err = core.ApplyColAxis(data, effectiveCfg, parserKey, title)

--- a/cmd/cli/pipeline_test.go
+++ b/cmd/cli/pipeline_test.go
@@ -446,16 +446,25 @@ func (s *PipelineSuite) TestLogAggregationResultAllUnique() {
 	s.NotContains(out, "Aggregated into")
 }
 
-func (s *PipelineSuite) TestPrepareDataAutoValuePreservesMetric() {
-	csvFile := s.writeFile("grid.csv", "x,y,z,value\n0,0,0,4\n0,0,1,3.22\n0,1,0,3.28\n")
+func (s *PipelineSuite) TestPrepareDataAutoColAxisExpandsSeries() {
+	// All-numeric auto path: ColAxis=x, no MetricColumn; rows aggregate then expand.
+	csvFile := s.writeFile("grid.csv", "a,b\n1,2\n3,4\n")
 	cfg := parser.Config{AutoGroup: true, ChartTypes: []string{"scatter"}}
 
 	results, effectiveCfg, _ := prepareData(csvFile, "csv", cfg)
-	s.Equal("value", effectiveCfg.MetricColumn)
-	s.Require().Len(results, 3)
-	s.Equal("4", results[0].Metric)
-	s.Equal("3.22", results[1].Metric)
-	s.Equal("3.28", results[2].Metric)
+	s.Equal("x", effectiveCfg.ColAxis)
+	s.Empty(effectiveCfg.MetricColumn)
+	s.Empty(effectiveCfg.Axes)
+	// 2 rows × 2 cols → aggregate sums to one key, expand → 2 series points
+	s.Require().Len(results, 2)
+	byX := map[string]float64{}
+	for _, dp := range results {
+		s.Require().Len(dp.Stats, 1)
+		s.Empty(dp.Stats[0].Type)
+		byX[dp.XAxis] = *dp.Stats[0].Value
+	}
+	s.Equal(4.0, byX["a"]) // 1+3
+	s.Equal(6.0, byX["b"]) // 2+4
 }
 
 func (s *PipelineSuite) TestPrepareDataAutoGroupSkipsCollapseLogWhenAllUnique() {
@@ -1157,23 +1166,21 @@ func (s *PipelineSuite) TestPrepareDataColAxisSameAxisFatals() {
 	})
 }
 
-func (s *PipelineSuite) TestPrepareDataColAxisWithoutGroupWarnsAndSkips() {
-	// No -g and AutoGroup off → no Group; col-axis must warn+skip (multi-stat flat).
+func (s *PipelineSuite) TestPrepareDataColAxisWithoutGroupExpands() {
+	// No -g: col-axis still expands multi-column stats onto the free axis.
 	csvFile := s.writeFile("wide.csv", "a,b,c\n1,2,3\n")
 	cfg := parser.Config{ColAxis: "x"}
 
-	var results []shared.DataPoint
-	var effective parser.Config
-	errOut := testutil.CaptureStderr(func() {
-		results, effective, _ = prepareData(csvFile, "csv", cfg, "Framework throughput")
-	})
-	s.Contains(errOut, "--col-axis requires grouping")
-	s.Contains(errOut, "--title ignored")
-	s.Empty(effective.ColAxis) // cleared on skip
-	s.NotEmpty(results)
-	// Unexpanded: still multi-stat column types, not empty-type long form
-	s.Require().NotEmpty(results[0].Stats)
-	s.NotEmpty(results[0].Stats[0].Type)
+	results, effective, _ := prepareData(csvFile, "csv", cfg, "Framework throughput")
+	s.Equal("x", effective.ColAxis)
+	s.Require().Len(results, 3)
+	xVals := map[string]struct{}{}
+	for _, dp := range results {
+		s.Require().Len(dp.Stats, 1)
+		s.Equal("Framework throughput", dp.Stats[0].Type)
+		xVals[dp.XAxis] = struct{}{}
+	}
+	s.ElementsMatch([]string{"a", "b", "c"}, keysOf(xVals))
 }
 
 func (s *PipelineSuite) TestPrepareDataColAxisNonTabularWarns() {
@@ -1194,7 +1201,7 @@ func (s *PipelineSuite) TestPrepareDataColAxisNonTabularWarns() {
 }
 
 func (s *PipelineSuite) TestPrepareDataColAxisSelectModeSkips() {
-	// Solo value --select (not multi-stat group path): warn+skip.
+	// Solo value --select (coordinate mode): warn+skip.
 	csvFile := s.writeFile("vals.csv", "x,y\n1,2\n3,4\n")
 	cfg := parser.Config{
 		ColAxis: "z",
@@ -1212,29 +1219,94 @@ func (s *PipelineSuite) TestPrepareDataColAxisSelectModeSkips() {
 	errOut := testutil.CaptureStderr(func() {
 		results, effective, _ = prepareData(csvFile, "csv", cfg)
 	})
-	s.Contains(errOut, "requires grouped multi-column stats")
+	s.Contains(errOut, "not compatible with solo value/mixed --select")
 	s.Empty(effective.ColAxis)
 	s.NotEmpty(results)
 }
 
-func (s *PipelineSuite) TestPrepareDataMultiStatColAxisAndTitleWarnsAndKeepsSelectTitles() {
+func (s *PipelineSuite) TestPrepareDataMultiStatColAxisExpands() {
+	// Multi-stat solo --select + ColAxis: expand series onto the free axis.
 	csvFile := s.writeFile("stats.csv", "region,latency,sales\nWest,10,100\n")
-	cfg := parser.Config{ColAxis: "x", SelectViews: []parser.SelectView{
+	cfg := parser.Config{ColAxis: "n", SelectViews: []parser.SelectView{
 		{Columns: []parser.ColumnSpec{{Source: "region", AxisKey: "x"}, {Source: "latency", AxisKey: "y"}}, TypeLabel: "Latency by Region"},
 		{Columns: []parser.ColumnSpec{{Source: "region", AxisKey: "x"}, {Source: "sales", AxisKey: "y"}}, TypeLabel: "Sales by Region"},
 	}}
 	cfg.Mode = parser.ResolveMode(cfg)
 
-	var results []shared.DataPoint
-	var effective parser.Config
-	errOut := testutil.CaptureStderr(func() {
-		results, effective, _ = prepareData(csvFile, "csv", cfg, "Ignored title")
+	results, effective, _ := prepareData(csvFile, "csv", cfg, "Unified title")
+	s.Equal("n", effective.ColAxis)
+	s.Require().Len(results, 2)
+	names := map[string]float64{}
+	for _, dp := range results {
+		s.Require().Len(dp.Stats, 1)
+		s.Equal("Unified title", dp.Stats[0].Type)
+		names[dp.Name] = *dp.Stats[0].Value
+	}
+	s.Equal(10.0, names["Latency by Region"])
+	s.Equal(100.0, names["Sales by Region"])
+}
+
+func (s *PipelineSuite) TestPrepareDataColAxisSelectFiltersSeries() {
+	// -A x --select a,b without -g: select is a stat filter, then expand.
+	csvFile := s.writeFile("wide.csv", "a,b,c\n1,2,3\n4,5,6\n")
+	cfg := parser.Config{
+		ColAxis: "x",
+		Select:  []parser.ColumnSpec{{Source: "a"}, {Source: "b"}},
+	}
+
+	results, effective, _ := prepareData(csvFile, "csv", cfg)
+	s.Equal("x", effective.ColAxis)
+	s.Require().Len(results, 2)
+	byX := map[string]float64{}
+	for _, dp := range results {
+		s.Require().Len(dp.Stats, 1)
+		byX[dp.XAxis] = *dp.Stats[0].Value
+	}
+	s.Equal(5.0, byX["a"]) // 1+4
+	s.Equal(7.0, byX["b"]) // 2+5
+	_, hasC := byX["c"]
+	s.False(hasC)
+}
+
+func (s *PipelineSuite) TestPrepareDataColAxisMultiRowSums() {
+	// Multi-row all-numeric + ColAxis aggregates (sums) before expand.
+	csvFile := s.writeFile("nums.csv", "a,b\n10,20\n30,40\n")
+	cfg := parser.Config{ColAxis: "x"}
+
+	results, _, _ := prepareData(csvFile, "csv", cfg)
+	s.Require().Len(results, 2)
+	byX := map[string]float64{}
+	for _, dp := range results {
+		s.Require().Len(dp.Stats, 1)
+		byX[dp.XAxis] = *dp.Stats[0].Value
+	}
+	s.Equal(40.0, byX["a"])
+	s.Equal(60.0, byX["b"])
+}
+
+func (s *PipelineSuite) TestPrepareDataGroupPatternAndColAxisStillWorks() {
+	// Regression: -g load -p y -A x
+	csvFile := s.writeFile("concurrency.csv",
+		"load,default,chi\n100,1,2\n1000,3,4\n")
+	cfg, err := parser.ResolveGroupConfig(parser.Config{
+		GroupPattern: "y",
+		Group:        []string{"load"},
+		ColAxis:      "x",
 	})
-	s.Contains(errOut, "--col-axis requires grouped multi-column stats")
-	s.Contains(errOut, "--title ignored")
-	s.Empty(effective.ColAxis)
-	s.Require().Len(results, 1)
-	s.ElementsMatch([]string{"Latency by Region", "Sales by Region"}, []string{results[0].Stats[0].Type, results[0].Stats[1].Type})
+	s.Require().NoError(err)
+
+	results, effective, _ := prepareData(csvFile, "csv", cfg)
+	s.Equal("x", effective.ColAxis)
+	s.Require().Len(results, 4)
+	xVals := map[string]struct{}{}
+	yVals := map[string]struct{}{}
+	for _, dp := range results {
+		s.Require().Len(dp.Stats, 1)
+		xVals[dp.XAxis] = struct{}{}
+		yVals[dp.YAxis] = struct{}{}
+	}
+	s.ElementsMatch([]string{"default", "chi"}, keysOf(xVals))
+	s.ElementsMatch([]string{"100", "1000"}, keysOf(yVals))
 }
 
 func (s *PipelineSuite) TestPrepareDataColAxisZWithoutXYFatals() {

--- a/cmd/cli/pipeline_test.go
+++ b/cmd/cli/pipeline_test.go
@@ -699,6 +699,28 @@ func (s *PipelineSuite) TestAssembleDatasetAppendMetricAxisFromConfig() {
 	s.Equal("noise", ds.Axes[3].Label)
 }
 
+func (s *PipelineSuite) TestPrepareDataSelectValueModeWithMetric() {
+	csvFile := s.writeFile("noise.csv", "x,y,z,value\n0,0,0,4\n1,2,3,5.5\n")
+	view, err := parser.ParseSelectViewFlag("x,y,z,value{Noise}")
+	s.Require().NoError(err)
+	cfg := parser.Config{SelectViews: []parser.SelectView{view}}
+	cfg.Mode = parser.ResolveMode(cfg)
+
+	results, effective, _ := prepareData(csvFile, "csv", cfg)
+	s.Equal("value", effective.MetricColumn)
+	s.Require().Len(results, 2)
+	s.Equal("0", results[0].XAxis)
+	s.Equal("0", results[0].YAxis)
+	s.Equal("0", results[0].ZAxis)
+	s.Equal("4", results[0].Metric)
+	s.Equal("5.5", results[1].Metric)
+
+	ds := assembleDataset(results, RunMeta{Name: "Noise", Parser: "csv"}, []internal_charts.ChartConfig{
+		&scatterchart.Config{Type: "scatter"},
+	}, effective, nil)
+	s.Contains(axisKeyList(ds.Axes), "metric")
+	s.Equal("Noise", ds.Axes[len(ds.Axes)-1].Label)
+}
 func (s *PipelineSuite) TestAssembleDatasetSelectViewMixedAxes() {
 	results := []shared.DataPoint{{XAxis: "Asia", YAxis: "12", Stats: []shared.Stat{}}}
 	cfg := parser.Config{

--- a/cmd/cli/pipeline_test.go
+++ b/cmd/cli/pipeline_test.go
@@ -589,8 +589,8 @@ func (s *PipelineSuite) TestAssembleDatasetSetsID() {
 	s.Equal("bench-v1", ds.ID)
 }
 
-func (s *PipelineSuite) TestAssembleDatasetUsesAutoValueAxesFromData() {
-	// Auto-value path: Stats empty + axes populated → value-type axes
+func (s *PipelineSuite) TestAssembleDatasetUsesValueAxesFromSelect() {
+	// Solo value-mode path: Stats empty + axes populated → value-type axes
 	results := []shared.DataPoint{{XAxis: "100", YAxis: "12", ZAxis: "5", Stats: []shared.Stat{}}}
 	cfg := parser.Config{
 		AutoGroup: true,

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -23,7 +23,6 @@ type groupingOptions struct {
 	Regex   string   `json:"regex"`
 	Columns []string `json:"columns"`
 	Filter  string   `json:"filter"`
-	ColAxis *string  `json:"colAxis"`
 }
 
 type unitOptions struct {
@@ -62,6 +61,7 @@ type convertRequest struct {
 	ID          *string          `json:"id"`
 	Name        *string          `json:"name"`
 	Title       *string          `json:"title"`
+	ColAxis     *string          `json:"colAxis"`
 	Theme       *string          `json:"theme"`
 	Description *string          `json:"description"`
 	Tag         *string          `json:"tag"`
@@ -80,7 +80,7 @@ type convertOutput struct {
 
 func (r *convertRequest) UnmarshalJSON(data []byte) error {
 	if err := rejectNullFields(data, "/", map[string]string{
-		"id": "/id", "name": "/name", "title": "/title", "theme": "/theme", "description": "/description",
+		"id": "/id", "name": "/name", "title": "/title", "colAxis": "/colAxis", "theme": "/theme", "description": "/description",
 		"tag": "/tag", "parser": "/parser", "grouping": "/grouping", "units": "/units",
 		"select": "/select", "jsonPath": "/jsonPath", "charts": "/charts", "output": "/output",
 	}); err != nil {
@@ -98,7 +98,7 @@ func (r *convertRequest) UnmarshalJSON(data []byte) error {
 func (o *groupingOptions) UnmarshalJSON(data []byte) error {
 	if err := rejectNullFields(data, "/grouping", map[string]string{
 		"pattern": "/grouping/pattern", "regex": "/grouping/regex",
-		"columns": "/grouping/columns", "filter": "/grouping/filter", "colAxis": "/grouping/colAxis",
+		"columns": "/grouping/columns", "filter": "/grouping/filter",
 	}); err != nil {
 		return err
 	}
@@ -263,7 +263,7 @@ func conversionOptionValidationError(selection chartSelection, optionErr *core.O
 	case "grouping":
 		path = "/grouping"
 	case "colAxis":
-		path = "/grouping/colAxis"
+		path = "/colAxis"
 	case "jsonPath":
 		path = "/jsonPath"
 	case "select":
@@ -397,6 +397,14 @@ func buildConvertMetadata(request convertRequest) (core.Metadata, *apiValidation
 
 func buildParserConfig(request convertRequest, key string) (parser.Config, *apiValidationError) {
 	cfg := parser.Config{GroupPattern: "x", MemUnit: "B", TimeUnit: "ns", JSONPath: request.JSONPath}
+	// ColAxis is applied before grouping/select so select routing can see it.
+	if request.ColAxis != nil {
+		if !slices.Contains([]string{"n", "x", "y", "z"}, *request.ColAxis) {
+			validationErr := bodyValidationError("/colAxis", "invalid_enum", "colAxis must be one of n, x, y, or z")
+			return cfg, &validationErr
+		}
+		cfg.ColAxis = *request.ColAxis
+	}
 	if request.Grouping != nil {
 		if request.Grouping.Pattern != nil {
 			cfg.GroupPattern = *request.Grouping.Pattern
@@ -404,13 +412,6 @@ func buildParserConfig(request convertRequest, key string) (parser.Config, *apiV
 		cfg.GroupRegex = request.Grouping.Regex
 		cfg.Group = slices.Clone(request.Grouping.Columns)
 		cfg.Filter = request.Grouping.Filter
-		if request.Grouping.ColAxis != nil {
-			if !slices.Contains([]string{"n", "x", "y", "z"}, *request.Grouping.ColAxis) {
-				validationErr := bodyValidationError("/grouping/colAxis", "invalid_enum", "grouping colAxis must be one of n, x, y, or z")
-				return cfg, &validationErr
-			}
-			cfg.ColAxis = *request.Grouping.ColAxis
-		}
 	}
 	if err := parser.ValidateGroupPattern(cfg.GroupPattern); err != nil {
 		validationErr := bodyValidationError("/grouping/pattern", "invalid_value", err.Error())
@@ -476,7 +477,7 @@ func applySelectOptions(cfg *parser.Config, rawSelect []string) *apiValidationEr
 	if len(rawSelect) == 0 {
 		return nil
 	}
-	if parser.IsExplicitGrouping(*cfg) {
+	if parser.IsExplicitGrouping(*cfg) || cfg.ColAxis != "" {
 		seen := map[string]bool{}
 		for i, raw := range rawSelect {
 			if strings.TrimSpace(raw) == "" {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -432,6 +432,26 @@ func (s *ServeSuite) TestConvertEndpoint() {
 		s.Equal("Framework throughput", stats[0].(map[string]any)["type"])
 	}
 
+	// Solo select with 4th visualMap metric column (noise-grid shape).
+	recorder = s.apiRequest(
+		handler,
+		"/",
+		`{"input":"x,y,z,value\n0,0,0,4\n1,2,3,5.5\n","parser":"csv","select":["x,y,z,value"],"charts":{"types":["scatter"]}}`,
+		"application/json",
+		"application/json",
+	)
+	s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+	s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &dataset))
+	axes := dataset["axes"].([]any)
+	keys := make([]string, 0, len(axes))
+	for _, a := range axes {
+		keys = append(keys, a.(map[string]any)["key"].(string))
+	}
+	s.Contains(keys, "metric")
+	pts := dataset["data"].([]any)
+	s.Require().NotEmpty(pts)
+	s.Equal("4", pts[0].(map[string]any)["metric"])
+
 	documented := `{
 		"input":{"data":[{"region":"west","latency":12},{"region":"east","latency":18}]},
 		"parser":"auto",

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -420,7 +420,7 @@ func (s *ServeSuite) TestConvertEndpoint() {
 	recorder = s.apiRequest(
 		handler,
 		"/",
-		`{"input":"load,default,chi\n100,1,2\n","name":"Q1 release","title":"Framework throughput","parser":"csv","grouping":{"pattern":"y","columns":["load"],"colAxis":"x"},"charts":{"types":["bar"]}}`,
+		`{"input":"load,default,chi\n100,1,2\n","name":"Q1 release","title":"Framework throughput","parser":"csv","colAxis":"x","grouping":{"pattern":"y","columns":["load"]},"charts":{"types":["bar"]}}`,
 		"application/json",
 		"application/json",
 	)
@@ -524,8 +524,9 @@ func (s *ServeSuite) TestConvertEndpointRejectsInvalidRequests() {
 func (s *ServeSuite) TestConvertEndpointValidatesStructuredOptions() {
 	handler := newRESTHandler()
 	tests := []struct {
-		name string
-		body string
+		name     string
+		body     string
+		wantPath string
 	}{
 		{name: "invalid parser", body: `{"input":"x,y\na,1\n","parser":"xml"}`},
 		{name: "invalid group pattern", body: `{"input":"x,y\na,1\n","parser":"csv","grouping":{"pattern":"["}}`},
@@ -546,8 +547,11 @@ func (s *ServeSuite) TestConvertEndpointValidatesStructuredOptions() {
 		{name: "duplicate grouped select", body: `{"input":"region,value\nwest,1\n","parser":"csv","grouping":{"pattern":"x","columns":["region"]},"select":["value","value"]}`},
 		{name: "group select conflict", body: `{"input":"region,value\nwest,1\n","parser":"csv","grouping":{"pattern":"x","columns":["region"]},"select":["region"]}`},
 		{name: "structured grouping separator mismatch", body: `{"input":"a,b,c\nx,y,1\n","grouping":{"pattern":"x,y,z","columns":["a/b/c"]}}`},
-		{name: "invalid col axis", body: `{"input":"load,a,b\n100,1,2\n","parser":"csv","grouping":{"pattern":"y","columns":["load"],"colAxis":"value"}}`},
-		{name: "title without col axis", body: `{"input":"load,a,b\n100,1,2\n","parser":"csv","title":"Ignored"}`},
+		{name: "invalid col axis", body: `{"input":"load,a,b\n100,1,2\n","parser":"csv","grouping":{"pattern":"y","columns":["load"]},"colAxis":"value"}`, wantPath: "/colAxis"},
+		{name: "nested grouping colAxis unknown", body: `{"input":"load,a,b\n100,1,2\n","parser":"csv","grouping":{"pattern":"y","columns":["load"],"colAxis":"x"}}`, wantPath: "/grouping/colAxis"},
+		{name: "null col axis", body: `{"input":"load,a,b\n100,1,2\n","parser":"csv","colAxis":null}`, wantPath: "/colAxis"},
+		// Mixed/auto-group has no col-axis; all-numeric auto-sets colAxis=x so title would apply.
+		{name: "title without col axis", body: `{"input":"region,a,b\nWest,1,2\n","parser":"csv","title":"Ignored"}`},
 		{name: "empty chart types", body: `{"input":"x,y\na,1\n","charts":{"types":[]}}`},
 		{name: "duplicate chart types", body: `{"input":"x,y\na,1\n","charts":{"types":["bar","bar"]}}`},
 		{name: "missing config type", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"showLabels":true}]}}`},
@@ -578,6 +582,9 @@ func (s *ServeSuite) TestConvertEndpointValidatesStructuredOptions() {
 			}
 			s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &problem))
 			s.NotEmpty(problem.Errors)
+			if test.wantPath != "" {
+				s.Equal(test.wantPath, problem.Errors[0].Path)
+			}
 		})
 	}
 }
@@ -961,7 +968,7 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 		}{
 			{name: "filter", path: "/grouping/filter"},
 			{name: "grouping", path: "/grouping"},
-			{name: "colAxis", path: "/grouping/colAxis"},
+			{name: "colAxis", path: "/colAxis"},
 			{name: "jsonPath", path: "/jsonPath"},
 			{name: "select", path: "/select"},
 			{name: "title", path: "/title"},
@@ -1006,8 +1013,9 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 		}{
 			{name: "null convert field", raw: `{"theme":null}`, target: new(convertRequest), path: "/theme"},
 			{name: "null title", raw: `{"title":null}`, target: new(convertRequest), path: "/title"},
-			{name: "null col axis", raw: `{"colAxis":null}`, target: new(groupingOptions), path: "/grouping/colAxis"},
+			{name: "null col axis", raw: `{"colAxis":null}`, target: new(convertRequest), path: "/colAxis"},
 			{name: "unknown grouping field", raw: `{"unexpected":true}`, target: new(groupingOptions), path: "/grouping/unexpected"},
+			{name: "nested grouping colAxis", raw: `{"colAxis":"x"}`, target: new(groupingOptions), path: "/grouping/colAxis"},
 			{name: "null unit field", raw: `{"memory":null}`, target: new(unitOptions), path: "/units/memory"},
 			{name: "unknown unit field", raw: `{"unexpected":true}`, target: new(unitOptions), path: "/units/unexpected"},
 		} {

--- a/docs/src/content/docs/charts/3d.mdx
+++ b/docs/src/content/docs/charts/3d.mdx
@@ -7,7 +7,7 @@ import { CardGrid, Card, Aside, LinkCard } from '@astrojs/starlight/components';
 
 vizb supports three 3D modes for **bar**, **line**, and **scatter** charts. Both render in a WebGL scene you can rotate, zoom, and pan in the browser. Other chart types (pie, radar, heatmap) receive z-axis data differently — they don't render a 3D scene.
 
-**Scatter** also supports continuous 3D from auto-value (all-numeric columns, no flags). Bar and line do the same when the data has 3+ numeric columns. See the [Scatter Chart](/charts/scatter) page for auto-value mode.
+**Scatter**, **bar**, and **line** also support continuous 3D when solo `--select` names three numeric columns (e.g. `--select x,y,z`). Bare all-numeric files use auto col-axis instead — not continuous coordinates. See the [Scatter Chart](/charts/scatter) page.
 
 ## Three 3D Modes
 
@@ -15,7 +15,7 @@ vizb supports three 3D modes for **bar**, **line**, and **scatter** charts. Both
 |------|---------------|-----------|-----------|------------|
 | **Grouped** | Add `z` to `--group-pattern` / `--group-regex` | categories | categories | metric value (stacked per z group) |
 | **Value (pseudo-3D)** | `vizb bar` / `vizb line` / `vizb scatter` with `--3d` on x+y-only data | categories | categories (former 2D legend) | metric value (single series, visualMap) |
-| **Value (continuous 3D)** | All-numeric CSV/JSON with 3+ columns (auto-value) | numeric | numeric | numeric |
+| **Value (continuous 3D)** | Solo `--select` with 3 numeric columns (e.g. `--select x,y,z`) | numeric | numeric | numeric |
 
 Grouped 3D takes precedence: if your data already has a z dimension, `--3d` is ignored.
 
@@ -95,24 +95,21 @@ The HTML bundles **3D view** and **3D visual map** toggles in settings (both on 
   `--3d` on `vizb bar` / `vizb line` is separate from `vizb ui --3d`, which only opts in to bundling the 3D engine for remote `--data-url` pages.
 </Aside>
 
-## Continuous 3D (auto-value)
+## Continuous 3D (solo `--select`)
 
-When your CSV/JSON data has 3+ numeric columns, auto-value renders continuous 3D — no `--3d` flag needed. This works on bar, line, and scatter:
+Pass solo `--select` with **three numeric columns** for continuous 3D — no `--3d` flag needed. This works on bar, line, and scatter. Bare all-numeric files do **not** enter this mode (they use [auto col-axis x](/guides/group-vs-select#auto-col-axis-all-numeric-data)).
 
 ```bash
-# All-numeric CSV — auto-detects x, y, z → bar3D
-vizb bar spiral.csv -o bar.html
+# Explicit value axes → continuous bar3D / line3D / scatter3D
+vizb bar spiral.csv --select x,y,z -o bar.html
+vizb line spiral.csv --select x,y,z -o line.html
+vizb scatter spiral.csv --select x,y,z -o scatter.html
 
-# Same for line and scatter
-vizb line spiral.csv -o line.html
-vizb scatter spiral.csv -o scatter.html
+# Two columns stays 2D
+vizb scatter spiral.csv --select x,y -o scatter2d.html
 ```
 
-See [Group vs Select → Auto-value](/guides/group-vs-select#auto-value-all-numeric-data) for the full inference rules. In short: 3 coordinate columns auto-enable 3D, and solo `--select` (or limiting it to 2 columns) keeps the chart 2D.
-
-When a CSV/JSON has **four** numeric columns, vizb treats the first three as `x`, `y`, `z` positions and the fourth as a **visual metric** — `3d-visualmap` is enabled automatically so point color and size follow the metric.
-
-Continuous 3D uses the same WebGL scene as grouped 3D — rotate, zoom, pan, and the auto-rotate toggle all apply.
+See [Select](/guides/select) for value-mode rules. Continuous 3D uses the same WebGL scene as grouped 3D — rotate, zoom, pan, and the auto-rotate toggle all apply.
 
 ## 3D Chart Types
 
@@ -126,7 +123,7 @@ Continuous 3D uses the same WebGL scene as grouped 3D — rotate, zoom, pan, and
     individual points stay readable.
   </Card>
   <Card title="3D Scatter" icon="magnifier">
-    `scatter3D` points — grouped z series or auto-value continuous coordinates.
+    `scatter3D` points — grouped z series or continuous coordinates via solo `--select`.
   </Card>
 </CardGrid>
 

--- a/docs/src/content/docs/charts/3d.mdx
+++ b/docs/src/content/docs/charts/3d.mdx
@@ -97,7 +97,7 @@ The HTML bundles **3D view** and **3D visual map** toggles in settings (both on 
 
 ## Continuous 3D (solo `--select`)
 
-Pass solo `--select` with **three numeric columns** for continuous 3D — no `--3d` flag needed. This works on bar, line, and scatter. Bare all-numeric files do **not** enter this mode (they use [auto col-axis x](/guides/group-vs-select#auto-col-axis-all-numeric-data)).
+Pass solo `--select` with **three numeric columns** for continuous 3D — no `--3d` flag needed. This works on bar, line, and scatter. An optional **fourth** column is the visualMap metric (e.g. noise-grid `value`). Bare all-numeric files do **not** enter this mode (they use [auto col-axis x](/guides/group-vs-select#auto-col-axis-all-numeric-data)).
 
 ```bash
 # Explicit value axes → continuous bar3D / line3D / scatter3D (solo --select required)
@@ -107,6 +107,9 @@ vizb scatter examples/csv/spiral-3d.csv --select x,y,z -o scatter.html
 
 # Noise height field as continuous bar3D
 vizb bar examples/csv/noise-surface.csv --select x,y,z --3d-visualmap -o surface.html
+
+# Voxel grid: position x,y,z + visualMap metric from value
+vizb scatter examples/csv/noise-grid.csv --select x,y,z,value --3d-visualmap -o noise.html
 
 # Two columns stays 2D
 vizb scatter examples/csv/spiral-3d.csv --select x,y -o scatter2d.html

--- a/docs/src/content/docs/charts/3d.mdx
+++ b/docs/src/content/docs/charts/3d.mdx
@@ -100,13 +100,16 @@ The HTML bundles **3D view** and **3D visual map** toggles in settings (both on 
 Pass solo `--select` with **three numeric columns** for continuous 3D — no `--3d` flag needed. This works on bar, line, and scatter. Bare all-numeric files do **not** enter this mode (they use [auto col-axis x](/guides/group-vs-select#auto-col-axis-all-numeric-data)).
 
 ```bash
-# Explicit value axes → continuous bar3D / line3D / scatter3D
-vizb bar spiral.csv --select x,y,z -o bar.html
-vizb line spiral.csv --select x,y,z -o line.html
-vizb scatter spiral.csv --select x,y,z -o scatter.html
+# Explicit value axes → continuous bar3D / line3D / scatter3D (solo --select required)
+vizb bar examples/csv/spiral-3d.csv --select x,y,z -o bar.html
+vizb line examples/csv/spiral-3d.csv --select x,y,z -o line.html
+vizb scatter examples/csv/spiral-3d.csv --select x,y,z -o scatter.html
+
+# Noise height field as continuous bar3D
+vizb bar examples/csv/noise-surface.csv --select x,y,z --3d-visualmap -o surface.html
 
 # Two columns stays 2D
-vizb scatter spiral.csv --select x,y -o scatter2d.html
+vizb scatter examples/csv/spiral-3d.csv --select x,y -o scatter2d.html
 ```
 
 See [Select](/guides/select) for value-mode rules. Continuous 3D uses the same WebGL scene as grouped 3D — rotate, zoom, pan, and the auto-rotate toggle all apply.

--- a/docs/src/content/docs/charts/bar.mdx
+++ b/docs/src/content/docs/charts/bar.mdx
@@ -73,26 +73,46 @@ vizb bar sales.csv -g order_date,category -p "[-y{Month}-x{Date}],z{Category}" -
 
 ## `--select` (csv/json)
 
-`--select` is **repeatable** (csv/json only). With explicit `-g` / `-p` / `-r`, it picks which numeric columns get their own chart (optional `{label}` renames each chart). Without group, it switches to solo value / mixed / multi-stat modes that plot raw columns as coordinate axes.
+`--select` is **repeatable** (csv/json only). Two different jobs, depending on grouping:
+
+| Context | What `--select` does |
+|---------|----------------------|
+| **With** `-g` / `-r` / non-default `-p` | Picks which **numeric** columns get their own chart (optional `{label}` renames each chart) |
+| **Without** group (and without `-A`) | Solo **value / mixed** mode — 2–3 columns become continuous coordinate axes (`x,y` or `x,y,z`) |
 
 ```bash
+# Grouped: only amount and total become charts
 vizb bar sales.csv -g region,product -p x,y --select amount,total -o bars.html
+
+# Continuous coordinates (all-numeric columns as x, y, z — not series names)
+vizb bar examples/csv/noise-surface.csv --select x,y,z -o surface.html --3d-visualmap
+
+# Continuous 3D spiral as bars
+vizb bar examples/csv/spiral-3d.csv --select x,y,z -o spiral.html
 ```
 
 See [Select](/guides/select) for the full mode reference, and [Group vs Select](/guides/group-vs-select) for when to use each.
 
 ## All-numeric data
 
-With no flags, an all-numeric CSV/JSON file uses **auto col-axis x** — every numeric column name becomes a series on X (one chart). For continuous coordinate / continuous 3D bars, pass explicit solo `--select`:
+Bare all-numeric CSV/JSON (no flags) uses **auto col-axis x** — every **numeric column name** becomes a series on X (one chart). That is **not** continuous coordinates.
+
+For continuous coordinate bars (including continuous 3D), always pass **solo `--select`**:
 
 ```bash
-# Continuous 3D value bars from x, y, z columns
-./bin/vizb bar noise-surface.csv --select x,y,z -o surface.html --3d-visualmap
+# Wide metrics as series on X (same as auto col-axis x)
+vizb bar metrics.csv -A x -o series.html
+
+# Continuous 3D value bars — position from columns x, y, z
+vizb bar examples/csv/noise-surface.csv --select x,y,z -o surface.html --3d-visualmap
+
+# Continuous 3D spiral
+vizb bar examples/csv/spiral-3d.csv --select x,y,z --3d-rotate -o spiral.html
 ```
 
 See [Auto col-axis](/guides/group-vs-select#auto-col-axis-all-numeric-data) and [Select](/guides/select).
 
-<DocImage src={bar3DValue} alt="3D bar chart with value-type bars along the Z axis" />
+<DocImage src={bar3DValue} alt="3D bar chart with value-type bars along continuous x, y, z coordinates" />
 
 ## Settings
 

--- a/docs/src/content/docs/charts/bar.mdx
+++ b/docs/src/content/docs/charts/bar.mdx
@@ -78,7 +78,7 @@ vizb bar sales.csv -g order_date,category -p "[-y{Month}-x{Date}],z{Category}" -
 | Context | What `--select` does |
 |---------|----------------------|
 | **With** `-g` / `-r` / non-default `-p` | Picks which **numeric** columns get their own chart (optional `{label}` renames each chart) |
-| **Without** group (and without `-A`) | Solo **value / mixed** mode — 2–3 columns become continuous coordinate axes (`x,y` or `x,y,z`) |
+| **Without** group (and without `-A`) | Solo **value / mixed** mode — 2–3 spatial axes (`x,y` or `x,y,z`); optional 4th = visualMap metric |
 
 ```bash
 # Grouped: only amount and total become charts

--- a/docs/src/content/docs/charts/bar.mdx
+++ b/docs/src/content/docs/charts/bar.mdx
@@ -81,13 +81,16 @@ vizb bar sales.csv -g region,product -p x,y --select amount,total -o bars.html
 
 See [Select](/guides/select) for the full mode reference, and [Group vs Select](/guides/group-vs-select) for when to use each.
 
-## Auto-value mode (all-numeric data)
+## All-numeric data
 
-On an all-numeric CSV/JSON file, vizb auto-detects the first 2–3 columns as coordinate axes and renders value-type bars — with 3+ columns it auto-enables 3D (`bar3D`). See [Auto-value](/guides/group-vs-select#auto-value-all-numeric-data) for the inference rules; solo `--select` overrides it.
+With no flags, an all-numeric CSV/JSON file uses **auto col-axis x** — every numeric column name becomes a series on X (one chart). For continuous coordinate / continuous 3D bars, pass explicit solo `--select`:
 
 ```bash
-./bin/vizb bar noise-surface.csv -o surface.html --3d-visualmap
+# Continuous 3D value bars from x, y, z columns
+./bin/vizb bar noise-surface.csv --select x,y,z -o surface.html --3d-visualmap
 ```
+
+See [Auto col-axis](/guides/group-vs-select#auto-col-axis-all-numeric-data) and [Select](/guides/select).
 
 <DocImage src={bar3DValue} alt="3D bar chart with value-type bars along the Z axis" />
 

--- a/docs/src/content/docs/charts/index.mdx
+++ b/docs/src/content/docs/charts/index.mdx
@@ -17,7 +17,7 @@ Vizb folds the same **x/y/z dimension model** into every chart type — you desc
     Track trends across X-axis values. One line per Y-series in 2D; switches to WebGL line3D with a z-axis.
   </Card>
   <Card title="Scatter Chart" icon="magnifier" href="/charts/scatter">
-    Plot individual points in 2D or 3D. Grouped categories or auto-value from all-numeric columns.
+    Plot individual points in 2D or 3D. Grouped categories or solo `--select` continuous coordinates.
   </Card>
   <Card title="Pie Chart" icon="puzzle" href="/charts/pie">
     Show proportional distribution. Scales from one pie (1D) to two side-by-side (2D) to three pies (3D).
@@ -44,9 +44,9 @@ Pie and radar have no cartesian axes, but the same `-p` pattern governs how many
 
 | Chart | 1D (`-p x`) | 2D (`-p x,y` / `-p x/y`) | 3D (`-p x,y,z` / `-p x/y/z`) |
 |-------|--------------|----------------|------------------|
-| **Bar** | Single bar series over X | Grouped bars, one series per Y value; or auto-value (all-numeric) | WebGL bar3D — Z stacked per (X, Y) cell; or auto-value continuous 3D |
-| **Line** | Single line over X | One line per Y value across X; or auto-value (all-numeric) | WebGL line3D — sparse points per Z; or auto-value continuous 3D |
-| **Scatter** | One point per X | One series per Y value across X; or auto-value (all-numeric) | WebGL scatter3D — points per Z; or auto-value continuous 3D |
+| **Bar** | Single bar series over X | Grouped bars, one series per Y value; or col-axis / solo `--select` | WebGL bar3D — Z stacked per (X, Y) cell; or continuous 3D via `--select x,y,z` |
+| **Line** | Single line over X | One line per Y value across X; or col-axis / solo `--select` | WebGL line3D — sparse points per Z; or continuous 3D via `--select x,y,z` |
+| **Scatter** | One point per X | One series per Y value across X; or col-axis / solo `--select` | WebGL scatter3D — points per Z; or continuous 3D via `--select x,y,z` |
 | **Pie** | One pie (X = slices) | Two pies side-by-side (By X / By Y) | Three pies (By X / By Y / By Z) |
 | **Radar** | One polygon, X = spokes, value = stat total | One polygon per X, Y = spokes, legend = X | One polygon per Z, X = data points, Y = spokes |
 | **Heatmap** | n/a — needs at least X + Y | Matrix X × Y, single-series gradient | Same matrix; cell = Σ z, color blends z palette |

--- a/docs/src/content/docs/charts/line.mdx
+++ b/docs/src/content/docs/charts/line.mdx
@@ -87,13 +87,15 @@ vizb line sales.csv -g region,product -p x,y --select latency,sales -o lines.htm
 
 See [Select](/guides/select) for the full mode reference, and [Group vs Select](/guides/group-vs-select) for when to use each.
 
-## Auto-value mode (all-numeric data)
+## All-numeric data
 
-On an all-numeric CSV/JSON file, vizb auto-detects the first 2–3 columns as coordinate axes and renders value-type lines — with 3+ columns it auto-enables 3D (`line3D`). See [Auto-value](/guides/group-vs-select#auto-value-all-numeric-data) for the inference rules; solo `--select` overrides it.
+With no flags, an all-numeric CSV/JSON file uses **auto col-axis x** — every numeric column name becomes a series on X (one chart). For continuous coordinate / continuous 3D lines, pass explicit solo `--select`:
 
 ```bash
-vizb line spiral-3d.csv -o line.html --3d-visualmap --3d-rotate
+vizb line spiral-3d.csv --select x,y,z -o line.html --3d-visualmap --3d-rotate
 ```
+
+See [Auto col-axis](/guides/group-vs-select#auto-col-axis-all-numeric-data) and [Select](/guides/select).
 
 <DocImage src={line2DValue} alt="2D value-type line chart plotting x and y coordinates from numeric columns" />
 

--- a/docs/src/content/docs/charts/line.mdx
+++ b/docs/src/content/docs/charts/line.mdx
@@ -79,20 +79,38 @@ vizb line worker-pools.txt -p z/y/x --scale log -o out.html
 
 ## `--select` (csv/json)
 
-`--select` is **repeatable** (csv/json only). With explicit `-g` / `-p` / `-r`, it picks which numeric columns get their own chart (optional `{label}` renames each chart). Without group, it switches to solo value / mixed / multi-stat modes that plot raw columns as coordinate axes.
+`--select` is **repeatable** (csv/json only). Two different jobs, depending on grouping:
+
+| Context | What `--select` does |
+|---------|----------------------|
+| **With** `-g` / `-r` / non-default `-p` | Picks which **numeric** columns get their own chart (optional `{label}` renames each chart) |
+| **Without** group (and without `-A`) | Solo **value / mixed** mode — 2–3 columns become continuous coordinate axes (`x,y` or `x,y,z`) |
 
 ```bash
+# Grouped: only latency and sales become charts
 vizb line sales.csv -g region,product -p x,y --select latency,sales -o lines.html
+
+# Continuous coordinates (all-numeric columns as x, y, z — not series names)
+vizb line examples/csv/spiral-3d.csv --select x,y,z -o line.html --3d-visualmap --3d-rotate
 ```
 
 See [Select](/guides/select) for the full mode reference, and [Group vs Select](/guides/group-vs-select) for when to use each.
 
 ## All-numeric data
 
-With no flags, an all-numeric CSV/JSON file uses **auto col-axis x** — every numeric column name becomes a series on X (one chart). For continuous coordinate / continuous 3D lines, pass explicit solo `--select`:
+Bare all-numeric CSV/JSON (no flags) uses **auto col-axis x** — every **numeric column name** becomes a series on X (one chart). That is **not** continuous coordinates.
+
+For continuous coordinate lines (including continuous 3D), always pass **solo `--select`**:
 
 ```bash
-vizb line spiral-3d.csv --select x,y,z -o line.html --3d-visualmap --3d-rotate
+# Wide metrics as series on X (same as auto col-axis x)
+vizb line metrics.csv -A x -o series.html
+
+# Continuous 3D spiral
+vizb line examples/csv/spiral-3d.csv --select x,y,z -o line.html --3d-visualmap --3d-rotate
+
+# Continuous noise surface as lines
+vizb line examples/csv/noise-surface.csv --select x,y,z -o surface.html
 ```
 
 See [Auto col-axis](/guides/group-vs-select#auto-col-axis-all-numeric-data) and [Select](/guides/select).

--- a/docs/src/content/docs/charts/line.mdx
+++ b/docs/src/content/docs/charts/line.mdx
@@ -84,7 +84,7 @@ vizb line worker-pools.txt -p z/y/x --scale log -o out.html
 | Context | What `--select` does |
 |---------|----------------------|
 | **With** `-g` / `-r` / non-default `-p` | Picks which **numeric** columns get their own chart (optional `{label}` renames each chart) |
-| **Without** group (and without `-A`) | Solo **value / mixed** mode — 2–3 columns become continuous coordinate axes (`x,y` or `x,y,z`) |
+| **Without** group (and without `-A`) | Solo **value / mixed** mode — 2–3 spatial axes (`x,y` or `x,y,z`); optional 4th = visualMap metric |
 
 ```bash
 # Grouped: only latency and sales become charts

--- a/docs/src/content/docs/charts/scatter.mdx
+++ b/docs/src/content/docs/charts/scatter.mdx
@@ -93,10 +93,10 @@ All-numeric files with no flags use **auto col-axis x**, not continuous coordina
 
 ```bash
 # 2D value scatter from x, y
-vizb scatter clusters.csv --select x,y --visualmap --symbol-size 10 -o scatter.html
+vizb scatter examples/csv/clusters.csv --select x,y --visualmap --symbol-size 10 -o scatter.html
 
 # 3D value scatter from x, y, z
-vizb scatter spiral-3d.csv --select x,y,z -o scatter.html
+vizb scatter examples/csv/spiral-3d.csv --select x,y,z -o scatter.html
 ```
 
 <DocImage src={scatter2DValue} alt="2D value-mode scatter chart of cluster coordinates with visualMap gradient coloring" />
@@ -130,10 +130,10 @@ vizb scatter data.csv -g category,metric --scale log -l -o out.html
 vizb scatter region-metrics.csv --select region,latency --scale log -o out.html
 
 # Cluster scatter with visualMap and diamond markers
-vizb scatter clusters.csv --select x,y --visualmap --symbol diamond --symbol-size 10 -o out.html
+vizb scatter examples/csv/clusters.csv --select x,y --visualmap --symbol diamond --symbol-size 10 -o out.html
 
 # 3D spiral with auto-rotate
-vizb scatter spiral.csv --select x,y,z --3d-rotate -o out.html
+vizb scatter examples/csv/spiral-3d.csv --select x,y,z --3d-rotate -o out.html
 ```
 
 ## Next Steps

--- a/docs/src/content/docs/charts/scatter.mdx
+++ b/docs/src/content/docs/charts/scatter.mdx
@@ -1,6 +1,6 @@
 ---
 title: Scatter Chart
-description: Plot individual points in 2D or 3D — grouped categories, solo --select axis mode, or auto-value from all-numeric columns.
+description: Plot individual points in 2D or 3D — grouped categories, solo --select axis mode, or col-axis series from all-numeric columns.
 ---
 
 import { LinkCard, Aside } from '@astrojs/starlight/components';
@@ -11,19 +11,19 @@ import scatter3D from '../../../assets/scatter-3D.png';
 import scatter2DValue from '../../../assets/scatter-2D-value.png';
 import scatter3DMixed from '../../../assets/scatter-3D-mixed.png';
 
-The **scatter chart** plots each row as a point in coordinate space. Unlike bar and line charts, scatter is built for coordinate plotting: you can map grouping columns to categorical axes, use solo `--select` for mixed or value axes, or auto-value from all-numeric columns.
+The **scatter chart** plots each row as a point in coordinate space. Unlike bar and line charts, scatter is built for coordinate plotting: you can map grouping columns to categorical axes, or use solo `--select` for mixed or continuous value axes.
 
 Use scatter charts when individual `(x, y[, z])` positions matter — latency vs. price, a 3D point cloud, or categorical x with a continuous y metric. Scatter is **opt-in**: add `-c scatter` or run `vizb scatter`; it is not in the default `bar,line,pie` bundle.
 
 ## How vizb builds it
 
-Scatter supports three input modes. Only one applies per dataset:
+Scatter supports these input modes. Only one applies per dataset:
 
 | Mode | CLI | What each row becomes |
 |------|-----|----------------------|
 | **Grouped** | `-g` / `-p` | Categorical x, optional y series, optional z depth — same dimension model as bar/line, rendered as `scatter` / `scatter3D` |
-| **Solo `--select`** | `--select` (no `-g` / `-r` / non-default `-p`) | 2–3 columns assigned to `x,y[,z]` — value axes (all numeric) or **mixed** (category x + value y[,z]) |
-| **Auto-value** | No flags (all-numeric CSV/JSON) | Auto-detected numeric columns as raw coordinates on value axes (`type: "value"`) |
+| **Solo `--select`** | `--select` (no `-g` / `-r` / non-default `-p`, no `-A`) | 2–3 columns assigned to `x,y[,z]` — value axes (all numeric) or **mixed** (category x + value y[,z]) |
+| **Col-axis / auto col-axis** | `-A` or no flags on all-numeric CSV/JSON | Numeric column names as series on the chosen axis (default auto: x) — not continuous coordinates |
 
 ## Grouped mode
 
@@ -87,21 +87,21 @@ vizb scatter life-expectancy-income.csv --select Country,"Life Expectancy",Incom
 
 Repeat `--select` (`dim,metric` per flag) for multi-stat datasets — charts separate by stat type. This does **not** enable grouping; use `-g`/`-p` when you need explicit group axes or aggregation. See [Select](/guides/select) for the full mode reference, and [Group vs Select](/guides/group-vs-select) for when to use each.
 
-## Auto-value mode (no flags)
+## Continuous coordinates (solo `--select`)
 
-On an all-numeric CSV/JSON file, vizb auto-detects the first 2–3 columns as coordinate axes and enters value mode automatically — with 3+ columns it renders continuous `scatter3D`. See [Auto-value](/guides/group-vs-select#auto-value-all-numeric-data) for the inference rules; solo `--select` overrides it.
+All-numeric files with no flags use **auto col-axis x**, not continuous coordinates. For value-mode scatter (including continuous 3D), pass explicit solo `--select`:
 
 ```bash
-# All-numeric CSV — auto-detects x, y
-vizb scatter clusters.csv --visualmap --symbol-size 10 -o scatter.html
+# 2D value scatter from x, y
+vizb scatter clusters.csv --select x,y --visualmap --symbol-size 10 -o scatter.html
 
-# Three columns — auto-detects x, y, z and enables 3D
-vizb scatter spiral-3d.csv -o scatter.html
+# 3D value scatter from x, y, z
+vizb scatter spiral-3d.csv --select x,y,z -o scatter.html
 ```
 
 <DocImage src={scatter2DValue} alt="2D value-mode scatter chart of cluster coordinates with visualMap gradient coloring" />
 
-Use the axis swapper in the UI to include or drop `z` and toggle between 2D and 3D without re-running the CLI.
+See [Select](/guides/select) and [Auto col-axis](/guides/group-vs-select#auto-col-axis-all-numeric-data). Use the axis swapper in the UI to include or drop `z` and toggle between 2D and 3D without re-running the CLI.
 
 ## Settings
 
@@ -109,9 +109,9 @@ These settings apply to scatter charts:
 
 | Setting | CLI flag | UI toggle | Notes |
 |---------|----------|-----------|-------|
-| Sort | `--sort asc\|desc` | Sort control | Grouped mode only — hidden for auto-value and mixed |
+| Sort | `--sort asc\|desc` | Sort control | Grouped mode only — hidden for value and mixed |
 | Labels | `--show-labels` | Show labels | Point labels where supported |
-| Swap | `--swap` | Axis switcher | Grouped mode; auto-value with 3 columns |
+| Swap | `--swap` | Axis switcher | Grouped mode; value mode with 3 columns |
 | Scale (log) | `--scale log` | Scale toggle | Log axes — 2D grouped, value, and mixed mode |
 | 3D view | `--3d` | 3D view | Pseudo-3D for grouped x+y (no z column) |
 | 3D visual map | `--3d-visualmap` | 3D visual map | Metric gradient on 3D points |
@@ -130,10 +130,10 @@ vizb scatter data.csv -g category,metric --scale log -l -o out.html
 vizb scatter region-metrics.csv --select region,latency --scale log -o out.html
 
 # Cluster scatter with visualMap and diamond markers
-vizb scatter clusters.csv --visualmap --symbol diamond --symbol-size 10 -o out.html
+vizb scatter clusters.csv --select x,y --visualmap --symbol diamond --symbol-size 10 -o out.html
 
 # 3D spiral with auto-rotate
-vizb scatter spiral.csv -o out.html  # auto-value x,y,z → 3D
+vizb scatter spiral.csv --select x,y,z --3d-rotate -o out.html
 ```
 
 ## Next Steps

--- a/docs/src/content/docs/charts/scatter.mdx
+++ b/docs/src/content/docs/charts/scatter.mdx
@@ -22,7 +22,7 @@ Scatter supports these input modes. Only one applies per dataset:
 | Mode | CLI | What each row becomes |
 |------|-----|----------------------|
 | **Grouped** | `-g` / `-p` | Categorical x, optional y series, optional z depth — same dimension model as bar/line, rendered as `scatter` / `scatter3D` |
-| **Solo `--select`** | `--select` (no `-g` / `-r` / non-default `-p`, no `-A`) | 2–3 columns assigned to `x,y[,z]` — value axes (all numeric) or **mixed** (category x + value y[,z]) |
+| **Solo `--select`** | `--select` (no `-g` / `-r` / non-default `-p`, no `-A`) | 2–4 columns: `x,y[,z][,metric]` — value axes (all numeric) or **mixed** (category x + value y[,z]); 4th is visualMap metric |
 | **Col-axis / auto col-axis** | `-A` or no flags on all-numeric CSV/JSON | Numeric column names as series on the chosen axis (default auto: x) — not continuous coordinates |
 
 ## Grouped mode
@@ -70,7 +70,7 @@ When you have only **x** and **y** grouping (no z column), pass `--3d` to projec
 
 ## `--select` (csv/json)
 
-`--select` is **repeatable** (csv/json only). With explicit `-g` / `-p` / `-r` it picks which numeric columns get their own chart, same as bar/line. **Without group**, scatter is the primary chart for solo `--select` coordinate plotting — its two signatures are value mode (all-numeric `x,y[,z]`) and mixed mode (category on x, values on y[,z]).
+`--select` is **repeatable** (csv/json only). With explicit `-g` / `-p` / `-r` it picks which numeric columns get their own chart, same as bar/line. **Without group**, scatter is the primary chart for solo `--select` coordinate plotting — value mode (all-numeric `x,y[,z][,metric]`), mixed mode (category on x, values on y[,z]), or multi-stat.
 
 ```bash
 # Value mode: two numeric columns → 2D scatter

--- a/docs/src/content/docs/ci-cd/github-action.mdx
+++ b/docs/src/content/docs/ci-cd/github-action.mdx
@@ -58,7 +58,7 @@ The action:
 | `time-unit` | `"ns"` | Time unit: `ns`, `us`, `ms`, `s` (`-T` flag). |
 | `number-unit` | `""` | Number unit: `K`, `M`, `B`, `T` (`-N` flag). |
 | `select` | `""` | **csv/json only:** select value columns; optional rename with `{label}` (e.g. `price{Unit price},count`) (`--select` flag). |
-| `col-axis` | `""` | **csv/json + group:** place numeric column names on this axis (`n`, `x`, `y`, or `z`) so all columns share one chart (`--col-axis` / `-A` flag). Requires group; target axis must not already be used by `group-pattern`. |
+| `col-axis` | `""` | **csv/json:** place numeric column names on this axis (`n`, `x`, `y`, or `z`) so all columns share one chart (`--col-axis` / `-A` flag). Works without group; only numeric columns become series. With group, target axis must not already be used by `group-pattern`. |
 | `json-path` | `""` | **json only:** select a nested array to chart via a jq-like dot path (e.g. `.data.results`) (`--json-path` flag). |
 | `stat` | `""` | Enable stats panel (`--stat` flag). Empty = disabled; `all` or `true` = all categories; otherwise comma-separated from: `counts`, `center`, `spread`, `extremes`, `shape`, `percentiles`, `confidence`, `correlations`. |
 | `chart` | `""` | Per-chart overrides (`--chart` flag, repeatable). One override per line: `<type>:<key>=<val>,...`. Keys: `swap`, `sort`, `scale`, `labels`, `3d-rotate`, `3d`. E.g. `bar:scale=log` or `pie:labels`. Blank lines and `#`-prefixed lines are ignored. |

--- a/docs/src/content/docs/ci-cd/github-action.mdx
+++ b/docs/src/content/docs/ci-cd/github-action.mdx
@@ -57,7 +57,7 @@ The action:
 | `mem-unit` | `"B"` | Memory unit: `b`, `B`, `KB`, `MB`, `GB` (`-M` flag). |
 | `time-unit` | `"ns"` | Time unit: `ns`, `us`, `ms`, `s` (`-T` flag). |
 | `number-unit` | `""` | Number unit: `K`, `M`, `B`, `T` (`-N` flag). |
-| `select` | `""` | **csv/json only:** select value columns; optional rename with `{label}` (e.g. `price{Unit price},count`) (`--select` flag). |
+| `select` | `""` | **csv/json only:** select columns. Solo mode: 2–4 cols `x,y[,z][,metric]` (e.g. `x,y,z,value`). Grouped mode: numeric stats with optional `{label}` (`--select` flag). |
 | `col-axis` | `""` | **csv/json:** place numeric column names on this axis (`n`, `x`, `y`, or `z`) so all columns share one chart (`--col-axis` / `-A` flag). Works without group; only numeric columns become series. With group, target axis must not already be used by `group-pattern`. |
 | `json-path` | `""` | **json only:** select a nested array to chart via a jq-like dot path (e.g. `.data.results`) (`--json-path` flag). |
 | `stat` | `""` | Enable stats panel (`--stat` flag). Empty = disabled; `all` or `true` = all categories; otherwise comma-separated from: `counts`, `center`, `spread`, `extremes`, `shape`, `percentiles`, `confidence`, `correlations`. |

--- a/docs/src/content/docs/commands/charts.mdx
+++ b/docs/src/content/docs/commands/charts.mdx
@@ -58,7 +58,7 @@ Every chart subcommand accepts the common data, grouping, and metadata flags:
 | `--visualmap` | — | — | ✅ | — | — | — | Color 2D scatter points by metric (off by default) |
 | `--3d-rotate` | ✅ | ✅ | ✅ | — | — | — | Auto-rotate the 3D scene (only meaningful with 3D data) |
 | `--horizontal` | ✅ | — | — | — | — | — | Horizontal grouped bars — 2D only |
-`bar`, `line`, and `scatter` render in 3D when the data has a z dimension (`-p n/x/y/z`) or auto-value detects 3+ numeric columns. Pie, heatmap, and radar are 2D-only for those flags — passing an unsupported flag is an error:
+`bar`, `line`, and `scatter` render in 3D when the data has a z dimension (`-p n/x/y/z`) or solo `--select` names three numeric columns (`--select x,y,z`). Pie, heatmap, and radar are 2D-only for those flags — passing an unsupported flag is an error:
 
 ```bash
 vizb pie data.csv --scale log   # Error: unknown flag: --scale
@@ -79,8 +79,8 @@ go test -bench . | vizb line -p n/y --swap yn -o line.html
 # Bar chart with horizontal grouped bars
 vizb bar sales.csv -g region,category -p x,y --horizontal -o bar.html
 
-# Scatter from all-numeric columns (auto-value)
-vizb scatter data.csv -o scatter.html
+# Scatter from continuous coordinates (explicit select)
+vizb scatter data.csv --select x,y -o scatter.html
 
 # JSON output for later merging / re-rendering
 vizb radar data.csv -g impl -o radar.json

--- a/docs/src/content/docs/commands/charts.mdx
+++ b/docs/src/content/docs/commands/charts.mdx
@@ -70,17 +70,23 @@ vizb pie data.csv --scale log   # Error: unknown flag: --scale
 # 3D bar with log scale and auto-rotation
 vizb bar data.csv -g category,metric,group -p n,x,y,z --scale log --3d-rotate -o bar3d.html
 
+# Continuous 3D bar from all-numeric columns (solo --select, not bare file)
+vizb bar examples/csv/noise-surface.csv --select x,y,z --3d-visualmap -o surface.html
+
 # Pie with value labels, ascending sort
 vizb pie data.csv -g impl --sort asc --show-labels -o pie.html
 
 # Line from Go benchmarks via stdin, swapping axes
 go test -bench . | vizb line -p n/y --swap yn -o line.html
 
+# Continuous 3D line spiral
+vizb line examples/csv/spiral-3d.csv --select x,y,z --3d-rotate -o spiral.html
+
 # Bar chart with horizontal grouped bars
 vizb bar sales.csv -g region,category -p x,y --horizontal -o bar.html
 
 # Scatter from continuous coordinates (explicit select)
-vizb scatter data.csv --select x,y -o scatter.html
+vizb scatter examples/csv/clusters.csv --select x,y --visualmap -o scatter.html
 
 # JSON output for later merging / re-rendering
 vizb radar data.csv -g impl -o radar.json

--- a/docs/src/content/docs/commands/root.mdx
+++ b/docs/src/content/docs/commands/root.mdx
@@ -147,7 +147,7 @@ See the [Group guide](/guides/group) and [3D Charts](/charts/3d) for detailed ex
 | Mode | Trigger | `--select` syntax | What it does |
 |------|---------|-------------------|--------------|
 | **Group stat pick** | `-g`, `-r`, or non-default `-p` | Any number of numeric columns; optional `{label}` | Picks which numeric columns get their own chart |
-| **Solo value axes** | `--select` only; all selected cols numeric | 2–3 cols per flag: `x,y` or `x,y,z` | Assigns columns to continuous coordinate axes; disables auto-group and auto col-axis |
+| **Solo value axes** | `--select` only; all spatial cols numeric | 2–4 cols: `x,y` / `x,y,z` / `x,y,z,value` | Continuous coordinate axes; optional 4th visualMap metric; disables auto-group and auto col-axis |
 | **Solo mixed axes** | One `--select` only; categorical `x` + numeric `y[,z]` | 2–3 cols: `region,latency` | Category on x, values on y/z; [scatter](/charts/scatter) is the primary chart |
 | **Solo multi-stat** | Repeatable `--select` only; 2 cols per flag | `region,latency` + `region,sales` | One dataset; each flag is an independent `dim,metric` pair; charts split by `stat.type` (default `latency by region`) |
 | **Auto-group** | No flags; mixed categorical + numeric file | — | Picks highest-cardinality categorical column as x |
@@ -156,9 +156,9 @@ See the [Group guide](/guides/group) and [3D Charts](/charts/3d) for detailed ex
 
 **Solo `--select` rules:**
 
-- A **single** `--select` needs **2–3 columns** (assigned to `x`, `y`, optional `z` by position).
+- A **single** `--select` needs **2–4 columns**: first 2–3 are spatial (`x`, `y`, optional `z`); optional 4th is the visualMap metric (`value` or `metric:col`).
 - **Repeatable** `--select` (2 columns per flag only): each flag is `dim,metric` → one stat type in a **single dataset**; charts separate by stat name (default `metric by dim`, e.g. `latency by region`). Rename axis labels with `{label}` on the dimension column (`region{Region}`). Rename chart tabs with a trailing `(Title)`: `--select region{Region},latency (Latency by Region)`. Legacy: `{label}` on the metric column still overrides the stat name when `()` is omitted.
-- **Explicit placement** (single `--select` only): `x:region,y:latency,z:sales` — use for every column or omit prefixes for all.
+- **Explicit placement** (single `--select` only): `x:region,y:latency,z:sales` or `x:x,y:y,z:z,metric:value` — use for every column or omit prefixes for all.
 - **No overlap** with `--group` columns. Repeatable solo `--select` does **not** imply grouping.
 - Other parsers warn and ignore `--select`.
 
@@ -167,7 +167,10 @@ See the [Group guide](/guides/group) and [3D Charts](/charts/3d) for detailed ex
 vizb bar sales.csv -g region,product -p x,y --select amount,total -o bars.html
 
 # Solo value: numeric x,y from spiral data
-vizb scatter spiral-3d.csv --select x,y -o xy.html
+vizb scatter examples/csv/spiral-3d.csv --select x,y -o xy.html
+
+# Solo value + visualMap metric (noise grid)
+vizb scatter examples/csv/noise-grid.csv --select x,y,z,value --3d-visualmap -o noise.html
 
 # Solo mixed: category region + value latency (scatter)
 vizb scatter examples/csv/region-metrics.csv --select region,latency -o mixed.html

--- a/docs/src/content/docs/commands/root.mdx
+++ b/docs/src/content/docs/commands/root.mdx
@@ -75,6 +75,7 @@ See the [Parser Guide](/guides/parsers) for each parser's metrics, and the
 | `--output` | `-o` | *(stdout)* | Output file path. `.json` → JSON, else → HTML |
 | `--parser` | `-P` | `auto` | Parser: `auto` (detect), `go`, `js:tinybench`, `js:vitest`, `rs:criterion`, `rs:divan`, `csv`, `json` |
 | `--name` | `-n` | `Benchmarks` | Dataset name |
+| `--title` | | `""` | Override chart title when `--col-axis` produces one chart; independent of `-n` |
 | `--theme` | | `default` | Initial series palette: `default`, `vintage`, `meadow`, `westeros`, `essos`, `wonderland`, `walden`, `chalk`, `infographic`, `macarons`, `roma`, `shine`, `purple-passion`, or 2+ comma-separated hex colors |
 | `--description` | `-d` | `""` | Dataset description |
 | `--tag` | `-t` | `""` | Tag identifier for release tracking |
@@ -83,6 +84,7 @@ See the [Parser Guide](/guides/parsers) for each parser's metrics, and the
 | `--group-regex` | `-r` | `""` | Regex-based grouping (named captures) |
 | `--group` | `-g` | `""` | Names dimensions in `--group-pattern` order. csv/json: column/field names (separators must match `-p`); benchmark parsers: human-readable axis labels |
 | `--select` | | *(repeatable)* | csv/json only: see [`--select` mode matrix](#--select-mode-matrix) below |
+| `--col-axis` | `-A` | `""` | csv/json: place numeric column names on axis `n`/`x`/`y`/`z` (one chart); works without `-g` |
 | `--json-path` | | `""` | json only: select a nested array to chart via a jq-like dot path (e.g. `--json-path '.data.results'`) |
 | `--sort` | `-s` | `""` | **Deprecated on root:** use `--chart <type>:sort=<asc\|desc>`. Sort order: `asc` or `desc` (default: as-is) |
 | `--charts` | `-c` | `bar,line,pie` | Chart types to generate (`bar`, `line`, `scatter`, `pie`, `heatmap`, `radar`) |
@@ -145,11 +147,12 @@ See the [Group guide](/guides/group) and [3D Charts](/charts/3d) for detailed ex
 | Mode | Trigger | `--select` syntax | What it does |
 |------|---------|-------------------|--------------|
 | **Group stat pick** | `-g`, `-r`, or non-default `-p` | Any number of numeric columns; optional `{label}` | Picks which numeric columns get their own chart |
-| **Solo value axes** | `--select` only; all selected cols numeric | 2–3 cols per flag: `x,y` or `x,y,z` | Assigns columns to continuous coordinate axes; disables auto-group and auto-value |
+| **Solo value axes** | `--select` only; all selected cols numeric | 2–3 cols per flag: `x,y` or `x,y,z` | Assigns columns to continuous coordinate axes; disables auto-group and auto col-axis |
 | **Solo mixed axes** | One `--select` only; categorical `x` + numeric `y[,z]` | 2–3 cols: `region,latency` | Category on x, values on y/z; [scatter](/charts/scatter) is the primary chart |
 | **Solo multi-stat** | Repeatable `--select` only; 2 cols per flag | `region,latency` + `region,sales` | One dataset; each flag is an independent `dim,metric` pair; charts split by `stat.type` (default `latency by region`) |
 | **Auto-group** | No flags; mixed categorical + numeric file | — | Picks highest-cardinality categorical column as x |
-| **Auto-value** | No flags; all-numeric file | — | First 2–3 numeric columns as coordinate axes |
+| **Auto col-axis x** | No flags; all-numeric file | — | Every numeric column name as series on x (one chart) |
+| **Col-axis** | `--col-axis` / `-A` (group optional) | Axis: `n`, `x`, `y`, or `z` | Numeric column names as series on that axis; with `--select`, select filters series |
 
 **Solo `--select` rules:**
 

--- a/docs/src/content/docs/examples/comparisons.mdx
+++ b/docs/src/content/docs/examples/comparisons.mdx
@@ -7,7 +7,7 @@ import { Aside, LinkCard } from '@astrojs/starlight/components';
 
 [![Comparisons examples workflow status](https://github.com/goptics/vizb/actions/workflows/comparisons-examples.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/comparisons-examples.yml)
 
-**Wide tables** where each competitor is a numeric column: map category columns with `--group`, put competitor names on an axis with `--col-axis` (`-A`), and keep everyone on **one chart**. Parser: **CSV**.
+**Wide tables** where each competitor is a numeric column: map category columns with `--group`, put competitor names on an axis with `--col-axis` (`-A`), and keep everyone on **one chart**. `--col-axis` also works without group. Parser: **CSV**.
 
 **Live dashboard:** [vizb.goptics.org/examples/live/comparisons/](https://vizb.goptics.org/examples/live/comparisons/)
 

--- a/docs/src/content/docs/examples/index.mdx
+++ b/docs/src/content/docs/examples/index.mdx
@@ -18,7 +18,7 @@ Sample inputs live under [`examples/`](https://github.com/goptics/vizb/tree/main
   <LinkCard
     title="Math & 3D"
     href="/examples/math-and-3d"
-    description="Spirals, noise surfaces/grids, and clusters — auto-value continuous charts."
+    description="Spirals, noise surfaces/grids, and clusters — continuous charts via solo --select."
   />
   <LinkCard
     title="Comparisons"

--- a/docs/src/content/docs/examples/math-and-3d.mdx
+++ b/docs/src/content/docs/examples/math-and-3d.mdx
@@ -1,13 +1,13 @@
 ---
 title: Math & 3D
-description: All-numeric auto-value examples — spirals, noise surfaces, and voxel grids for continuous 3D charts.
+description: Continuous coordinate examples via solo --select — spirals, noise surfaces, and voxel grids for continuous 3D charts.
 ---
 
 import { Aside, LinkCard } from '@astrojs/starlight/components';
 
 [![Math and 3D examples workflow status](https://github.com/goptics/vizb/actions/workflows/math-and-3d-examples.yml/badge.svg)](https://github.com/goptics/vizb/actions/workflows/math-and-3d-examples.yml)
 
-All-numeric CSV → **auto-value** mode (continuous `x` / `y` / `z`, optional 4th metric for color/size). Parser: **CSV**. Source files under [`examples/csv/`](https://github.com/goptics/vizb/tree/main/examples/csv).
+All-numeric CSV → continuous `x` / `y` / `z` via **explicit solo `--select`** (e.g. `--select x,y,z`). Bare all-numeric files use auto col-axis x instead — not coordinate mode. Parser: **CSV**. Source files under [`examples/csv/`](https://github.com/goptics/vizb/tree/main/examples/csv).
 
 **Live dashboard:** [vizb.goptics.org/examples/live/math-and-3d/](https://vizb.goptics.org/examples/live/math-and-3d/)
 
@@ -32,13 +32,14 @@ Prefer the 21³ grid for everyday loads; use 41³ when you need every voxel.
 ## Related guides
 
 - [3D Charts (WebGL)](/charts/3d) — bar3D / line3D / scatter3D, rotate, visualMap
-- [Tabular data](/guides/data) — auto-value when every column is numeric
+- [Select](/guides/select) — solo `--select` for continuous coordinates
+- [Tabular data](/guides/data) — auto col-axis when every column is numeric (no flags)
 
 <Aside type="tip">
   ```bash
-  vizb scatter examples/csv/spiral-3d.csv -o spiral.html
-  vizb scatter examples/csv/noise-grid.csv --3d-visualmap --3d-rotate -o noise.html
-  vizb scatter examples/csv/clusters.csv --visualmap --symbol-size 10 -o clusters.html
+  vizb scatter examples/csv/spiral-3d.csv --select x,y,z -o spiral.html
+  vizb scatter examples/csv/noise-grid.csv --select x,y,z --3d-visualmap --3d-rotate -o noise.html
+  vizb scatter examples/csv/clusters.csv --select x,y --visualmap --symbol-size 10 -o clusters.html
   ```
 </Aside>
 

--- a/docs/src/content/docs/examples/math-and-3d.mdx
+++ b/docs/src/content/docs/examples/math-and-3d.mdx
@@ -41,7 +41,7 @@ Prefer the 21³ grid for everyday loads; use 41³ when you need every voxel.
   vizb scatter examples/csv/spiral-3d.csv --select x,y,z -o spiral.html
   vizb line examples/csv/spiral-3d.csv --select x,y,z --3d-rotate -o spiral-line.html
   vizb bar examples/csv/noise-surface.csv --select x,y,z --3d-visualmap -o surface.html
-  vizb scatter examples/csv/noise-grid.csv --select x,y,z --3d-visualmap --3d-rotate -o noise.html
+  vizb scatter examples/csv/noise-grid.csv --select x,y,z,value --3d-visualmap --3d-rotate -o noise.html
   vizb scatter examples/csv/clusters.csv --select x,y --visualmap --symbol-size 10 -o clusters.html
   ```
 </Aside>

--- a/docs/src/content/docs/examples/math-and-3d.mdx
+++ b/docs/src/content/docs/examples/math-and-3d.mdx
@@ -37,7 +37,10 @@ Prefer the 21³ grid for everyday loads; use 41³ when you need every voxel.
 
 <Aside type="tip">
   ```bash
+  # Continuous coordinates always need solo --select (not bare all-numeric)
   vizb scatter examples/csv/spiral-3d.csv --select x,y,z -o spiral.html
+  vizb line examples/csv/spiral-3d.csv --select x,y,z --3d-rotate -o spiral-line.html
+  vizb bar examples/csv/noise-surface.csv --select x,y,z --3d-visualmap -o surface.html
   vizb scatter examples/csv/noise-grid.csv --select x,y,z --3d-visualmap --3d-rotate -o noise.html
   vizb scatter examples/csv/clusters.csv --select x,y --visualmap --symbol-size 10 -o clusters.html
   ```

--- a/docs/src/content/docs/examples/tabular-data.mdx
+++ b/docs/src/content/docs/examples/tabular-data.mdx
@@ -26,7 +26,7 @@ Mixed **categorical + numeric** tables: sales orders, house prices, and life exp
 | Sales auto-group | Auto-group by highest-cardinality categorical column |
 | Sales grouped | Explicit `--group` / `--group-pattern` for product × region × category |
 | Sales by date | Date axis splitting with `[n{Year}-y{Month}-x{Date}]` |
-| House price | Auto-value 2D scatter + `--visualmap` |
+| House price | Solo `--select area,price` 2D scatter + `--visualmap` |
 | Life expectancy | Mixed axes via `--select` |
 
 Local-only sample (not on the live dashboard yet): [`region-metrics.csv`](https://github.com/goptics/vizb/blob/main/examples/csv/region-metrics.csv) for multi-view `--select` demos.
@@ -40,7 +40,7 @@ Local-only sample (not on the live dashboard yet): [`region-metrics.csv`](https:
 <Aside type="tip">
   ```bash
   vizb bar examples/csv/sales.csv -o sales.html
-  vizb scatter examples/csv/house-price-area2.csv --visualmap -o house.html
+  vizb scatter examples/csv/house-price-area2.csv --select area,price --visualmap -o house.html
   ```
 </Aside>
 

--- a/docs/src/content/docs/guides/data.mdx
+++ b/docs/src/content/docs/guides/data.mdx
@@ -80,7 +80,7 @@ For all-numeric grids, omit headers and vizb assigns `x`, `y`, `z`, `metric`, th
 ]
 ```
 
-That enters the same auto-value path as all-numeric CSV: `x`, `y`, and `z` become coordinate axes, and `metric` drives visualMap where supported.
+With no flags, that follows the same path as all-numeric CSV: **auto col-axis x** — every numeric column name becomes a series on the x axis (one chart). For continuous coordinates or continuous 3D, pass explicit solo `--select` (e.g. `--select x,y` or `--select x,y,z`).
 
 ### Rules
 
@@ -122,7 +122,7 @@ vizb sales.csv --select=price,count
 vizb sales.csv --select="price{USD}",count   # quote names with , { or }
 ```
 
-A column cannot be in both `--select` and `--group`. Without `--group`, `--select` switches to solo coordinate-axes mode (value / mixed / multi-stat) — see [Select](/guides/select) for the full reference, and [Group vs Select](/guides/group-vs-select) for when to use each.
+A column cannot be in both `--select` and `--group`. Without `--group` and without `--col-axis`, `--select` switches to solo coordinate-axes mode (value / mixed / multi-stat). With `--col-axis`, `--select` filters which numeric columns become series. All-numeric files with no flags use auto col-axis x — see [Select](/guides/select), and [Group vs Select](/guides/group-vs-select).
 
 ## Selecting a nested array with `--json-path`
 

--- a/docs/src/content/docs/guides/group-vs-select.mdx
+++ b/docs/src/content/docs/guides/group-vs-select.mdx
@@ -35,7 +35,7 @@ A third layout, **`--col-axis` / `-A`**, puts many numeric column **names** on o
     See the [Group guide](/guides/group) for pattern syntax, bracket slots, regex, and axis labels.
   </TabItem>
   <TabItem label="Select" icon="set">
-    Use **select** when you want to **plot several columns together in one chart** — a scatter of latency vs. price, or category vs. metric. Solo `--select` assigns 2–3 columns to coordinate axes and keeps every row as its own point.
+    Use **select** when you want to **plot several columns together in one chart** — a scatter of latency vs. price, or category vs. metric. Solo `--select` assigns 2–3 columns to coordinate axes (optional 4th visualMap metric) and keeps every row as its own point.
 
     ```bash
     vizb scatter data.csv --select region,latency -o mixed.html

--- a/docs/src/content/docs/guides/group-vs-select.mdx
+++ b/docs/src/content/docs/guides/group-vs-select.mdx
@@ -1,6 +1,6 @@
 ---
 title: Group vs Select
-description: How vizb turns columns into charts — group gives every numeric column its own chart, bucketed by category; select merges columns into one chart as coordinate axes. Plus the auto-inference that picks for you.
+description: How vizb turns columns into charts — group gives every numeric column its own chart, bucketed by category; select merges columns into one chart as coordinate axes. Plus auto-group and auto col-axis inference.
 ---
 
 import { Aside, Tabs, TabItem, LinkCard } from '@astrojs/starlight/components';
@@ -19,6 +19,8 @@ Vizb charts tabular data (CSV/JSON) two ways. The difference is what your **colu
 | Works on benchmarks | yes — the name is the label | no — CSV/JSON only |
 
 The same data often works with either — the choice is about what you want to *see*, not what the file contains.
+
+A third layout, **`--col-axis` / `-A`**, puts many numeric column **names** on one axis so competitors share a single chart (works with or without group). All-numeric files with no flags use **auto col-axis x** — see below.
 
 ## When to use which
 
@@ -44,7 +46,7 @@ The same data often works with either — the choice is about what you want to *
 </Tabs>
 
 <Aside type="tip">
-  Rule of thumb: **one chart per metric, bucketed by category → group** (it aggregates); **several columns plotted together as coordinates → select** (it never merges).
+  Rule of thumb: **one chart per metric, bucketed by category → group** (it aggregates); **several columns plotted together as coordinates → select** (it never merges); **many numeric columns as series on one axis → col-axis**.
 </Aside>
 
 ### Decision matrix
@@ -53,10 +55,12 @@ The same data often works with either — the choice is about what you want to *
 |---|---|---|
 | One chart **per metric across categories** | Group + numeric `--select` | `-g region,product -p x,y --select latency,sales` |
 | Plot **one metric per category label** on a coordinate chart | Solo mixed `--select` | `--select region,latency` → scatter |
-| Plot **raw numeric coordinates** (no categories) | Solo value `--select` or auto-value | `--select x,y` or no flags on all-numeric file |
+| Plot **raw numeric coordinates** (no categories) | Solo value `--select` | `--select x,y` or `--select x,y,z` |
 | **Several metric views** from one file (no grouping) | Repeatable solo `--select` | `--select region,latency --select region,sales` |
+| **Competitors side-by-side** (column names as series) | `--col-axis` (optional group) | `-g load -p y -A x` or bare all-numeric file |
 | Split a column into year/month/day on axes | Group with bracket `-p` | `-g date,category -p '[n-y-x],z'` |
 | Quick chart with no flags on mixed data | Auto-group | `vizb bar sales.csv` picks highest-cardinality categorical column |
+| Quick chart with no flags on all-numeric data | Auto col-axis x | `vizb bar metrics.csv` — every numeric column on X |
 
 ## Auto-inference (no flags needed)
 
@@ -80,27 +84,24 @@ vizb sales.csv -g region,product -p x,y --3d -o 3d.html   # grouped 3D with expl
 vizb sales.csv -g product -p y -o o.html                  # explicit --group disables auto-group
 ```
 
-### Auto-value (all-numeric data)
+### Auto col-axis (all-numeric data)
 
-When every column in a CSV/JSON file is numeric (no categorical columns exist), auto-group has nothing to pick. Instead, vizb **auto-assigns the first 2-3 columns** as value-type coordinate axes (`x`, `y`, `z`) — no flag needed. This works on **bar**, **line**, and **scatter** charts.
-
-| Columns | Axes | Pattern |
-|---|---|---|
-| 2+ | `x`, `y` | 2D value |
-| 3+ | `x`, `y`, `z` (first 3) | **3D value** (auto-enables 3D) |
-| 4+ | `x`, `y`, `z` + 4th as **metric** | **3D value** + auto visualMap (color/size by metric) |
-
-With 2+ numeric columns, vizb creates a 2D value-mode chart. With 3+, it automatically enables 3D (`bar3D` / `line3D` / `scatter3D`). With 4+, the first three columns are coordinates and the fourth becomes a visual metric. The inference is logged: `🧠 Auto-valued by columns: x, y, z (3D pattern x-y-z), metric: value`.
+When every column in a CSV/JSON file is numeric (no categorical columns exist), auto-group has nothing to pick. Instead, vizb applies **auto col-axis x**: every numeric column name becomes a series on the **x** axis — **one chart**, same layout as explicit `--col-axis x`. There is no 2–3 column coordinate auto-value and no 4th-metric auto visualMap.
 
 ```bash
-vizb scatter allnums.csv -o scatter.html        # auto-value x,y from first 2 columns
-vizb scatter allnums.csv --3d -o 3d.html         # auto-value x,y,z from 3+ columns (auto-3D)
-vizb bar allnums.csv -o bars.html                # bar auto-value (auto-3D with 3+ cols)
-vizb line allnums.csv -o lines.html              # line auto-value (auto-3D with 3+ cols)
+vizb bar allnums.csv -o bars.html     # auto col-axis x — all columns as series on X
+vizb line allnums.csv -o lines.html   # same layout for line
+```
+
+For continuous coordinates or continuous 3D, use **explicit** solo `--select` (not a bare file):
+
+```bash
+vizb scatter points.csv --select x,y -o scatter.html      # 2D value coordinates
+vizb scatter spiral.csv --select x,y,z -o scatter3d.html  # 3D value coordinates
 ```
 
 <Aside type="note">
-  Solo `--select` **overrides** auto-value: it disables inference and uses only the columns you name. Selecting 2 columns keeps the chart 2D even if the file has more numeric columns.
+  Solo `--select` (without `--col-axis`) is **coordinate / mixed / multi-stat mode** — it does not use col-axis layout. Pair `--select` with `-A` when you want to filter which numeric columns become series while still placing them on a col-axis.
 </Aside>
 
 ## The dimensions
@@ -118,7 +119,7 @@ See [Group → The dimensions](/guides/group#the-dimensions) for the full refere
 
 ## Benchmarks
 
-Benchmark output (Go, Rust, JavaScript) is **always grouped** — the benchmark name is already the label (e.g. `BenchmarkSort/1024/QuickSort`), so there are no columns to select. Solo `--select` and auto-value do not apply. See [Group benchmarks](/guides/group#group-benchmarks).
+Benchmark output (Go, Rust, JavaScript) is **always grouped** — the benchmark name is already the label (e.g. `BenchmarkSort/1024/QuickSort`), so there are no columns to select. Solo `--select` and auto col-axis do not apply. See [Group benchmarks](/guides/group#group-benchmarks).
 
-<LinkCard title="Group" href="/guides/group" description="Dimensions, --group, pattern & regex syntax, bracket slots, axis labels, aggregation." />
+<LinkCard title="Group" href="/guides/group" description="Dimensions, --group, pattern & regex syntax, bracket slots, axis labels, aggregation, --col-axis." />
 <LinkCard title="Select" href="/guides/select" description="The --select flag — grouped stat pick and solo value / mixed / multi-stat modes." />

--- a/docs/src/content/docs/guides/group-vs-select.mdx
+++ b/docs/src/content/docs/guides/group-vs-select.mdx
@@ -96,8 +96,10 @@ vizb line allnums.csv -o lines.html   # same layout for line
 For continuous coordinates or continuous 3D, use **explicit** solo `--select` (not a bare file):
 
 ```bash
-vizb scatter points.csv --select x,y -o scatter.html      # 2D value coordinates
-vizb scatter spiral.csv --select x,y,z -o scatter3d.html  # 3D value coordinates
+vizb scatter examples/csv/clusters.csv --select x,y -o scatter.html
+vizb scatter examples/csv/spiral-3d.csv --select x,y,z -o scatter3d.html
+vizb bar examples/csv/noise-surface.csv --select x,y,z --3d-visualmap -o surface.html
+vizb line examples/csv/spiral-3d.csv --select x,y,z --3d-rotate -o spiral-line.html
 ```
 
 <Aside type="note">

--- a/docs/src/content/docs/guides/group.mdx
+++ b/docs/src/content/docs/guides/group.mdx
@@ -52,7 +52,7 @@ Group extracts up to four dimensions from each label:
 CSV and JSON rows have no benchmark name. You tell vizb which columns carry the structure. The `--group` / `-g` flag selects columns. The `--group-pattern` / `-p` flag assigns each column to a dimension. By default each column maps to one dimension (`-p y,x`). Use **bracket slots** `[...]` when a single column's **cell value** encodes multiple dimensions (dates, slash paths, underscore IDs, etc.).
 
 <Aside type="note">
-  Not sure whether to group or to use `--select`? See [Group vs Select](/guides/group-vs-select) for the two models, auto-group / auto-value inference, and a decision matrix. Solo `--select` value, mixed, and multi-stat modes are covered in [Select](/guides/select).
+  Not sure whether to group or to use `--select`? See [Group vs Select](/guides/group-vs-select) for the two models, auto-group / auto col-axis inference, and a decision matrix. Solo `--select` value, mixed, and multi-stat modes are covered in [Select](/guides/select).
 </Aside>
 
 ### Matching separators
@@ -217,7 +217,9 @@ The columns you **don't** select decide the chart values:
 
 ### Competitor columns — `--col-axis` / `-A`
 
-When several numeric columns are **the same metric for different series** (frameworks, libraries, versions), you usually want **one chart**, not one chart per column. `--col-axis` (short `-A`) places those column names onto a free group dimension (`n`, `x`, `y`, or `z`), like merge’s `--tag-axis`.
+When several numeric columns are **the same metric for different series** (frameworks, libraries, versions), you usually want **one chart**, not one chart per column. `--col-axis` (short `-A`) places those **numeric** column names onto a free dimension (`n`, `x`, `y`, or `z`), like merge’s `--tag-axis`.
+
+Works **with or without** `--group`. Without group, only numeric columns become series (non-numeric columns are ignored). All-numeric files with no flags get the same layout via **auto col-axis x** — see [Group vs Select](/guides/group-vs-select#auto-col-axis-all-numeric-data).
 
 Example wide table:
 
@@ -228,19 +230,24 @@ load,default,chi,echo,gin,goframe,httpz
 ```
 
 ```bash
-# Frameworks on X, load levels as Y series — single chart
+# Frameworks on X, load levels as Y series — single chart (group + col-axis)
 vizb bar concurrency.csv -g load -p y -A x -o out.html
 
 # Load on X, frameworks as Y series (classic grouped bar)
 vizb bar concurrency.csv -g load -p x -A y -o out.html
+
+# Col-axis alone (no -g): every numeric column name on X as series
+vizb bar metrics.csv -A x -o out.html
 ```
 
 | Rule | Behaviour |
 |------|-----------|
-| Requires group | Needs `-g` / `-r` / non-default `-p` (or auto-group). Without group: warn and skip |
+| Group optional | Works without `-g` / `-r` / non-default `-p`. With group, target axis must be free |
+| Numeric only | Only **numeric** columns become series; non-numeric ignored when col-axis is used without group |
+| With `--select` | Independent: `--select` filters which numeric columns are series; `-A` places them on the axis |
 | csv/json only | Other parsers: warn and skip |
-| Free axis | Target must **not** already be used by `-p` (e.g. `-p x -A x` is fatal) |
-| `z` | Requires both `x` and `y` group dimensions |
+| Free axis | With group, target must **not** already be used by `-p` (e.g. `-p x -A x` is fatal) |
+| `z` | With group, requires both `x` and `y` group dimensions |
 | Chart title | Expanded points omit `stats[].type`; the UI uses the dataset name (`-n`) as the chart title |
 
 <Aside type="note">

--- a/docs/src/content/docs/guides/select.mdx
+++ b/docs/src/content/docs/guides/select.mdx
@@ -8,7 +8,7 @@ import { Aside, Tabs, TabItem, LinkCard } from '@astrojs/starlight/components';
 The `--select` flag is **repeatable** and applies to the `csv` and `json` parsers only. Other parsers warn and ignore it. It plays two different roles depending on whether group is active:
 
 - **With group** (`-g`, `-r`, or a non-default `-p`) — `--select` picks which **numeric columns** get their own chart.
-- **Without group** (solo) — each `--select` assigns 2–3 columns to **coordinate axes**, and vizb plots every row as a separate point (no aggregation).
+- **Without group** (solo) — each `--select` assigns 2–3 columns to **coordinate axes** (optional 4th = visualMap metric), and vizb plots every row as a separate point (no aggregation).
 
 A column cannot be in both `--select` and `--group`. See [Group vs Select](/guides/group-vs-select) for when to use each approach.
 
@@ -33,14 +33,14 @@ This is the grouped companion to `--group` — see the [Group guide](/guides/gro
 
 ## Role 2 — Solo `--select` (no group)
 
-Pass `--select` **without** group (`-g`, `-r`, or non-default `-p`) and **without** `--col-axis` and vizb enters **select axis mode**. Auto-group and auto col-axis are both disabled. Each `--select` defines one view with 2–3 columns assigned to `x`, `y`, and optional `z`. Every row stays a separate point — nothing is summed.
+Pass `--select` **without** group (`-g`, `-r`, or non-default `-p`) and **without** `--col-axis` and vizb enters **select axis mode**. Auto-group and auto col-axis are both disabled. Each `--select` defines one view with 2–3 spatial columns (`x`, `y`, optional `z`) and an optional 4th visualMap metric. Every row stays a separate point — nothing is summed.
 
 The mode depends on the column types you select:
 
 | Mode | Trigger | Result |
 |---|---|---|
-| **Value** | All selected columns numeric | Continuous coordinate axes (`x`, `y`[, `z`]) |
-| **Mixed** | One categorical + numeric | Category on x, values on y[, `z`]; [scatter](/charts/scatter) is the primary chart |
+| **Value** | All spatial columns numeric | Continuous coordinate axes (`x`, `y`[, `z`]); optional 4th metric for visualMap |
+| **Mixed** | One categorical + numeric | Category on x, values on y[, `z`]; [scatter](/charts/scatter) is the primary chart (no metric) |
 | **Multi-stat** | Repeatable flags, 2 columns each | One dataset; each flag → a stat type (`latency by region`); chart tabs by stat |
 
 ### Value mode (all numeric)
@@ -95,9 +95,9 @@ vizb scatter region-metrics.csv \
 
 ## Solo `--select` rules
 
-- A **single** `--select` needs **2–3 columns** (assigned to `x`, `y`, optional `z` by position).
+- A **single** `--select` needs **2–4 columns**: first 2–3 are spatial (`x`, `y`, optional `z` by position); an optional **4th** is the visualMap metric (`value` or explicit `metric:col`).
 - **Repeatable** `--select` takes 2 columns per flag only: each flag is `dim,metric` → one stat type in a **single dataset**; charts separate by stat name. (Legacy: `{label}` on the metric column still overrides the stat name when `()` is omitted.)
-- **Explicit placement** (single `--select` only): `x:region,y:latency,z:sales` — use prefixes for every column or omit them for all.
+- **Explicit placement** (single `--select` only): `x:region,y:latency,z:sales` or `x:x,y:y,z:z,metric:value` — use prefixes for every column or omit them for all.
 - **No overlap** with `--group` columns. Repeatable solo `--select` does **not** imply grouping.
 - Other parsers warn and ignore `--select`.
 
@@ -108,8 +108,8 @@ All-numeric files with **no** flags use **auto col-axis x** (column names as ser
 | | **Auto col-axis x** | **Solo `--select`** |
 |---|---|---|
 | Trigger | No flags; all-numeric file | `--select` only (no group, no `-A`) |
-| Layout | Every numeric column name → series on X (one chart) | Named columns → continuous `x,y[,z]` (or mixed) |
-| 2D vs 3D | Categorical-style series chart | 3 names → 3D; 2 names stays 2D |
+| Layout | Every numeric column name → series on X (one chart) | Named columns → continuous `x,y[,z][,metric]` (or mixed) |
+| 2D vs 3D | Categorical-style series chart | 3 spatial names → 3D; 2 stays 2D; 4th = visualMap metric |
 | Inference | Logged to stdout | None — you are explicit |
 
 ## `--select` with `--col-axis`

--- a/docs/src/content/docs/guides/select.mdx
+++ b/docs/src/content/docs/guides/select.mdx
@@ -33,7 +33,7 @@ This is the grouped companion to `--group` — see the [Group guide](/guides/gro
 
 ## Role 2 — Solo `--select` (no group)
 
-Pass `--select` **without** group (`-g`, `-r`, or non-default `-p`) and vizb enters **select axis mode**. Auto-group and auto-value are both disabled. Each `--select` defines one view with 2–3 columns assigned to `x`, `y`, and optional `z`. Every row stays a separate point — nothing is summed.
+Pass `--select` **without** group (`-g`, `-r`, or non-default `-p`) and **without** `--col-axis` and vizb enters **select axis mode**. Auto-group and auto col-axis are both disabled. Each `--select` defines one view with 2–3 columns assigned to `x`, `y`, and optional `z`. Every row stays a separate point — nothing is summed.
 
 The mode depends on the column types you select:
 
@@ -45,7 +45,7 @@ The mode depends on the column types you select:
 
 ### Value mode (all numeric)
 
-Pick two or three numeric columns as coordinate axes. With three, vizb auto-enables 3D.
+Pick two or three numeric columns as coordinate axes. With three, vizb auto-enables 3D. All-numeric files do **not** enter this mode automatically — you must pass `--select` explicitly.
 
 ```bash
 # Two numeric columns → 2D value scatter
@@ -95,18 +95,31 @@ vizb scatter region-metrics.csv \
 - **No overlap** with `--group` columns. Repeatable solo `--select` does **not** imply grouping.
 - Other parsers warn and ignore `--select`.
 
-## Solo `--select` vs auto-value
+## Solo `--select` vs auto col-axis
 
-Both produce value/mixed charts, but they differ in who picks the columns:
+All-numeric files with **no** flags use **auto col-axis x** (column names as series on X), not coordinate mode. Solo `--select` is the explicit path for coordinates:
 
-| | **Auto-value** | **Solo `--select`** |
+| | **Auto col-axis x** | **Solo `--select`** |
 |---|---|---|
-| Trigger | No flags; all-numeric file | `--select` only |
-| Columns | First 2–3 numeric columns, auto-detected | Only the columns you name |
-| 2D vs 3D | 3+ columns → auto-3D | 3 names → 3D; 2 names stays 2D |
-| Inference | Logged to stdout (`🧠 Auto-valued by …`) | None — you are explicit |
+| Trigger | No flags; all-numeric file | `--select` only (no group, no `-A`) |
+| Layout | Every numeric column name → series on X (one chart) | Named columns → continuous `x,y[,z]` (or mixed) |
+| 2D vs 3D | Categorical-style series chart | 3 names → 3D; 2 names stays 2D |
+| Inference | Logged to stdout | None — you are explicit |
 
-Solo `--select` is the override when auto-value guesses wrong or you want fewer columns than the file holds. See [Group vs Select → Auto-value](/guides/group-vs-select#auto-value-all-numeric-data) for the inference rules.
+## `--select` with `--col-axis`
+
+`--select` and `--col-axis` are **independent** and compose:
+
+- **`--select` only** → value / mixed / multi-stat coordinate mode (above).
+- **`--col-axis` only** → all numeric columns become series on that axis.
+- **Both** → `--select` filters which numeric columns are series; `--col-axis` places those series on the chosen axis.
+
+```bash
+# Only default and chi as series on X
+vizb bar concurrency.csv -g load -p y -A x --select default,chi -o out.html
+```
+
+See [Group → Competitor columns](/guides/group#competitor-columns----col-axis--a) and [Group vs Select → Auto col-axis](/guides/group-vs-select#auto-col-axis-all-numeric-data).
 
 <Aside type="note">
   For the full mode-by-mode flag reference, see the [`--select` mode matrix](/commands/root#--select-mode-matrix) on the root command page.

--- a/docs/src/content/docs/guides/select.mdx
+++ b/docs/src/content/docs/guides/select.mdx
@@ -45,14 +45,20 @@ The mode depends on the column types you select:
 
 ### Value mode (all numeric)
 
-Pick two or three numeric columns as coordinate axes. With three, vizb auto-enables 3D. All-numeric files do **not** enter this mode automatically — you must pass `--select` explicitly.
+Pick two or three numeric columns as coordinate axes. With three, vizb auto-enables 3D. An optional **fourth** column is the visualMap **metric** (not a spatial axis). All-numeric files do **not** enter this mode automatically — you must pass `--select` explicitly.
 
 ```bash
 # Two numeric columns → 2D value scatter
-vizb scatter spiral-3d.csv --select x,y -o scatter.html
+vizb scatter examples/csv/spiral-3d.csv --select x,y -o scatter.html
 
 # Three numeric columns → 3D value scatter (auto-enables 3D)
-vizb scatter spiral-3d.csv --select x,y,z -o scatter3d.html
+vizb scatter examples/csv/spiral-3d.csv --select x,y,z -o scatter3d.html
+
+# Four columns → x,y,z position + value metric for visualMap color/size
+vizb scatter examples/csv/noise-grid.csv --select x,y,z,value --3d-visualmap -o noise.html
+
+# Explicit metric key (equivalent to a positional 4th column)
+vizb scatter examples/csv/noise-grid.csv --select x:x,y:y,z:z,metric:value --3d-visualmap -o noise.html
 ```
 
 ### Mixed mode (category + value)

--- a/docs/src/content/docs/ui/index.mdx
+++ b/docs/src/content/docs/ui/index.mdx
@@ -19,7 +19,7 @@ Vizb supports six chart types. All render in a single view:
     Track trends across X-axis values. Best for sequential data like input sizes or concurrency levels.
   </Card>
   <Card title="Scatter Chart" icon="magnifier">
-    Plot individual points in 2D or 3D. Supports grouped categories and auto-value from all-numeric columns. See [Scatter Chart](/charts/scatter).
+    Plot individual points in 2D or 3D. Supports grouped categories and solo `--select` continuous coordinates. See [Scatter Chart](/charts/scatter).
   </Card>
   <Card title="Pie Chart" icon="puzzle">
     Show proportional distribution. Useful for comparing relative sizes of categories.

--- a/examples/csv/README.md
+++ b/examples/csv/README.md
@@ -6,7 +6,7 @@ Run any example from the repo root:
 
 ```bash
 vizb bar examples/csv/sales.csv -o out.html
-vizb scatter examples/csv/noise-grid.csv -o out.html
+vizb scatter examples/csv/noise-grid.csv --select x,y,z -o out.html
 ```
 
 Use a chart subcommand (`bar`, `line`, `scatter`, `pie`, …) or the root command with `--charts`. CSV is auto-detected when you pass a `.csv` file.
@@ -41,15 +41,15 @@ These variants are also built in CI as `00-sales-auto-group`, `01-sales-grouped`
 
 **Shape:** Three numeric columns only — `x`, `y`, `z` (25,000 points along a 3D spiral).
 
-**What vizb does:** No categorical columns → **auto-value mode**. First three columns become continuous `x`, `y`, `z` axes; 3D is enabled automatically for bar / line / scatter.
+**What vizb does:** No categorical columns → **auto col-axis x** if you pass no flags (column names as series on X). For continuous 3D coordinates, use explicit solo `--select x,y,z`.
 
 **Good for:** Continuous `scatter3D` / `line3D` / `bar3D`, camera rotate.
 
 | Goal | Command |
 |------|---------|
-| Auto-value 3D scatter | `vizb scatter examples/csv/spiral-3d.csv` |
-| Auto-rotate | `vizb scatter examples/csv/spiral-3d.csv --3d-rotate` |
-| 3D bar or line | `vizb bar examples/csv/spiral-3d.csv` · `vizb line examples/csv/spiral-3d.csv` |
+| Continuous 3D scatter | `vizb scatter examples/csv/spiral-3d.csv --select x,y,z` |
+| Auto-rotate | `vizb scatter examples/csv/spiral-3d.csv --select x,y,z --3d-rotate` |
+| 3D bar or line | `vizb bar examples/csv/spiral-3d.csv --select x,y,z` · `vizb line examples/csv/spiral-3d.csv --select x,y,z` |
 
 ---
 
@@ -57,29 +57,29 @@ These variants are also built in CI as `00-sales-auto-group`, `01-sales-grouped`
 
 **Shape:** Three numeric columns — `x`, `y`, `z` on a **21×21** grid (441 points). `z` is a simplex-noise height field over `(x, y)`.
 
-**What vizb does:** Auto-value mode (2D coordinates + height on `z`). Renders as a continuous 3D surface-style bar chart.
+**What vizb does:** Continuous 3D via `--select x,y,z` (2D coordinates + height on `z`). Renders as a continuous 3D surface-style bar chart.
 
 **Good for:** 2D grid → 3D height (bar3D), quick noise demo (smaller than the grid examples).
 
 | Goal | Command |
 |------|---------|
-| Noise height field | `vizb bar examples/csv/noise-surface.csv` |
-| Scatter view of same points | `vizb scatter examples/csv/noise-surface.csv` |
+| Noise height field | `vizb bar examples/csv/noise-surface.csv --select x,y,z` |
+| Scatter view of same points | `vizb scatter examples/csv/noise-surface.csv --select x,y,z` |
 
 ---
 
 ## `noise-grid.csv`
 
-**Shape:** Four numeric columns — `x`, `y`, `z`, `value` on a **21³** voxel grid (9,261 points, indices 0–20). `value` is the visual metric (simplex noise × 2 + 4).
+**Shape:** Four numeric columns — `x`, `y`, `z`, `value` on a **21³** voxel grid (9,261 points, indices 0–20). `value` is a visual metric (simplex noise × 2 + 4).
 
-**What vizb does:** Auto-value mode: `x,y,z` = position, 4th column = **metric**. Enables **3D** and **visualMap** automatically (point color and size by `value`), orthographic `scatter3D` like the [ECharts simplex-noise demo](https://echarts.apache.org/examples/en/editor.html?c=scatter3D-simplex-noise&gl=1).
+**What vizb does:** Continuous 3D via `--select x,y,z` for position. Pair with `--3d-visualmap` for gradient coloring (orthographic `scatter3D` like the [ECharts simplex-noise demo](https://echarts.apache.org/examples/en/editor.html?c=scatter3D-simplex-noise&gl=1)).
 
 **Good for:** `scatter3D` + visualMap on a manageable file size.
 
 | Goal | Command |
 |------|---------|
-| 3D scatter + visualMap (default) | `vizb scatter examples/csv/noise-grid.csv` |
-| Explicit visualMap flag | `vizb scatter examples/csv/noise-grid.csv --3d-visualmap` |
+| 3D scatter + visualMap | `vizb scatter examples/csv/noise-grid.csv --select x,y,z --3d-visualmap` |
+| With auto-rotate | `vizb scatter examples/csv/noise-grid.csv --select x,y,z --3d-visualmap --3d-rotate` |
 
 ---
 
@@ -87,13 +87,13 @@ These variants are also built in CI as `00-sales-auto-group`, `01-sales-grouped`
 
 **Shape:** Same as `noise-grid.csv` but **41³** (68,921 points, indices 0–40) — full resolution matching the ECharts example loop (`i,j,k` from 0 to 40, `value = noise3D(i/20,j/20,k/20)*2+4`).
 
-**What vizb does:** Same auto-value + metric + visualMap behavior as `noise-grid.csv`. Heavier dataset; same chart settings.
+**What vizb does:** Same continuous 3D via `--select x,y,z` as `noise-grid.csv`. Heavier dataset; same chart settings.
 
 **Good for:** Full-density ECharts-style demo when you want every voxel.
 
 | Goal | Command |
 |------|---------|
-| Full ECharts-scale grid | `vizb scatter examples/csv/noise-grid-41.csv` |
+| Full ECharts-scale grid | `vizb scatter examples/csv/noise-grid-41.csv --select x,y,z --3d-visualmap` |
 
 Use `noise-grid.csv` for faster loads; use this file when you need the complete grid.
 
@@ -117,17 +117,21 @@ Use `noise-grid.csv` for faster loads; use this file when you need the complete 
 
 ## `house-price-area2.csv`
 
-**Shape:** `area`, `price` — 16,174 rows ([ECharts house-price scatter](https://echarts.apache.org/examples/en/editor.html?c=scatter-large)). Auto-value xy; add `--visualmap` for price gradient. CI id: `03-house-price-area2` (tabular-data dashboard).
+**Shape:** `area`, `price` — 16,174 rows ([ECharts house-price scatter](https://echarts.apache.org/examples/en/editor.html?c=scatter-large)). Continuous xy via `--select area,price`; add `--visualmap` for price gradient. CI id: `03-house-price-area2` (tabular-data dashboard).
+
+| Goal | Command |
+|------|---------|
+| House price scatter | `vizb scatter examples/csv/house-price-area2.csv --select area,price --visualmap` |
 
 ---
 
 ## `clusters.csv`
 
-**Shape:** `x`, `y` — 60 rows of 2D cluster coordinates. Auto-value xy; `--visualmap` and `--symbol-size 10` for sized, color-mapped points. CI id: `04-clusters` (math-and-3d dashboard).
+**Shape:** `x`, `y` — 60 rows of 2D cluster coordinates. Continuous xy via `--select x,y`; `--visualmap` and `--symbol-size 10` for sized, color-mapped points. CI id: `04-clusters` (math-and-3d dashboard).
 
 | Goal | Command |
 |------|---------|
-| Cluster scatter with visualMap | `vizb scatter examples/csv/clusters.csv --visualmap --symbol-size 10 -o out.html` |
+| Cluster scatter with visualMap | `vizb scatter examples/csv/clusters.csv --select x,y --visualmap --symbol-size 10 -o out.html` |
 
 ---
 
@@ -154,16 +158,16 @@ CI id: `00-concurrency-frameworks` on the **comparisons** dashboard (see `.githu
 | File | Rows | Mode | Typical chart |
 |------|------|------|----------------|
 | `sales.csv` | 10,000 | Auto-group or explicit `--group` | Bar (2D / 3D), line, scatter |
-| `spiral-3d.csv` | 25,000 | Auto-value (xyz) | Scatter3D, line3D, bar3D |
-| `noise-surface.csv` | 441 | Auto-value (xyz grid) | Bar3D surface |
-| `noise-grid.csv` | 9,261 | Auto-value (xyz + metric) | Scatter3D + visualMap |
-| `noise-grid-41.csv` | 68,921 | Auto-value (xyz + metric) | Scatter3D + visualMap (full grid) |
+| `spiral-3d.csv` | 25,000 | Solo `--select x,y,z` | Scatter3D, line3D, bar3D |
+| `noise-surface.csv` | 441 | Solo `--select x,y,z` | Bar3D surface |
+| `noise-grid.csv` | 9,261 | Solo `--select x,y,z` | Scatter3D + visualMap |
+| `noise-grid-41.csv` | 68,921 | Solo `--select x,y,z` | Scatter3D + visualMap (full grid) |
 | `region-metrics.csv` | 8 | Solo `--select` mixed | Scatter mixed (region × metric) |
-| `house-price-area2.csv` | 16,174 | Auto-value (xy) | Scatter2D + visualMap |
-| `clusters.csv` | 60 | Auto-value (xy) | Scatter2D + visualMap, symbol size 10 |
+| `house-price-area2.csv` | 16,174 | Solo `--select area,price` | Scatter2D + visualMap |
+| `clusters.csv` | 60 | Solo `--select x,y` | Scatter2D + visualMap, symbol size 10 |
 | `concurrency.csv` | 3 | Group + `--col-axis` | Bar/line competitor compare |
 
-**Auto-group** applies when the file has categorical columns and you did not pass `--group`. **Auto-value** applies when every column is numeric — vizb assigns `x`, `y`, `z` (and optional 4th metric) without flags.
+**Auto-group** applies when the file has categorical columns and you did not pass `--group`. **Auto col-axis x** applies when every column is numeric and you pass no flags — every numeric column name becomes a series on X (one chart). Continuous coordinates always need explicit solo `--select`.
 
 ## More detail
 

--- a/examples/csv/README.md
+++ b/examples/csv/README.md
@@ -160,8 +160,8 @@ CI id: `00-concurrency-frameworks` on the **comparisons** dashboard (see `.githu
 | `sales.csv` | 10,000 | Auto-group or explicit `--group` | Bar (2D / 3D), line, scatter |
 | `spiral-3d.csv` | 25,000 | Solo `--select x,y,z` | Scatter3D, line3D, bar3D |
 | `noise-surface.csv` | 441 | Solo `--select x,y,z` | Bar3D surface |
-| `noise-grid.csv` | 9,261 | Solo `--select x,y,z` | Scatter3D + visualMap |
-| `noise-grid-41.csv` | 68,921 | Solo `--select x,y,z` | Scatter3D + visualMap (full grid) |
+| `noise-grid.csv` | 9,261 | Solo `--select x,y,z,value` | Scatter3D + visualMap metric |
+| `noise-grid-41.csv` | 68,921 | Solo `--select x,y,z,value` | Scatter3D + visualMap (full grid) |
 | `region-metrics.csv` | 8 | Solo `--select` mixed | Scatter mixed (region × metric) |
 | `house-price-area2.csv` | 16,174 | Solo `--select area,price` | Scatter2D + visualMap |
 | `clusters.csv` | 60 | Solo `--select x,y` | Scatter2D + visualMap, symbol size 10 |

--- a/examples/csv/README.md
+++ b/examples/csv/README.md
@@ -72,14 +72,14 @@ These variants are also built in CI as `00-sales-auto-group`, `01-sales-grouped`
 
 **Shape:** Four numeric columns — `x`, `y`, `z`, `value` on a **21³** voxel grid (9,261 points, indices 0–20). `value` is a visual metric (simplex noise × 2 + 4).
 
-**What vizb does:** Continuous 3D via `--select x,y,z` for position. Pair with `--3d-visualmap` for gradient coloring (orthographic `scatter3D` like the [ECharts simplex-noise demo](https://echarts.apache.org/examples/en/editor.html?c=scatter3D-simplex-noise&gl=1)).
+**What vizb does:** Continuous 3D via `--select x,y,z,value` — position from the first three columns, **visualMap metric** from `value`. Pair with `--3d-visualmap` for gradient coloring (orthographic `scatter3D` like the [ECharts simplex-noise demo](https://echarts.apache.org/examples/en/editor.html?c=scatter3D-simplex-noise&gl=1)).
 
 **Good for:** `scatter3D` + visualMap on a manageable file size.
 
 | Goal | Command |
 |------|---------|
-| 3D scatter + visualMap | `vizb scatter examples/csv/noise-grid.csv --select x,y,z --3d-visualmap` |
-| With auto-rotate | `vizb scatter examples/csv/noise-grid.csv --select x,y,z --3d-visualmap --3d-rotate` |
+| 3D scatter + visualMap | `vizb scatter examples/csv/noise-grid.csv --select x,y,z,value --3d-visualmap` |
+| With auto-rotate | `vizb scatter examples/csv/noise-grid.csv --select x,y,z,value --3d-visualmap --3d-rotate` |
 
 ---
 
@@ -87,13 +87,13 @@ These variants are also built in CI as `00-sales-auto-group`, `01-sales-grouped`
 
 **Shape:** Same as `noise-grid.csv` but **41³** (68,921 points, indices 0–40) — full resolution matching the ECharts example loop (`i,j,k` from 0 to 40, `value = noise3D(i/20,j/20,k/20)*2+4`).
 
-**What vizb does:** Same continuous 3D via `--select x,y,z` as `noise-grid.csv`. Heavier dataset; same chart settings.
+**What vizb does:** Same continuous 3D via `--select x,y,z,value` as `noise-grid.csv`. Heavier dataset; same chart settings.
 
 **Good for:** Full-density ECharts-style demo when you want every voxel.
 
 | Goal | Command |
 |------|---------|
-| Full ECharts-scale grid | `vizb scatter examples/csv/noise-grid-41.csv --select x,y,z --3d-visualmap` |
+| Full ECharts-scale grid | `vizb scatter examples/csv/noise-grid-41.csv --select x,y,z,value --3d-visualmap` |
 
 Use `noise-grid.csv` for faster loads; use this file when you need the complete grid.
 

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -158,10 +158,12 @@ func Convert(in ConvertInput) (ConvertResult, error) {
 		return ConvertResult{}, err
 	}
 	if tabular {
-		if len(effectiveCfg.Group) == 0 {
-			points = shared.CollapseDataPointsByKey(points)
-		} else {
+		// Grouped rows and col-axis multi-stat both sum by key; plain flat
+		// multi-column (no group, no col-axis) collapses without summing.
+		if len(effectiveCfg.Group) > 0 || effectiveCfg.ColAxis != "" {
 			points = shared.AggregateDataPoints(points)
+		} else {
+			points = shared.CollapseDataPointsByKey(points)
 		}
 	}
 	points, effectiveCfg, err = ApplyColAxis(points, effectiveCfg, key, in.Title)
@@ -195,8 +197,9 @@ func Convert(in ConvertInput) (ConvertResult, error) {
 	return ConvertResult{Dataset: dataset, Warnings: warnings}, nil
 }
 
-// ApplyColAxis expands grouped multi-column stats onto a free axis and applies
-// the optional single-chart title. Ignored errors are warnings at the CLI
+// ApplyColAxis expands multi-column stats onto a free axis and applies the
+// optional single-chart title. Grouping is optional: empty group + ColAxis
+// expands after AggregateDataPoints. Ignored errors are warnings at the CLI
 // boundary and validation errors for strict callers such as the REST API.
 func ApplyColAxis(data []shared.DataPoint, cfg parser.Config, parserKey, title string) ([]shared.DataPoint, parser.Config, error) {
 	ignored := func(name, message string) ([]shared.DataPoint, parser.Config, error) {
@@ -219,20 +222,24 @@ func ApplyColAxis(data []shared.DataPoint, cfg parser.Config, parserKey, title s
 	if parserKey != "csv" && parserKey != "json" {
 		return ignored("colAxis", "--col-axis is only supported for csv/json parsers; ignoring")
 	}
-	if cfg.Mode.IsSelectAxis() {
-		return ignored("colAxis", "--col-axis requires grouped multi-column stats; ignoring")
-	}
-	if len(cfg.Group) == 0 && !parser.IsExplicitGrouping(cfg) {
-		return ignored("colAxis", "--col-axis requires grouping (-g/-r/-p or auto-group); ignoring")
+	// Solo value/mixed --select places coordinates on axes; col-axis expand is
+	// for multi-stat (or empty-group multi-column) series. Multi-stat is allowed.
+	if cfg.Mode.IsSelectAxis() && !cfg.Mode.IsMultiStat() {
+		return ignored("colAxis", "--col-axis not compatible with solo value/mixed --select")
 	}
 
 	dim := shared.Dimension(cfg.ColAxis)
-	groupAxes := parser.GroupAxes(cfg)
-	for _, axis := range groupAxes {
-		if axis.Key == dim.AxisKey() {
-			return data, cfg, &OptionError{
-				Name: "colAxis",
-				Err:  fmt.Errorf("--col-axis %q conflicts with group dimension (already used by --group-pattern)", cfg.ColAxis),
+	// Only treat pattern slots as occupied when grouping is actually active.
+	// A bare default GroupPattern "x" with empty Group must not block ColAxis=x.
+	var groupAxes []shared.Axis
+	if len(cfg.Group) > 0 || cfg.GroupRegex != "" || parser.IsExplicitGrouping(cfg) {
+		groupAxes = parser.GroupAxes(cfg)
+		for _, axis := range groupAxes {
+			if axis.Key == dim.AxisKey() {
+				return data, cfg, &OptionError{
+					Name: "colAxis",
+					Err:  fmt.Errorf("--col-axis %q conflicts with group dimension (already used by --group-pattern)", cfg.ColAxis),
+				}
 			}
 		}
 	}

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -232,7 +232,7 @@ func ApplyColAxis(data []shared.DataPoint, cfg parser.Config, parserKey, title s
 	// Only treat pattern slots as occupied when grouping is actually active.
 	// A bare default GroupPattern "x" with empty Group must not block ColAxis=x.
 	var groupAxes []shared.Axis
-	if len(cfg.Group) > 0 || cfg.GroupRegex != "" || parser.IsExplicitGrouping(cfg) {
+	if parser.IsExplicitGrouping(cfg) {
 		groupAxes = parser.GroupAxes(cfg)
 		for _, axis := range groupAxes {
 			if axis.Key == dim.AxisKey() {

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -400,11 +400,20 @@ func appendMetricAxis(axes []shared.Axis, cfg parser.Config, points []shared.Dat
 			return axes
 		}
 	}
-	label := cfg.MetricColumn
-	if label == "" {
-		label = "value"
-	}
+	label := metricAxisLabel(cfg)
 	return append(axes, shared.Axis{Key: "metric", Label: label, Type: "value"})
+}
+
+// metricAxisLabel prefers an explicit {label} from the 4th --select column when
+// present on the first SelectView; otherwise the metric column source name.
+func metricAxisLabel(cfg parser.Config) string {
+	if len(cfg.SelectViews) > 0 && cfg.SelectViews[0].MetricLabel != "" {
+		return cfg.SelectViews[0].MetricLabel
+	}
+	if cfg.MetricColumn != "" {
+		return cfg.MetricColumn
+	}
+	return "value"
 }
 
 func autoEnableValueMode3D(configs []internalcharts.ChartConfig, axes []shared.Axis, visualMap bool) {

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -52,8 +52,9 @@ func (s *CoreSuite) TestConvertColAxisTitle() {
 		s.Equal("Framework throughput", point.Stats[0].Type)
 	}
 
+	// Title without col-axis: categorical auto-group leaves multi-stat columns → title ignored.
 	_, err = Convert(ConvertInput{
-		Input:  []byte("load,default,chi\n100,1,2\n"),
+		Input:  []byte("region,default,chi\nwest,1,2\n"),
 		Parser: "csv",
 		Title:  "Ignored",
 		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
@@ -66,6 +67,24 @@ func (s *CoreSuite) TestConvertColAxisTitle() {
 	_, _, err = ApplyColAxis(nil, parser.Config{ColAxis: "value"}, "csv", "")
 	s.Require().ErrorAs(err, &optionErr)
 	s.Equal("colAxis", optionErr.Name)
+}
+
+func (s *CoreSuite) TestConvertColAxisWithoutGroup() {
+	result, err := Convert(ConvertInput{
+		Input:  []byte("a,b\n1,2\n3,4\n"),
+		Parser: "csv",
+		Config: parser.Config{ColAxis: "x"},
+		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
+	})
+	s.Require().NoError(err)
+	s.Len(result.Dataset.Data, 2)
+	byX := map[string]float64{}
+	for _, point := range result.Dataset.Data {
+		s.Require().Len(point.Stats, 1)
+		byX[point.XAxis] = *point.Stats[0].Value
+	}
+	s.Equal(4.0, byX["a"])
+	s.Equal(6.0, byX["b"])
 }
 
 func (s *CoreSuite) TestConvertJSONAndValidationFailures() {

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -432,6 +432,14 @@ func (s *CoreSuite) TestAssembleFallbacksAndHelpers() {
 	axes = appendMetricAxis(nil, parser.Config{}, []shared.DataPoint{{Metric: "1"}})
 	s.Equal("value", axes[0].Label)
 
+	// Prefer SelectView MetricLabel over MetricColumn source name.
+	axes = appendMetricAxis(nil, parser.Config{
+		MetricColumn: "value",
+		SelectViews:  []parser.SelectView{{MetricSource: "value", MetricLabel: "Noise"}},
+	}, []shared.DataPoint{{Metric: "4"}})
+	s.Equal("metric", axes[0].Key)
+	s.Equal("Noise", axes[0].Label)
+
 	bar := &barchart.Config{Type: "bar"}
 	autoEnableValueMode3D([]internalcharts.ChartConfig{bar}, []shared.Axis{{Key: "x", Type: "value"}, {Key: "y", Type: "value"}}, false)
 	s.Nil(bar.ThreeD)

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -87,6 +87,83 @@ func (s *CoreSuite) TestConvertColAxisWithoutGroup() {
 	s.Equal(6.0, byX["b"])
 }
 
+func (s *CoreSuite) TestApplyColAxisGuards() {
+	var optionErr *OptionError
+
+	_, _, err := ApplyColAxis(nil, parser.Config{ColAxis: "x"}, "go", "")
+	s.Require().ErrorAs(err, &optionErr)
+	s.Equal("colAxis", optionErr.Name)
+	s.True(optionErr.Ignored)
+	s.Contains(err.Error(), "only supported for csv/json")
+
+	_, _, err = ApplyColAxis(nil, parser.Config{
+		ColAxis: "x",
+		Mode:    parser.ModeValue,
+		SelectViews: []parser.SelectView{{
+			Columns: []parser.ColumnSpec{{Source: "x"}, {Source: "y"}},
+		}},
+	}, "csv", "t")
+	s.Require().ErrorAs(err, &optionErr)
+	s.True(optionErr.Ignored)
+	s.Contains(err.Error(), "not compatible with solo")
+
+	_, _, err = ApplyColAxis(nil, parser.Config{
+		ColAxis:      "x",
+		Group:        []string{"region"},
+		GroupPattern: "x",
+	}, "csv", "")
+	s.Require().ErrorAs(err, &optionErr)
+	s.False(optionErr.Ignored)
+	s.Contains(err.Error(), "conflicts with group dimension")
+
+	_, _, err = ApplyColAxis(nil, parser.Config{
+		ColAxis:      "z",
+		Group:        []string{"region"},
+		GroupPattern: "x",
+	}, "csv", "")
+	s.Require().ErrorAs(err, &optionErr)
+	s.Contains(err.Error(), "requires both x and y")
+}
+
+func (s *CoreSuite) TestMetricAxisLabelFromSelectView() {
+	points := []shared.DataPoint{{
+		XAxis: "1", YAxis: "2", ZAxis: "3", Metric: "4",
+		Stats: []shared.Stat{},
+	}}
+	cfg := parser.Config{
+		Mode:         parser.ModeValue,
+		MetricColumn: "noise",
+		SelectViews: []parser.SelectView{{
+			Columns: []parser.ColumnSpec{
+				{Source: "x", AxisKey: "x"},
+				{Source: "y", AxisKey: "y"},
+				{Source: "z", AxisKey: "z"},
+			},
+			MetricSource: "noise",
+			MetricLabel:  "Noise",
+		}},
+		Axes: []parser.ColumnSpec{
+			{Source: "x", AxisKey: "x"},
+			{Source: "y", AxisKey: "y"},
+			{Source: "z", AxisKey: "z"},
+		},
+	}
+	ds := Assemble(AssembleInput{
+		Points: points,
+		Parser: "csv",
+		Config: cfg,
+		Charts: []internalcharts.ChartConfig{&scatterchart.Config{Type: "scatter", Scale: "linear"}},
+	})
+	var metric shared.Axis
+	for _, ax := range ds.Axes {
+		if ax.Key == "metric" {
+			metric = ax
+		}
+	}
+	s.Equal("metric", metric.Key)
+	s.Equal("Noise", metric.Label)
+}
+
 func (s *CoreSuite) TestConvertJSONAndValidationFailures() {
 	result, err := Convert(ConvertInput{
 		Input:  []byte(`[{"region":"west","latency":12},{"region":"east","latency":18}]`),

--- a/pkg/parser/axes_spec.go
+++ b/pkg/parser/axes_spec.go
@@ -92,11 +92,16 @@ func ValueAxes(cfg Config) []shared.Axis {
 	return axes
 }
 
-// SelectViewAxesCfg returns a cfg copy with Axes from the first solo --select view.
+// SelectViewAxesCfg returns a cfg copy with Axes (and optional MetricColumn)
+// from the first solo --select view.
 func SelectViewAxesCfg(cfg Config) Config {
 	c := cfg
 	if len(cfg.SelectViews) > 0 {
-		c.Axes = append([]ColumnSpec(nil), cfg.SelectViews[0].Columns...)
+		view := cfg.SelectViews[0]
+		c.Axes = append([]ColumnSpec(nil), view.Columns...)
+		if view.MetricSource != "" {
+			c.MetricColumn = view.MetricSource
+		}
 	}
 	return c
 }

--- a/pkg/parser/csv/csv_test.go
+++ b/pkg/parser/csv/csv_test.go
@@ -526,14 +526,15 @@ func (s *CSVAutoGroupSuite) TestHighestCardinalityCategoricalWins() {
 	s.Equal([]string{"sells"}, statTypes(results[0].Stats))
 }
 
-func (s *CSVAutoGroupSuite) TestAllNumericAutoValues() {
-	// all numeric → auto-value-mode kicks in: first 2 cols become x,y value axes
+func (s *CSVAutoGroupSuite) TestAllNumericAutoColAxis() {
+	// all numeric → auto col-axis x; multi-stat points (expand is pipeline-side)
 	csv := "id,sells\n1,10\n2,20\n3,30\n"
-	results, _ := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	results, effective := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	s.Equal("x", effective.ColAxis)
+	s.Empty(effective.Axes)
 	s.Require().Len(results, 3)
-	s.Equal("1", results[0].XAxis)
-	s.Equal("10", results[0].YAxis)
-	s.Empty(results[0].Stats)
+	s.Empty(results[0].XAxis)
+	s.ElementsMatch([]string{"id", "sells"}, statTypes(results[0].Stats))
 }
 
 func (s *CSVAutoGroupSuite) TestAutoGroupPicksSingleColumnEvenWithMultipleCategoricals() {
@@ -570,116 +571,118 @@ func TestCSVAutoGroupSuite(t *testing.T) {
 	suite.Run(t, new(CSVAutoGroupSuite))
 }
 
-type CSVAutoValueSuite struct {
+type CSVAutoColAxisSuite struct {
 	suite.Suite
 	cfg           parser.Config
 	restoreOsExit func()
 }
 
-func (s *CSVAutoValueSuite) SetupTest() {
+func (s *CSVAutoColAxisSuite) SetupTest() {
 	s.restoreOsExit, _ = testutil.TrapOsExitPanic(s.T())
 	s.cfg = parser.Config{GroupPattern: "x", AutoGroup: true, ChartTypes: []string{"scatter"}}
 }
 
-func (s *CSVAutoValueSuite) TearDownTest() {
+func (s *CSVAutoColAxisSuite) TearDownTest() {
 	s.restoreOsExit()
 }
 
-func (s *CSVAutoValueSuite) writeFile(content string) string {
+func (s *CSVAutoColAxisSuite) writeFile(content string) string {
 	path := filepath.Join(s.T().TempDir(), "data.csv")
 	s.Require().NoError(os.WriteFile(path, []byte(content), 0644))
 	return path
 }
 
-func (s *CSVAutoValueSuite) TestTwoNumericColsProduceValueAxes() {
+func (s *CSVAutoColAxisSuite) TestTwoNumericColsSetColAxisMultiStat() {
 	csv := "price,latency\n10,5\n20,7\n30,9\n"
-	results, _ := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	results, effective := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	s.Equal("x", effective.ColAxis)
+	s.Empty(effective.Axes)
 	s.Require().Len(results, 3)
-	s.Equal("10", results[0].XAxis)
-	s.Equal("5", results[0].YAxis)
-	s.Equal("20", results[1].XAxis)
-	s.Equal("7", results[1].YAxis)
-	s.Empty(results[0].Stats)
+	s.Empty(results[0].XAxis)
+	s.Empty(results[0].YAxis)
+	s.ElementsMatch([]string{"price", "latency"}, statTypes(results[0].Stats))
+	s.Equal(10.0, *results[0].Stats[0].Value)
 }
 
-func (s *CSVAutoValueSuite) TestThreeNumericColsProduceValueAxes() {
+func (s *CSVAutoColAxisSuite) TestThreeNumericColsAllAsStats() {
 	csv := "price,latency,memory\n10,5,100\n20,7,200\n30,9,300\n"
-	results, _ := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	results, effective := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	s.Equal("x", effective.ColAxis)
+	s.Empty(effective.Axes)
 	s.Require().Len(results, 3)
-	s.Equal("10", results[0].XAxis)
-	s.Equal("5", results[0].YAxis)
-	s.Equal("100", results[0].ZAxis)
-	s.Empty(results[0].Stats)
+	s.Empty(results[0].XAxis)
+	s.ElementsMatch([]string{"price", "latency", "memory"}, statTypes(results[0].Stats))
 }
 
-func (s *CSVAutoValueSuite) TestFourNumericColsTakeFirstThree() {
+func (s *CSVAutoColAxisSuite) TestFourNumericColsAllAsStatsNoMetric() {
 	csv := "a,b,c,d\n1,2,3,4\n5,6,7,8\n"
-	results, _ := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	results, effective := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	s.Equal("x", effective.ColAxis)
+	s.Empty(effective.Axes)
+	s.Empty(effective.MetricColumn)
 	s.Require().Len(results, 2)
-	s.Equal("1", results[0].XAxis)
-	s.Equal("2", results[0].YAxis)
-	s.Equal("3", results[0].ZAxis)
-	s.Equal("4", results[0].Metric)
-	s.Empty(results[0].Stats)
+	s.Empty(results[0].Metric)
+	s.ElementsMatch([]string{"a", "b", "c", "d"}, statTypes(results[0].Stats))
 }
 
-func (s *CSVAutoValueSuite) TestOneNumericColFallsBackToFlat() {
-	// single numeric column → auto-group and auto-value both skip, flat series
+func (s *CSVAutoColAxisSuite) TestOneNumericColSetsColAxis() {
 	csv := "price\n10\n20\n"
-	results, _ := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	results, effective := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	s.Equal("x", effective.ColAxis)
 	s.Require().Len(results, 2)
 	s.Empty(results[0].XAxis)
-	s.NotEmpty(results[0].Stats)
+	s.Equal([]string{"price"}, statTypes(results[0].Stats))
 }
 
-func (s *CSVAutoValueSuite) TestAutoGroupTakesPriorityOverAutoValue() {
-	// categorical columns exist → auto-group fires, not auto-value
+func (s *CSVAutoColAxisSuite) TestAutoGroupTakesPriorityOverAutoColAxis() {
+	// categorical columns exist → auto-group fires, not auto col-axis
 	csv := "region,price,product\nWest,10,foo\nEast,20,bar\n"
-	results, _ := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	results, effective := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	s.Empty(effective.ColAxis)
 	s.Require().Len(results, 2)
 	s.NotEmpty(results[0].XAxis) // categorical xAxis from auto-group
 	s.Empty(results[0].YAxis)    // single-col group
 	s.NotEmpty(results[0].Stats) // price becomes chart column
 }
 
-func (s *CSVAutoValueSuite) TestMixedTypesSkipsNonNumeric() {
+func (s *CSVAutoColAxisSuite) TestMixedTypesAutoGroupNotColAxis() {
 	// region (non-numeric), price (numeric), product (non-numeric), latency (numeric)
 	// auto-group picks the categorical with highest cardinality
-	// auto-value only fires when NO categoricals exist
 	csv := "region,price,product,latency\nWest,10,foo,5\nEast,20,bar,7\n"
-	results, _ := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
-	// region has 2 distinct, product has 2 distinct → auto-group picks region as xAxis
+	results, effective := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	s.Empty(effective.ColAxis)
 	s.Require().Len(results, 2)
 	s.NotEmpty(results[0].XAxis)
 	s.NotEmpty(results[0].Stats)
 }
 
-func (s *CSVAutoValueSuite) TestPieChartFallsBackToFlat() {
-	// pie chart type → auto-value is NOT eligible, falls back to flat series
+func (s *CSVAutoColAxisSuite) TestPieChartGetsAutoColAxis() {
 	s.cfg.ChartTypes = []string{"pie"}
 	csv := "price,latency\n10,5\n20,7\n"
-	results, _ := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	results, effective := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	s.Equal("x", effective.ColAxis)
 	s.Require().Len(results, 2)
 	s.Empty(results[0].XAxis)
-	s.NotEmpty(results[0].Stats)
+	s.ElementsMatch([]string{"price", "latency"}, statTypes(results[0].Stats))
 }
 
-func (s *CSVAutoValueSuite) TestHeatmapChartFallsBackToFlat() {
+func (s *CSVAutoColAxisSuite) TestHeatmapGetsAutoColAxis() {
 	s.cfg.ChartTypes = []string{"heatmap"}
 	csv := "price,latency\n10,5\n20,7\n"
-	results, _ := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	results, effective := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	s.Equal("x", effective.ColAxis)
 	s.Require().Len(results, 2)
-	s.Empty(results[0].XAxis)
-	s.NotEmpty(results[0].Stats)
+	s.ElementsMatch([]string{"price", "latency"}, statTypes(results[0].Stats))
 }
 
-func (s *CSVAutoValueSuite) TestSelectSkipsAutoDetect() {
-	// Solo --select (SelectViews) disables auto-value inference and routes value mode.
+func (s *CSVAutoColAxisSuite) TestSelectSkipsAutoDetect() {
+	// Solo --select (SelectViews) disables auto col-axis inference and routes value mode.
 	s.cfg.SelectViews = []parser.SelectView{
 		{Columns: []parser.ColumnSpec{{Source: "x", AxisKey: "x"}, {Source: "y", AxisKey: "y"}}},
 	}
 	csv := "x,y,z,w\n1,2,3,4\n"
-	results, _ := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	results, effective := mustParseCSVFile(s.T(), s.writeFile(csv), s.cfg)
+	s.Empty(effective.ColAxis)
 	s.Require().Len(results, 1)
 	s.Equal("1", results[0].XAxis)
 	s.Equal("2", results[0].YAxis)
@@ -789,6 +792,6 @@ func (s *CSVErrorSuite) TestSelectMultiStatModeCustomTypeLabel() {
 	s.Equal("sales by region", results[0].Stats[1].Type)
 }
 
-func TestCSVAutoValueSuite(t *testing.T) {
-	suite.Run(t, new(CSVAutoValueSuite))
+func TestCSVAutoColAxisSuite(t *testing.T) {
+	suite.Run(t, new(CSVAutoColAxisSuite))
 }

--- a/pkg/parser/csv/csv_test.go
+++ b/pkg/parser/csv/csv_test.go
@@ -739,6 +739,26 @@ func (s *CSVErrorSuite) TestSelectValueModeAllNumeric() {
 	s.Empty(results[0].Stats)
 }
 
+func (s *CSVErrorSuite) TestSelectValueModeWithMetricColumn() {
+	// noise-grid shape: x,y,z position + value visualMap metric
+	view, err := parser.ParseSelectViewFlag("x,y,z,value")
+	s.Require().NoError(err)
+	s.cfg.SelectViews = []parser.SelectView{view}
+	s.cfg.Mode = parser.ResolveMode(s.cfg)
+	path := s.writeFile("x,y,z,value\n0,0,0,4\n1,2,3,5.5\n")
+
+	results, effective := mustParseCSVFile(s.T(), path, s.cfg)
+	s.Equal("value", effective.MetricColumn)
+	s.Require().Len(results, 2)
+	s.Equal("0", results[0].XAxis)
+	s.Equal("0", results[0].YAxis)
+	s.Equal("0", results[0].ZAxis)
+	s.Equal("4", results[0].Metric)
+	s.Equal("1", results[1].XAxis)
+	s.Equal("5.5", results[1].Metric)
+	s.Empty(results[0].Stats)
+}
+
 func (s *CSVErrorSuite) TestSelectMultiStatModeIndependentCombinations() {
 	s.cfg.SelectViews = []parser.SelectView{
 		{Columns: []parser.ColumnSpec{{Source: "region", AxisKey: "x"}, {Source: "latency", AxisKey: "y"}}},

--- a/pkg/parser/group_spec.go
+++ b/pkg/parser/group_spec.go
@@ -236,8 +236,8 @@ func AutoGroupColumns(headers []string, rows [][]string) (cols []string, pattern
 
 // NoExplicitGrouping reports whether the user supplied no explicit grouping
 // configuration (no --group, no --group-regex, default --group-pattern "x",
-// no --select, no auto-value axes). The pipeline uses it to decide whether to
-// opt the csv/json parsers into auto-grouping.
+// no --select, no explicit --axes). The pipeline uses it to decide whether to
+// opt the csv/json parsers into auto-grouping / auto col-axis.
 func NoExplicitGrouping(cfg Config) bool {
 	return !IsExplicitGrouping(cfg) &&
 		!HasSelect(cfg) &&
@@ -299,33 +299,6 @@ func numericColumns(headers []string, rows [][]string) []string {
 	return cols
 }
 
-// AutoValueColumns returns the first 2-3 purely numeric columns (in file
-// order) for auto-value-mode value axes (x, y, z). A column is numeric when
-// all non-empty cells parse as finite floats. Returns ok=false when <2 such
-// columns exist — caller falls back to flat-series.
-func AutoValueColumns(headers []string, rows [][]string) (cols []string, ok bool) {
-	all := numericColumns(headers, rows)
-	if len(all) < 2 {
-		return nil, false
-	}
-	if len(all) > 3 {
-		return all[:3], true
-	}
-	return all, true
-}
-
-// AutoValueEligible reports whether the given chart types are eligible for
-// auto-value-mode. Currently only scatter, bar, and line are supported;
-// pie/heatmap/radar fall back to flat series when all columns are numeric.
-func AutoValueEligible(types []string) bool {
-	for _, t := range types {
-		if t == "scatter" || t == "bar" || t == "line" {
-			return true
-		}
-	}
-	return false
-}
-
 // LogAutoGroup prints the inferred group column. The csv/json parsers call it
 // from their prelude so the inference is non-silent, mirroring the CLI's
 // "Auto-detected parser" message.
@@ -340,22 +313,9 @@ func LogAutoGroup(cols []string) {
 	fmt.Println(style.Info.Render(fmt.Sprintf("🧠 Auto-grouped by %s: %s", noun, strings.Join(cols, ", "))))
 }
 
-// LogAutoValue prints the inferred value axis columns (parallel to LogAutoGroup).
-func LogAutoValue(cols []string, metricCol string) {
-	if len(cols) == 0 {
-		return
-	}
-	noun := "columns"
-	if len(cols) == 2 {
-		noun = "columns (2D pattern x-y)"
-	} else if len(cols) == 3 {
-		noun = "columns (3D pattern x-y-z)"
-	}
-	msg := fmt.Sprintf("🧠 Auto-valued by %s: %s", noun, strings.Join(cols, ", "))
-	if metricCol != "" {
-		msg += fmt.Sprintf(", metric: %s", metricCol)
-	}
-	fmt.Println(style.Info.Render(msg))
+// LogAutoColAxis prints the inferred col-axis placement (parallel to LogAutoGroup).
+func LogAutoColAxis() {
+	fmt.Println(style.Info.Render("🧠 Auto col-axis x: all numeric columns as series"))
 }
 
 // FinalizeGroupConfig resolves and validates explicit --group config for tabular parsers.
@@ -371,7 +331,7 @@ func FinalizeGroupConfig(cfg Config) (Config, error) {
 	return cfg, ValidateTabularGroupAlignment(cfg)
 }
 
-// AutoDetectTabularConfig infers group columns or value axes when auto-group is enabled.
+// AutoDetectTabularConfig infers group columns or col-axis when auto-group is enabled.
 func AutoDetectTabularConfig(cfg Config, autoHeaders []string, rows [][]string) (Config, error) {
 	return autoDetectTabularConfig(cfg, autoHeaders, rows, true)
 }
@@ -385,6 +345,11 @@ func AutoDetectTabularConfigQuiet(cfg Config, autoHeaders []string, rows [][]str
 
 func autoDetectTabularConfig(cfg Config, autoHeaders []string, rows [][]string, log bool) (Config, error) {
 	if !AutoGroupApplies(cfg) {
+		return cfg, nil
+	}
+	// User-set col-axis alone means numeric multi-stat + expand later; do not
+	// auto-group or overwrite ColAxis.
+	if cfg.ColAxis != "" {
 		return cfg, nil
 	}
 
@@ -403,26 +368,13 @@ func autoDetectTabularConfig(cfg Config, autoHeaders []string, rows [][]string, 
 		return cfg, nil
 	}
 
-	if !AutoValueEligible(cfg.ChartTypes) {
-		return cfg, nil
-	}
-	allNumeric := numericColumns(autoHeaders, rows)
-	if len(allNumeric) < 2 {
-		return cfg, nil
-	}
-	valCols := allNumeric
-	if len(valCols) > 3 {
-		valCols = valCols[:3]
-	}
-	cfg.Axes = make([]ColumnSpec, len(valCols))
-	for i, name := range valCols {
-		cfg.Axes[i] = ColumnSpec{Source: name}
-	}
-	if len(allNumeric) >= 4 {
-		cfg.MetricColumn = allNumeric[3]
-	}
-	if log {
-		LogAutoValue(valCols, cfg.MetricColumn)
+	// All-numeric (or no categorical) fallback: place every numeric column as a
+	// series on x via --col-axis. Expand happens in the pipeline after aggregate.
+	if len(numericColumns(autoHeaders, rows)) >= 1 {
+		cfg.ColAxis = "x"
+		if log {
+			LogAutoColAxis()
+		}
 	}
 	return cfg, nil
 }

--- a/pkg/parser/group_spec_test.go
+++ b/pkg/parser/group_spec_test.go
@@ -238,116 +238,55 @@ func TestAutoGroupColumnsSuite(t *testing.T) {
 	suite.Run(t, new(AutoGroupColumnsSuite))
 }
 
-type AutoValueColumnsSuite struct {
+type NumericColumnsSuite struct {
 	suite.Suite
 }
 
-func (s *AutoValueColumnsSuite) TestThreeNumericCols() {
+func (s *NumericColumnsSuite) TestThreeNumericCols() {
 	headers := []string{"price", "latency", "memory"}
 	rows := [][]string{
 		{"10", "5", "100"},
 		{"20", "7", "200"},
 		{"30", "9", "300"},
 	}
-	cols, ok := AutoValueColumns(headers, rows)
-	s.Require().True(ok)
-	s.Equal([]string{"price", "latency", "memory"}, cols)
+	s.Equal([]string{"price", "latency", "memory"}, numericColumns(headers, rows))
 }
 
-func (s *AutoValueColumnsSuite) TestTwoNumericCols() {
-	headers := []string{"price", "latency"}
-	rows := [][]string{
-		{"10", "5"},
-		{"20", "7"},
-	}
-	cols, ok := AutoValueColumns(headers, rows)
-	s.Require().True(ok)
-	s.Equal([]string{"price", "latency"}, cols)
-}
-
-func (s *AutoValueColumnsSuite) TestOneNumericColReturnsFalse() {
-	headers := []string{"price", "region"}
-	rows := [][]string{
-		{"10", "West"},
-		{"20", "East"},
-	}
-	cols, ok := AutoValueColumns(headers, rows)
-	s.False(ok)
-	s.Empty(cols)
-}
-
-func (s *AutoValueColumnsSuite) TestAllNonNumericReturnsFalse() {
-	headers := []string{"region", "product"}
-	rows := [][]string{
-		{"West", "A"},
-		{"East", "B"},
-	}
-	cols, ok := AutoValueColumns(headers, rows)
-	s.False(ok)
-	s.Empty(cols)
-}
-
-func (s *AutoValueColumnsSuite) TestFourNumericColsReturnsFirstThree() {
-	headers := []string{"a", "b", "c", "d"}
-	rows := [][]string{
-		{"1", "2", "3", "4"},
-		{"5", "6", "7", "8"},
-	}
-	cols, ok := AutoValueColumns(headers, rows)
-	s.Require().True(ok)
-	s.Equal([]string{"a", "b", "c"}, cols)
-	all := numericColumns(headers, rows)
-	s.Require().GreaterOrEqual(len(all), 4)
-	s.Equal("d", all[3])
-}
-
-func (s *AutoValueColumnsSuite) TestMixedTypesSkipsNonNumeric() {
+func (s *NumericColumnsSuite) TestMixedTypesSkipsNonNumeric() {
 	headers := []string{"region", "price", "product", "latency"}
 	rows := [][]string{
 		{"West", "10", "foo", "5"},
 		{"East", "20", "bar", "7"},
 	}
-	// region (non-numeric) skipped, price (numeric) kept, product (non-numeric) skipped, latency (numeric) kept
-	cols, ok := AutoValueColumns(headers, rows)
-	s.Require().True(ok)
-	s.Equal([]string{"price", "latency"}, cols)
+	s.Equal([]string{"price", "latency"}, numericColumns(headers, rows))
 }
 
-func (s *AutoValueColumnsSuite) TestEmptyHeaderSkipped() {
+func (s *NumericColumnsSuite) TestEmptyHeaderSkipped() {
 	headers := []string{"price", "", "latency"}
 	rows := [][]string{
 		{"10", "x", "5"},
 		{"20", "y", "7"},
 	}
-	cols, ok := AutoValueColumns(headers, rows)
-	s.Require().True(ok)
-	s.Equal([]string{"price", "latency"}, cols)
+	s.Equal([]string{"price", "latency"}, numericColumns(headers, rows))
 }
 
-func (s *AutoValueColumnsSuite) TestNumericStringValuesClassifiedNumeric() {
-	headers := []string{"price", "count"}
+func (s *NumericColumnsSuite) TestAllNonNumeric() {
+	headers := []string{"region", "product"}
 	rows := [][]string{
-		{"10.5", "100"},
-		{"20.0", "200"},
+		{"West", "A"},
+		{"East", "B"},
 	}
-	cols, ok := AutoValueColumns(headers, rows)
-	s.Require().True(ok)
-	s.Equal([]string{"price", "count"}, cols)
+	s.Empty(numericColumns(headers, rows))
 }
 
-func (s *AutoValueColumnsSuite) TestSingleColumnOnlyReturnsFalse() {
+func (s *NumericColumnsSuite) TestSingleNumericColumn() {
 	headers := []string{"price"}
-	rows := [][]string{
-		{"10"},
-		{"20"},
-	}
-	cols, ok := AutoValueColumns(headers, rows)
-	s.False(ok)
-	s.Empty(cols)
+	rows := [][]string{{"10"}, {"20"}}
+	s.Equal([]string{"price"}, numericColumns(headers, rows))
 }
 
-func TestAutoValueColumnsSuite(t *testing.T) {
-	suite.Run(t, new(AutoValueColumnsSuite))
+func TestNumericColumnsSuite(t *testing.T) {
+	suite.Run(t, new(NumericColumnsSuite))
 }
 
 func (s *GroupSpecSuite) TestParseGroupSpecEmptyGroup() {
@@ -445,15 +384,11 @@ func (s *GroupingHelpersSuite) TestLogAutoGroupEmptyIsNoOp() {
 	}
 }
 
-func (s *GroupingHelpersSuite) TestLogAutoValueBranches() {
+func (s *GroupingHelpersSuite) TestLogAutoColAxis() {
 	t := s.T()
-	out := testutil.CaptureStdout(func() { LogAutoValue([]string{"x", "y"}, "") })
-	if !strings.Contains(out, "2D") || !strings.Contains(out, "x, y") {
-		t.Fatalf("unexpected 2D log: %q", out)
-	}
-	out = testutil.CaptureStdout(func() { LogAutoValue([]string{"x", "y", "z"}, "m") })
-	if !strings.Contains(out, "3D") || !strings.Contains(out, "metric: m") {
-		t.Fatalf("unexpected 3D log: %q", out)
+	out := testutil.CaptureStdout(func() { LogAutoColAxis() })
+	if !strings.Contains(out, "Auto col-axis x") || !strings.Contains(out, "all numeric columns as series") {
+		t.Fatalf("unexpected auto col-axis log: %q", out)
 	}
 }
 
@@ -475,7 +410,7 @@ func (s *AutoDetectTabularConfigSuite) TestAutoGroupPath() {
 	s.Contains(out, "Auto-grouped")
 }
 
-func (s *AutoDetectTabularConfigSuite) TestAutoValue2D() {
+func (s *AutoDetectTabularConfigSuite) TestAutoColAxisAllNumeric() {
 	cfg := Config{AutoGroup: true, GroupPattern: "x", ChartTypes: []string{"scatter"}}
 	headers := []string{"price", "latency"}
 	rows := [][]string{{"10", "5"}, {"20", "7"}}
@@ -483,14 +418,15 @@ func (s *AutoDetectTabularConfigSuite) TestAutoValue2D() {
 	out := testutil.CaptureStdout(func() {
 		got, err := AutoDetectTabularConfig(cfg, headers, rows)
 		s.Require().NoError(err)
-		s.Len(got.Axes, 2)
-		s.Equal("price", got.Axes[0].Source)
-		s.Equal("latency", got.Axes[1].Source)
+		s.Equal("x", got.ColAxis)
+		s.Empty(got.Axes)
+		s.Empty(got.MetricColumn)
+		s.Empty(got.Group)
 	})
-	s.Contains(out, "2D")
+	s.Contains(out, "Auto col-axis x")
 }
 
-func (s *AutoDetectTabularConfigSuite) TestAutoValue3DWithMetric() {
+func (s *AutoDetectTabularConfigSuite) TestAutoColAxisFourNumericNoAxes() {
 	cfg := Config{AutoGroup: true, GroupPattern: "x", ChartTypes: []string{"line"}}
 	headers := []string{"a", "b", "c", "d"}
 	rows := [][]string{{"1", "2", "3", "4"}}
@@ -498,11 +434,40 @@ func (s *AutoDetectTabularConfigSuite) TestAutoValue3DWithMetric() {
 	out := testutil.CaptureStdout(func() {
 		got, err := AutoDetectTabularConfig(cfg, headers, rows)
 		s.Require().NoError(err)
-		s.Len(got.Axes, 3)
-		s.Equal("d", got.MetricColumn)
+		s.Equal("x", got.ColAxis)
+		s.Empty(got.Axes)
+		s.Empty(got.MetricColumn)
 	})
-	s.Contains(out, "3D")
-	s.Contains(out, "metric: d")
+	s.Contains(out, "Auto col-axis x")
+}
+
+func (s *AutoDetectTabularConfigSuite) TestAutoColAxisSingleNumeric() {
+	cfg := Config{AutoGroup: true, GroupPattern: "x", ChartTypes: []string{"scatter"}}
+	got, err := AutoDetectTabularConfig(cfg, []string{"price"}, [][]string{{"10"}, {"20"}})
+	s.Require().NoError(err)
+	s.Equal("x", got.ColAxis)
+	s.Empty(got.Axes)
+}
+
+func (s *AutoDetectTabularConfigSuite) TestPieGetsAutoColAxis() {
+	cfg := Config{AutoGroup: true, GroupPattern: "x", ChartTypes: []string{"pie"}}
+	got, err := AutoDetectTabularConfig(cfg, []string{"a", "b"}, [][]string{{"1", "2"}})
+	s.Require().NoError(err)
+	s.Equal("x", got.ColAxis)
+	s.Empty(got.Axes)
+}
+
+func (s *AutoDetectTabularConfigSuite) TestColAxisSetSkipsAutoGroup() {
+	// User col-axis alone: no auto-group even when categoricals exist.
+	cfg := Config{AutoGroup: true, GroupPattern: "x", ColAxis: "x", ChartTypes: []string{"bar"}}
+	headers := []string{"region", "sells"}
+	rows := [][]string{{"West", "10"}, {"East", "20"}}
+
+	got, err := AutoDetectTabularConfig(cfg, headers, rows)
+	s.Require().NoError(err)
+	s.Equal("x", got.ColAxis)
+	s.Empty(got.Group)
+	s.Empty(got.Axes)
 }
 
 func (s *AutoDetectTabularConfigSuite) TestSkipsWhenAutoGroupOff() {
@@ -510,20 +475,16 @@ func (s *AutoDetectTabularConfigSuite) TestSkipsWhenAutoGroupOff() {
 	got, err := AutoDetectTabularConfig(cfg, []string{"a", "b"}, [][]string{{"1", "2"}})
 	s.Require().NoError(err)
 	s.Empty(got.Axes)
+	s.Empty(got.ColAxis)
 }
 
-func (s *AutoDetectTabularConfigSuite) TestSkipsWhenPieOnly() {
-	cfg := Config{AutoGroup: true, GroupPattern: "x", ChartTypes: []string{"pie"}}
-	got, err := AutoDetectTabularConfig(cfg, []string{"a", "b"}, [][]string{{"1", "2"}})
+func (s *AutoDetectTabularConfigSuite) TestNoNumericLeavesUnchanged() {
+	cfg := Config{AutoGroup: true, GroupPattern: "x", ChartTypes: []string{"bar"}}
+	// Single categorical column: auto-group needs ≥2 headers; no numeric → no col-axis.
+	got, err := AutoDetectTabularConfig(cfg, []string{"region"}, [][]string{{"West"}, {"East"}})
 	s.Require().NoError(err)
-	s.Empty(got.Axes)
-}
-
-func (s *AutoDetectTabularConfigSuite) TestSkipsWhenFewerThanTwoNumeric() {
-	cfg := Config{AutoGroup: true, GroupPattern: "x", ChartTypes: []string{"scatter"}}
-	got, err := AutoDetectTabularConfig(cfg, []string{"price"}, [][]string{{"10"}, {"20"}})
-	s.Require().NoError(err)
-	s.Empty(got.Axes)
+	s.Empty(got.ColAxis)
+	s.Empty(got.Group)
 }
 
 func (s *AutoDetectTabularConfigSuite) TestFinalizeGroupConfigSkipsRegex() {
@@ -535,33 +496,6 @@ func (s *AutoDetectTabularConfigSuite) TestFinalizeGroupConfigSkipsRegex() {
 
 func TestAutoDetectTabularConfigSuite(t *testing.T) {
 	suite.Run(t, new(AutoDetectTabularConfigSuite))
-}
-
-func (s *GroupingHelpersSuite) TestAutoValueEligible() {
-	t := s.T()
-	tests := []struct {
-		name  string
-		types []string
-		want  bool
-	}{
-		{"scatter only", []string{"scatter"}, true},
-		{"bar only", []string{"bar"}, true},
-		{"line only", []string{"line"}, true},
-		{"pie only", []string{"pie"}, false},
-		{"heatmap only", []string{"heatmap"}, false},
-		{"radar only", []string{"radar"}, false},
-		{"mixed with eligible", []string{"pie", "bar", "radar"}, true},
-		{"mixed without eligible", []string{"pie", "heatmap", "radar"}, false},
-		{"empty slice", []string{}, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := AutoValueEligible(tt.types)
-			if got != tt.want {
-				t.Errorf("AutoValueEligible(%v) = %v, want %v", tt.types, got, tt.want)
-			}
-		})
-	}
 }
 
 func TestGroupingHelpersSuite(t *testing.T) {

--- a/pkg/parser/json/json_test.go
+++ b/pkg/parser/json/json_test.go
@@ -714,20 +714,6 @@ func (s *JSONErrorSuite) TestValueModeSkipsRowWithBadMetric() {
 	s.Equal("8", results[1].Metric)
 }
 
-func (s *JSONAutoValueSuite) TestSelectSkipsAutoDetect() {
-	// Solo --select (SelectViews) disables auto-value inference and routes value mode.
-	s.cfg.SelectViews = []parser.SelectView{
-		{Columns: []parser.ColumnSpec{{Source: "x", AxisKey: "x"}, {Source: "y", AxisKey: "y"}}},
-	}
-	path := s.writeFile(`[{"x":1,"y":2,"z":3,"w":4}]`)
-
-	results, _ := mustParseJSONFile(s.T(), path, s.cfg)
-	s.Require().Len(results, 1)
-	s.Equal("1", results[0].XAxis)
-	s.Equal("2", results[0].YAxis)
-	s.Empty(results[0].Stats)
-}
-
 func (s *JSONErrorSuite) TestSelectMixedModeMapsCategoryXAndValueY() {
 	s.cfg.SelectViews = []parser.SelectView{
 		{Columns: []parser.ColumnSpec{{Source: "region", AxisKey: "x"}, {Source: "latency", AxisKey: "y"}}},
@@ -844,14 +830,15 @@ func (s *JSONAutoGroupSuite) TestNestedFlattenedFieldChosen() {
 	s.Equal([]string{"sells"}, statTypes(results[0].Stats))
 }
 
-func (s *JSONAutoGroupSuite) TestAllNumericAutoValues() {
-	// all numeric → auto-value-mode: first 2 cols become x,y value axes
+func (s *JSONAutoGroupSuite) TestAllNumericAutoColAxis() {
+	// all numeric → auto col-axis x; multi-stat points (expand is pipeline-side)
 	j := `[{"id":1,"sells":10},{"id":2,"sells":20},{"id":3,"sells":30}]`
-	results, _ := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	results, effective := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	s.Equal("x", effective.ColAxis)
+	s.Empty(effective.Axes)
 	s.Require().Len(results, 3)
-	s.Equal("1", results[0].XAxis)
-	s.Equal("10", results[0].YAxis)
-	s.Empty(results[0].Stats)
+	s.Empty(results[0].XAxis)
+	s.ElementsMatch([]string{"id", "sells"}, statTypes(results[0].Stats))
 }
 
 func (s *JSONAutoGroupSuite) TestAutoGroupPicksSingleFieldEvenWithMultipleCategoricals() {
@@ -887,137 +874,159 @@ func TestJSONAutoGroupSuite(t *testing.T) {
 	suite.Run(t, new(JSONAutoGroupSuite))
 }
 
-type JSONAutoValueSuite struct {
+type JSONAutoColAxisSuite struct {
 	suite.Suite
 	cfg           parser.Config
 	restoreOsExit func()
 }
 
-func (s *JSONAutoValueSuite) SetupTest() {
+func (s *JSONAutoColAxisSuite) SetupTest() {
 	s.restoreOsExit, _ = testutil.TrapOsExitPanic(s.T())
 	s.cfg = parser.Config{GroupPattern: "x", AutoGroup: true, ChartTypes: []string{"scatter"}}
 }
 
-func (s *JSONAutoValueSuite) TearDownTest() {
+func (s *JSONAutoColAxisSuite) TearDownTest() {
 	s.restoreOsExit()
 }
 
-func (s *JSONAutoValueSuite) writeFile(content string) string {
+func (s *JSONAutoColAxisSuite) writeFile(content string) string {
 	path := filepath.Join(s.T().TempDir(), "data.json")
 	s.Require().NoError(os.WriteFile(path, []byte(content), 0644))
 	return path
 }
 
-func (s *JSONAutoValueSuite) TestTwoNumericFields() {
+func (s *JSONAutoColAxisSuite) TestTwoNumericFields() {
 	j := `[{"price":10,"latency":5},{"price":20,"latency":7}]`
-	results, _ := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	results, effective := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	s.Equal("x", effective.ColAxis)
+	s.Empty(effective.Axes)
 	s.Require().Len(results, 2)
-	s.Equal("10", results[0].XAxis)
-	s.Equal("5", results[0].YAxis)
-	s.Empty(results[0].Stats)
+	s.Empty(results[0].XAxis)
+	s.ElementsMatch([]string{"price", "latency"}, statTypes(results[0].Stats))
 }
 
-func (s *JSONAutoValueSuite) TestNoHeaderMatrixTwoNumericColumnsAutoValue() {
+func (s *JSONAutoColAxisSuite) TestNoHeaderMatrixTwoNumericColumnsAutoColAxis() {
 	j := `[[1,2],[3,4],[5,6]]`
 
-	results, _ := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	results, effective := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
 
+	s.Equal("x", effective.ColAxis)
+	s.Empty(effective.Axes)
 	s.Require().Len(results, 3)
-	s.Equal("1", results[0].XAxis)
-	s.Equal("2", results[0].YAxis)
-	s.Empty(results[0].Stats)
+	s.Empty(results[0].XAxis)
+	// matrix columns are named x, y, …
+	s.NotEmpty(results[0].Stats)
 }
 
-func (s *JSONAutoValueSuite) TestThreeNumericFields() {
+func (s *JSONAutoColAxisSuite) TestThreeNumericFields() {
 	j := `[{"price":10,"latency":5,"mem":100},{"price":20,"latency":7,"mem":200}]`
-	results, _ := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	results, effective := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	s.Equal("x", effective.ColAxis)
+	s.Empty(effective.Axes)
 	s.Require().Len(results, 2)
-	s.Equal("10", results[0].XAxis)
-	s.Equal("5", results[0].YAxis)
-	s.Equal("100", results[0].ZAxis)
-	s.Empty(results[0].Stats)
+	s.Empty(results[0].XAxis)
+	s.ElementsMatch([]string{"price", "latency", "mem"}, statTypes(results[0].Stats))
 }
 
-func (s *JSONAutoValueSuite) TestNoHeaderMatrixFourNumericColumnsUsesMetric() {
+func (s *JSONAutoColAxisSuite) TestNoHeaderMatrixFourNumericColumnsAllAsStats() {
 	j := `[[1,2,3,4],[5,6,7,8]]`
 
-	results, _ := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	results, effective := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
 
+	s.Equal("x", effective.ColAxis)
+	s.Empty(effective.Axes)
+	s.Empty(effective.MetricColumn)
 	s.Require().Len(results, 2)
-	s.Equal("1", results[0].XAxis)
-	s.Equal("2", results[0].YAxis)
-	s.Equal("3", results[0].ZAxis)
-	s.Equal("4", results[0].Metric)
-	s.Empty(results[0].Stats)
+	s.Empty(results[0].Metric)
+	s.NotEmpty(results[0].Stats)
 }
 
-func (s *JSONAutoValueSuite) TestNestedMatrixViaJSONPathAutoValue() {
+func (s *JSONAutoColAxisSuite) TestNestedMatrixViaJSONPathAutoColAxis() {
 	source := s.writeFile(`{"payload":{"rows":[[1,2],[3,4]]}}`)
 	selected, err := SelectPath(source, ".payload.rows")
 	s.Require().NoError(err)
 
-	results, _ := mustParseJSONFile(s.T(), s.writeFile(string(selected)), s.cfg)
+	results, effective := mustParseJSONFile(s.T(), s.writeFile(string(selected)), s.cfg)
 
+	s.Equal("x", effective.ColAxis)
 	s.Require().Len(results, 2)
-	s.Equal("1", results[0].XAxis)
-	s.Equal("2", results[0].YAxis)
-	s.Empty(results[0].Stats)
+	s.Empty(results[0].XAxis)
+	s.NotEmpty(results[0].Stats)
 }
 
-func (s *JSONAutoValueSuite) TestFourNumericFieldsTakeFirstThree() {
+func (s *JSONAutoColAxisSuite) TestFourNumericFieldsAllAsStatsNoMetric() {
 	j := `[{"a":1,"b":2,"c":3,"d":4},{"a":5,"b":6,"c":7,"d":8}]`
-	results, _ := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	results, effective := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	s.Equal("x", effective.ColAxis)
+	s.Empty(effective.Axes)
+	s.Empty(effective.MetricColumn)
 	s.Require().Len(results, 2)
-	s.Equal("1", results[0].XAxis)
-	s.Equal("2", results[0].YAxis)
-	s.Equal("3", results[0].ZAxis)
-	s.Equal("4", results[0].Metric)
-	s.Empty(results[0].Stats)
+	s.Empty(results[0].Metric)
+	s.ElementsMatch([]string{"a", "b", "c", "d"}, statTypes(results[0].Stats))
 }
 
-func (s *JSONAutoValueSuite) TestAutoGroupTakesPriority() {
+func (s *JSONAutoColAxisSuite) TestAutoGroupTakesPriority() {
 	// categorical exists → auto-group fires
 	j := `[{"region":"West","price":10},{"region":"East","price":20}]`
-	results, _ := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	results, effective := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	s.Empty(effective.ColAxis)
 	s.Require().Len(results, 2)
 	s.Equal("West", results[0].XAxis)
 	s.NotEmpty(results[0].Stats)
 }
 
-func (s *JSONAutoValueSuite) TestOneNumericFieldFallsBackToFlat() {
+func (s *JSONAutoColAxisSuite) TestOneNumericFieldSetsColAxis() {
 	j := `[{"price":10},{"price":20}]`
-	results, _ := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	results, effective := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	s.Equal("x", effective.ColAxis)
 	s.Require().Len(results, 2)
 	s.Empty(results[0].XAxis)
-	s.NotEmpty(results[0].Stats)
+	s.Equal([]string{"price"}, statTypes(results[0].Stats))
 }
 
-func (s *JSONAutoValueSuite) TestOneColumnMatrixFallsBackToFlat() {
+func (s *JSONAutoColAxisSuite) TestOneColumnMatrixSetsColAxis() {
 	j := `[[10],[20]]`
-	results, _ := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	results, effective := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	s.Equal("x", effective.ColAxis)
 	s.Require().Len(results, 2)
 	s.Empty(results[0].XAxis)
 	s.Equal([]string{"x"}, statTypes(results[0].Stats))
 }
 
-func (s *JSONAutoValueSuite) TestPieChartFallsBackToFlat() {
+func (s *JSONAutoColAxisSuite) TestPieChartGetsAutoColAxis() {
 	s.cfg.ChartTypes = []string{"pie"}
 	j := `[{"price":10,"latency":5},{"price":20,"latency":7}]`
-	results, _ := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	results, effective := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	s.Equal("x", effective.ColAxis)
 	s.Require().Len(results, 2)
 	s.Empty(results[0].XAxis)
-	s.NotEmpty(results[0].Stats)
+	s.ElementsMatch([]string{"price", "latency"}, statTypes(results[0].Stats))
 }
 
-func (s *JSONAutoValueSuite) TestRadarChartFallsBackToFlat() {
+func (s *JSONAutoColAxisSuite) TestRadarChartGetsAutoColAxis() {
 	s.cfg.ChartTypes = []string{"radar"}
 	j := `[{"price":10,"latency":5},{"price":20,"latency":7}]`
-	results, _ := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	results, effective := mustParseJSONFile(s.T(), s.writeFile(j), s.cfg)
+	s.Equal("x", effective.ColAxis)
 	s.Require().Len(results, 2)
-	s.Empty(results[0].XAxis)
-	s.NotEmpty(results[0].Stats)
+	s.ElementsMatch([]string{"price", "latency"}, statTypes(results[0].Stats))
 }
 
-func TestJSONAutoValueSuite(t *testing.T) {
-	suite.Run(t, new(JSONAutoValueSuite))
+func (s *JSONAutoColAxisSuite) TestSelectSkipsAutoDetect() {
+	// Solo --select (SelectViews) disables auto col-axis and routes value mode.
+	s.cfg.SelectViews = []parser.SelectView{
+		{Columns: []parser.ColumnSpec{{Source: "x", AxisKey: "x"}, {Source: "y", AxisKey: "y"}}},
+	}
+	path := s.writeFile(`[{"x":1,"y":2,"z":3,"w":4}]`)
+
+	results, effective := mustParseJSONFile(s.T(), path, s.cfg)
+	s.Empty(effective.ColAxis)
+	s.Require().Len(results, 1)
+	s.Equal("1", results[0].XAxis)
+	s.Equal("2", results[0].YAxis)
+	s.Empty(results[0].Stats)
+}
+
+func TestJSONAutoColAxisSuite(t *testing.T) {
+	suite.Run(t, new(JSONAutoColAxisSuite))
 }

--- a/pkg/parser/mode.go
+++ b/pkg/parser/mode.go
@@ -9,7 +9,7 @@ package parser
 //  2. Solo SelectViews (no explicit grouping):
 //     a. len > 1 → ModeMultiStat (validated to 2-col dim,metric)
 //     b. len == 1 → ModeValue or ModeMixed (caller resolves after type inference)
-//  3. Otherwise → ModeAuto
+//  3. Otherwise → ModeAuto (auto-group and/or auto col-axis; not auto-value axes)
 //
 // Mixed vs value for a solo single view is not known until ResolveAxesTypes
 // runs (it needs the data). ResolveMode sets ModeValue for a single solo view;

--- a/pkg/parser/registry.go
+++ b/pkg/parser/registry.go
@@ -26,11 +26,11 @@ type Config struct {
 	NumberUnit      string
 	Select          []ColumnSpec // grouped mode: numeric stat columns
 	SelectViews     []SelectView // solo axis mode: one entry per --select occurrence
-	Axes            []ColumnSpec // auto-value mode: numeric cols placed on x,y[,z]
-	MetricColumn    string       // auto-value: 4th numeric col → visualMap metric
+	Axes            []ColumnSpec // solo --select / --axes value mode: numeric cols on x,y[,z]
+	MetricColumn    string       // solo --select / --axes value mode: 4th numeric col → visualMap metric
 	JSONPath        string       // json only: jq-like dot path to the nested array to chart
-	AutoGroup       bool         // csv/json: infer group columns when no explicit grouping is configured
-	ChartTypes      []string     // csv/json auto-value eligibility check (scatter/bar/line only)
+	AutoGroup       bool         // csv/json: infer group columns / col-axis when no explicit grouping is configured
+	ChartTypes      []string     // chart types for the current run (used by chart-aware inference)
 	Mode            Mode         // resolved once in ParseConfig so downstream switches on cfg.Mode
 	ColAxis         string       // csv/json: place numeric column names on this axis (n/x/y/z); empty = one chart per column
 	QuietAutoDetect bool         // suppress csv/json auto-detection notices for request-scoped callers
@@ -42,7 +42,7 @@ type Config struct {
 type Mode int
 
 const (
-	ModeAuto      Mode = iota // no --select and no explicit grouping → auto-group/auto-value
+	ModeAuto      Mode = iota // no --select and no explicit grouping → auto-group / auto col-axis
 	ModeGrouped               // explicit grouping (-g/-r/-p) + --select numeric stat columns
 	ModeValue                 // solo --select, all numeric columns → value axes x,y[,z]
 	ModeMixed                 // solo --select, one categorical x + numeric y[,z]

--- a/pkg/parser/registry.go
+++ b/pkg/parser/registry.go
@@ -51,9 +51,13 @@ const (
 
 // SelectView is one solo --select flag: column placement plus an optional
 // chart-tab name from a trailing (Title) suffix in multi-stat mode.
+// MetricSource is an optional 4th value-mode column (positional or metric:col)
+// used as the visualMap metric; it is not a spatial axis.
 type SelectView struct {
-	Columns   []ColumnSpec
-	TypeLabel string
+	Columns      []ColumnSpec
+	TypeLabel    string
+	MetricSource string // optional visualMap metric column name
+	MetricLabel  string // optional {label} for the metric axis
 }
 
 // ParseFunc parses request-local input and returns data points, the effective

--- a/pkg/parser/select_view_spec.go
+++ b/pkg/parser/select_view_spec.go
@@ -48,9 +48,8 @@ func parseSelectViewColumns(raw string) (specs []ColumnSpec, metricSrc, metricLa
 	seenKey := map[string]bool{}
 	explicitCount := 0
 	type parsed struct {
-		spec       ColumnSpec
-		key        string
-		isExplicit bool
+		spec ColumnSpec
+		key  string // non-empty when explicit x:/y:/z:/metric:
 	}
 	items := make([]parsed, 0, n)
 
@@ -75,7 +74,7 @@ func parseSelectViewColumns(raw string) (specs []ColumnSpec, metricSrc, metricLa
 			seenKey[key] = true
 			spec.AxisKey = key
 		}
-		items = append(items, parsed{spec: spec, key: key, isExplicit: isExplicit})
+		items = append(items, parsed{spec: spec, key: key})
 	}
 
 	if explicitCount > 0 && explicitCount != n {
@@ -87,9 +86,6 @@ func parseSelectViewColumns(raw string) (specs []ColumnSpec, metricSrc, metricLa
 		axisItems := make([]parsed, 0, n)
 		for _, it := range items {
 			if it.key == "metric" {
-				if metricSrc != "" {
-					return nil, "", "", fmt.Errorf("duplicate metric column in --select")
-				}
 				metricSrc = it.spec.Source
 				metricLabel = it.spec.Label
 				continue
@@ -98,9 +94,6 @@ func parseSelectViewColumns(raw string) (specs []ColumnSpec, metricSrc, metricLa
 		}
 		if metricSrc != "" && len(axisItems) < 2 {
 			return nil, "", "", fmt.Errorf("--select metric requires at least x and y axes")
-		}
-		if metricSrc != "" && len(axisItems) > 3 {
-			return nil, "", "", fmt.Errorf("--select metric allows at most 3 spatial axes (x,y[,z])")
 		}
 		specs = make([]ColumnSpec, len(axisItems))
 		for i, it := range axisItems {

--- a/pkg/parser/select_view_spec.go
+++ b/pkg/parser/select_view_spec.go
@@ -8,8 +8,9 @@ import (
 	"github.com/goptics/vizb/shared/utils"
 )
 
-// ParseSelectViewFlag parses one solo --select value (e.g. "region,latency" or
-// "x:region,y:latency,z:sales") into 2–3 column specs with x/y/z axis keys.
+// ParseSelectViewFlag parses one solo --select value (e.g. "region,latency",
+// "x:region,y:latency,z:sales", or "x,y,z,value" / "x:x,y:y,z:z,metric:value")
+// into 2–3 spatial axis specs plus an optional visualMap metric column.
 // Reuses tokenizeSelectFlag from select_spec.go for {label}/quoting.
 // Multi-stat views may end with " (Chart Tab Name)" to rename stat.type.
 func ParseSelectViewFlag(raw string) (SelectView, error) {
@@ -17,68 +18,114 @@ func ParseSelectViewFlag(raw string) (SelectView, error) {
 	if err != nil {
 		return SelectView{}, err
 	}
-	specs, err := parseSelectViewColumns(cols)
+	specs, metricSrc, metricLabel, err := parseSelectViewColumns(cols)
 	if err != nil {
 		return SelectView{}, err
 	}
-	return SelectView{Columns: specs, TypeLabel: typeLabel}, nil
+	return SelectView{
+		Columns:      specs,
+		TypeLabel:    typeLabel,
+		MetricSource: metricSrc,
+		MetricLabel:  metricLabel,
+	}, nil
 }
 
-func parseSelectViewColumns(raw string) ([]ColumnSpec, error) {
+func parseSelectViewColumns(raw string) (specs []ColumnSpec, metricSrc, metricLabel string, err error) {
 	if strings.TrimSpace(raw) == "" {
-		return nil, fmt.Errorf("--select requires 2 or 3 columns (x,y[,z]); got 0")
+		return nil, "", "", fmt.Errorf("--select requires 2–4 columns (x,y[,z][,metric]); got 0")
 	}
 
 	tokens, err := tokenizeSelectFlag(raw)
 	if err != nil {
-		return nil, err
+		return nil, "", "", err
 	}
-	if n := len(tokens); n < 2 || n > 3 {
-		return nil, fmt.Errorf("--select requires 2 or 3 columns (x,y[,z]); got %d", n)
+	n := len(tokens)
+	if n < 2 || n > 4 {
+		return nil, "", "", fmt.Errorf("--select requires 2–4 columns (x,y[,z][,metric]); got %d", n)
 	}
 
 	seenCol := map[string]bool{}
 	seenKey := map[string]bool{}
-	specs := make([]ColumnSpec, 0, len(tokens))
 	explicitCount := 0
+	type parsed struct {
+		spec       ColumnSpec
+		key        string
+		isExplicit bool
+	}
+	items := make([]parsed, 0, n)
 
-	for i, tok := range tokens {
-		spec, key, isExplicit, err := parseAxisToken(tok)
-		if err != nil {
-			return nil, err
+	for _, tok := range tokens {
+		spec, key, isExplicit, perr := parseAxisToken(tok)
+		if perr != nil {
+			return nil, "", "", perr
 		}
 		if spec.Source == "" {
-			return nil, fmt.Errorf("empty column name in --select")
+			return nil, "", "", fmt.Errorf("empty column name in --select")
 		}
 		if seenCol[spec.Source] {
-			return nil, fmt.Errorf("duplicate column '%s' in --select", spec.Source)
+			return nil, "", "", fmt.Errorf("duplicate column '%s' in --select", spec.Source)
 		}
 		seenCol[spec.Source] = true
 
 		if isExplicit {
 			explicitCount++
 			if seenKey[key] {
-				return nil, fmt.Errorf("duplicate axis key '%s' in --select", key)
+				return nil, "", "", fmt.Errorf("duplicate axis key '%s' in --select", key)
 			}
 			seenKey[key] = true
 			spec.AxisKey = key
-		} else {
-			keys := []string{"x", "y", "z"}
-			spec.AxisKey = keys[i]
 		}
-		specs = append(specs, spec)
+		items = append(items, parsed{spec: spec, key: key, isExplicit: isExplicit})
 	}
 
-	if explicitCount > 0 && explicitCount != len(tokens) {
-		return nil, fmt.Errorf("--select: use explicit x:/y:/z: syntax for every column, or omit prefixes for all")
+	if explicitCount > 0 && explicitCount != n {
+		return nil, "", "", fmt.Errorf("--select: use explicit x:/y:/z:/metric: syntax for every column, or omit prefixes for all")
 	}
+
+	// Explicit metric:col peels off the visualMap metric; remaining are spatial axes.
 	if explicitCount > 0 {
-		if err := validateExplicitSelectAxisKeys(specs); err != nil {
-			return nil, err
+		axisItems := make([]parsed, 0, n)
+		for _, it := range items {
+			if it.key == "metric" {
+				if metricSrc != "" {
+					return nil, "", "", fmt.Errorf("duplicate metric column in --select")
+				}
+				metricSrc = it.spec.Source
+				metricLabel = it.spec.Label
+				continue
+			}
+			axisItems = append(axisItems, it)
 		}
+		if metricSrc != "" && len(axisItems) < 2 {
+			return nil, "", "", fmt.Errorf("--select metric requires at least x and y axes")
+		}
+		if metricSrc != "" && len(axisItems) > 3 {
+			return nil, "", "", fmt.Errorf("--select metric allows at most 3 spatial axes (x,y[,z])")
+		}
+		specs = make([]ColumnSpec, len(axisItems))
+		for i, it := range axisItems {
+			specs[i] = it.spec
+		}
+		if err := validateExplicitSelectAxisKeys(specs); err != nil {
+			return nil, "", "", err
+		}
+		return specs, metricSrc, metricLabel, nil
 	}
 
-	return specs, nil
+	// Positional: 2–3 → x,y[,z]; 4 → x,y,z + metric (last column).
+	if n == 4 {
+		metricSrc = items[3].spec.Source
+		metricLabel = items[3].spec.Label
+		items = items[:3]
+	}
+	keys := []string{"x", "y", "z"}
+	specs = make([]ColumnSpec, len(items))
+	for i, it := range items {
+		spec := it.spec
+		spec.AxisKey = keys[i]
+		specs[i] = spec
+	}
+	return specs, metricSrc, metricLabel, nil
 }
 
 // splitTrailingParenLabel strips a view-level " (Title)" suffix used for
@@ -120,7 +167,7 @@ func parseAxisToken(tok string) (ColumnSpec, string, bool, error) {
 	}
 
 	key := strings.TrimSpace(tok[:colon])
-	if key != "x" && key != "y" && key != "z" {
+	if key != "x" && key != "y" && key != "z" && key != "metric" {
 		spec, err := parseColumnToken(tok)
 		return spec, "", false, err
 	}
@@ -146,6 +193,7 @@ func validateExplicitSelectAxisKeys(specs []ColumnSpec) error {
 	if len(specs) == 3 && !has["z"] {
 		return fmt.Errorf("--select with 3 columns requires z:column in explicit syntax")
 	}
+	// metric: is peeled before this runs; only spatial keys remain.
 	return nil
 }
 

--- a/pkg/parser/select_view_spec_test.go
+++ b/pkg/parser/select_view_spec_test.go
@@ -60,6 +60,38 @@ func (s *SelectViewSpecSuite) TestParseSelectViewFlagExplicitSyntax() {
 	}
 }
 
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagFourColumnsPositionalMetric() {
+	view, err := ParseSelectViewFlag("x,y,z,value")
+	s.Require().NoError(err)
+	s.Len(view.Columns, 3)
+	s.Equal("x", view.Columns[0].AxisKey)
+	s.Equal("x", view.Columns[0].Source)
+	s.Equal("y", view.Columns[1].Source)
+	s.Equal("z", view.Columns[2].Source)
+	s.Equal("value", view.MetricSource)
+	s.Empty(view.MetricLabel)
+}
+
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagFourColumnsMetricLabel() {
+	view, err := ParseSelectViewFlag("x,y,z,value{Noise}")
+	s.Require().NoError(err)
+	s.Equal("value", view.MetricSource)
+	s.Equal("Noise", view.MetricLabel)
+}
+
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagExplicitMetric() {
+	view, err := ParseSelectViewFlag("x:x,y:y,z:z,metric:value")
+	s.Require().NoError(err)
+	s.Len(view.Columns, 3)
+	s.Equal("value", view.MetricSource)
+}
+
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagRejectsFiveColumns() {
+	_, err := ParseSelectViewFlag("a,b,c,d,e")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "2–4 columns")
+}
+
 func (s *SelectViewSpecSuite) TestParseSelectViewFlagTrailingParenTypeLabel() {
 	t := s.T()
 	view, err := ParseSelectViewFlag("region,latency (Latency by Region)")
@@ -107,8 +139,8 @@ func (s *SelectViewSpecSuite) TestParseSelectViewFlagRejectsArity() {
 	if _, err := ParseSelectViewFlag("region"); err == nil {
 		t.Fatal("want error for 1 column")
 	}
-	if _, err := ParseSelectViewFlag("a,b,c,d"); err == nil {
-		t.Fatal("want error for 4 columns")
+	if _, err := ParseSelectViewFlag("a,b,c,d,e"); err == nil {
+		t.Fatal("want error for 5 columns")
 	}
 	if _, err := ParseSelectViewFlag(""); err == nil {
 		t.Fatal("want error for empty")

--- a/pkg/parser/select_view_spec_test.go
+++ b/pkg/parser/select_view_spec_test.go
@@ -86,6 +86,39 @@ func (s *SelectViewSpecSuite) TestParseSelectViewFlagExplicitMetric() {
 	s.Equal("value", view.MetricSource)
 }
 
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagExplicitMetricWithLabel() {
+	view, err := ParseSelectViewFlag("x:x,y:y,metric:noise{Noise}")
+	s.Require().NoError(err)
+	s.Equal("noise", view.MetricSource)
+	s.Equal("Noise", view.MetricLabel)
+	s.Len(view.Columns, 2)
+}
+
+func (s *SelectViewSpecSuite) TestParseSelectViewFlagMetricErrorPaths() {
+	_, err := ParseSelectViewFlag(`"region,latency`)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "unclosed")
+
+	_, err = ParseSelectViewFlag(`x:col{bad,y:latency`)
+	s.Require().Error(err)
+
+	_, err = ParseSelectViewFlag("x:,y:latency")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "empty column")
+
+	_, err = ParseSelectViewFlag("x:a,y:b,metric:c,metric:d")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "duplicate axis key")
+
+	_, err = ParseSelectViewFlag("x:a,metric:b")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "at least x and y")
+
+	_, err = ParseSelectViewFlag("metric:only")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "2–4 columns")
+}
+
 func (s *SelectViewSpecSuite) TestParseSelectViewFlagRejectsFiveColumns() {
 	_, err := ParseSelectViewFlag("a,b,c,d,e")
 	s.Require().Error(err)

--- a/pkg/parser/tabular.go
+++ b/pkg/parser/tabular.go
@@ -150,7 +150,7 @@ func ParseSelectStatMode(rows []RowReader, cfg Config) ([]shared.DataPoint, erro
 	return results, nil
 }
 
-// DispatchSelectMode routes a solo --select (or --axes/auto-value) Config to the
+// DispatchSelectMode routes a solo --select (or explicit --axes) Config to the
 // right parse function after running ResolveAxesTypes. Called by the CSV/JSON
 // entry points; the flag label is baked into kindFn by the caller.
 func DispatchSelectMode(rows []RowReader, cfg *Config, kindFn AxisColumnKind) ([]shared.DataPoint, error) {

--- a/pkg/parser/tabular.go
+++ b/pkg/parser/tabular.go
@@ -169,7 +169,14 @@ func DispatchSelectMode(rows []RowReader, cfg *Config, kindFn AxisColumnKind) ([
 			cfg.SelectViews[0].Columns[i].AxisType = axesCfg.Axes[i].AxisType
 		}
 	}
+	// Surface metric column on the caller's config for dataset assembly.
+	if axesCfg.MetricColumn != "" {
+		cfg.MetricColumn = axesCfg.MetricColumn
+	}
 	if isMixedAxes(axesCfg) {
+		if axesCfg.MetricColumn != "" {
+			return nil, fmt.Errorf("--select metric is only supported in value mode (all-numeric axes); not with a categorical x")
+		}
 		cfg.Mode = ModeMixed
 		return ParseMixedMode(rows, axesCfg), nil
 	}

--- a/pkg/parser/tabular_test.go
+++ b/pkg/parser/tabular_test.go
@@ -211,6 +211,51 @@ func (s *TabularSuite) TestDispatchSelectMode() {
 	s.ErrorContains(err, "invalid axis")
 }
 
+func (s *TabularSuite) TestDispatchSelectModePropagatesMetricColumn() {
+	cfg := Config{Mode: ModeValue, SelectViews: []SelectView{{
+		Columns: []ColumnSpec{
+			{Source: "x", AxisKey: "x"},
+			{Source: "y", AxisKey: "y"},
+			{Source: "z", AxisKey: "z"},
+		},
+		MetricSource: "value",
+	}}}
+	rows := []RowReader{mockRowReader{
+		cells:   map[string]string{"value": "4"},
+		numeric: map[string]float64{"x": 1, "y": 2, "z": 3, "value": 4},
+		headers: []string{"x", "y", "z", "value"},
+	}}
+	points, err := DispatchSelectMode(rows, &cfg, func(string, string) (string, error) { return "value", nil })
+	s.Require().NoError(err)
+	s.Equal("value", cfg.MetricColumn)
+	s.Require().Len(points, 1)
+	s.Equal("4", points[0].Metric)
+	s.Equal("1", points[0].XAxis)
+	s.Equal("3", points[0].ZAxis)
+}
+
+func (s *TabularSuite) TestDispatchSelectModeRejectsMetricWithMixedAxes() {
+	cfg := Config{Mode: ModeValue, SelectViews: []SelectView{{
+		Columns: []ColumnSpec{
+			{Source: "region", AxisKey: "x"},
+			{Source: "latency", AxisKey: "y"},
+		},
+		MetricSource: "score",
+	}}}
+	rows := []RowReader{mockRowReader{
+		cells:   map[string]string{"region": "West"},
+		numeric: map[string]float64{"latency": 10, "score": 1},
+	}}
+	kindFn := func(source, _ string) (string, error) {
+		if source == "region" {
+			return "category", nil
+		}
+		return "value", nil
+	}
+	_, err := DispatchSelectMode(rows, &cfg, kindFn)
+	s.ErrorContains(err, "metric is only supported in value mode")
+}
+
 func (s *TabularSuite) TestParseSelectStatModeNonMerge() {
 	t := s.T()
 	cfg := Config{


### PR DESCRIPTION
## Summary

- **Remove auto-value** for all-numeric CSV/JSON: no more first 2–3 columns as continuous coordinates / auto 3D / 4th metric. Coordinate charts now require explicit solo `--select x,y[,z]`.
- **Auto col-axis x**: when no non-numeric columns exist, every numeric column becomes a series on **x** (one chart).
- **`--col-axis` without grouping**: works alone; only numeric columns become series (non-numeric ignored). Still composes with `-g`/`-p` (e.g. `-g load -p y -A x`).
- **`--col-axis` + `--select`**: independent; together, select filters numeric series and col-axis places them.
- **REST**: move `colAxis` to a top-level convert field (breaking; nested `grouping.colAxis` rejected).

## Test plan

- [x] `go test -count=1 ./api ./cmd ./cmd/cli ./pkg/core ./pkg/parser ./pkg/parser/csv ./pkg/parser/json`
- [x] Pre-commit suite (format + full CLI/UI tests)
- [x] Smoke: all-numeric no flags → series on x; mixed `-A x` → numeric only; `-A x --select a,b`; concurrency `-g load -p y -A x`
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * All-numeric CSV/JSON no longer auto-infer coordinate/value modes unless you provide `--select x,y` or `--select x,y,z`.
  * With no flags, all-numeric inputs now default to `--col-axis x` (each numeric column becomes an x-axis series).
  * `--col-axis` now works without grouping (numeric columns only); when grouping is used, axis conflicts with group patterns are still prevented.
  * REST conversion requests now accept `colAxis` as a top-level field.
* **Documentation**
  * Updated CLI/API docs, charts, guides, and example commands to match the new `--select`/`--col-axis` rules.
* **Tests**
  * Updated and expanded parsing, auto-inference, and request validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->