### PR TITLE
feat:docker packaging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ bin
 **/.vite
 .pnpm-store
 coverage.out
+pkg/template/vizb-ui.gen.go

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+bin
+**/node_modules
+**/dist
+**/.astro
+**/.vite
+.pnpm-store
+coverage.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM gcr.io/distroless/static-debian12:nonroot
+
+# Release wiring will copy the GoReleaser Linux binary into this context.
+COPY vizb /vizb
+
+ENTRYPOINT ["/vizb"]
+CMD ["serve", "--host", "0.0.0.0", "--port", "8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,28 @@
+FROM node:22-bookworm-slim AS ui
+
+WORKDIR /src/ui
+COPY ui/package.json ui/pnpm-lock.yaml ./
+RUN corepack enable && corepack prepare pnpm@9.12.0 --activate && pnpm install --frozen-lockfile
+
+COPY ui .
+COPY pkg /src/pkg
+RUN EMBED_UI=True pnpm build
+
+FROM golang:1.26-bookworm AS build
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+COPY --from=ui /src/pkg/template/vizb-ui.gen.go ./pkg/template/vizb-ui.gen.go
+
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o /vizb .
+
 FROM gcr.io/distroless/static-debian12:nonroot
 
-# Release wiring will copy the GoReleaser Linux binary into this context.
-COPY vizb /vizb
+# Release wiring may replace this build stage with the GoReleaser Linux binary.
+COPY --from=build /vizb /vizb
 
 ENTRYPOINT ["/vizb"]
 CMD ["serve", "--host", "0.0.0.0", "--port", "8080"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  vizb:
+    build: .
+    ports:
+      - "8080:8080"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,5 @@
 services:
   vizb:
-    build: .
+    image: vizb:local
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,5 @@
 services:
   vizb:
-    image: vizb:local
+    build: .
     ports:
       - "127.0.0.1:8080:8080"


### PR DESCRIPTION
## Related Issue
Closes #254 

## Changes
- Added multi-stage Docker build for UI embedding and Linux Go binary
  compilation.

- Uses minimal distroless nonroot runtime image.
- Preserves CLI argument override and default API server command.
- Added .dockerignore for smaller build context.
- Added Compose configuration with local build and loopback port binding.
- Verified with Docker build, CLI/API smoke tests, Compose, and full pre-
  submit checks.

## Test Result
### Docker
```bash
docker build --no-cache -t vizb:local .

docker run --rm vizb:local --help
docker run --rm vizb:local bar --help

docker run --rm -d \
    --name vizb-smoke \
    -p 127.0.0.1:8080:8080 \
    vizb:local
    
 curl -sS -o /dev/null -w '%{http_code}\n' \
    http://127.0.0.1:8080/
# expected 405
 
curl -sS -o /dev/null -w '%{http_code}\n' \
    -X POST http://127.0.0.1:8080/ \
    -H 'Content-Type: application/json' \
    -H 'Accept: application/json' \
    -d '{"input":"x,y\na,1\n","parser":"csv"}'

# expected: 200
```


### Docker Compose
```bash
docker compose up --build -d
docker compose ps

curl -sS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8080/
# Expected: 405
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker support for building and running the application in a production-ready container.
  * Added Docker Compose configuration for launching the service locally on port 8080.
* **Chores**
  * Reduced Docker build context by excluding development files, caches, dependencies, and build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->