### PR TITLE
feat(api): add health endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,12 +1,12 @@
 # API contract
 
-`openapi.yaml` is Vizb's canonical public REST contract. It describes only
-`POST /`, `POST /merge`, and `POST /ui`.
+`openapi.yaml` is Vizb's canonical public REST contract. It describes
+`GET /health`, `POST /`, `POST /merge`, and `POST /ui`.
 
 Errors use `application/problem+json`: malformed JSON returns `400`, bodies
 over 10 MiB return `413`, and valid JSON that violates schema or semantic rules
 returns `422`. Unknown paths return `404`; unsupported methods return `405`
-with `Allow: POST`.
+with the route's supported method in `Allow`.
 
 Run the contract checks from this directory:
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: Vizb REST API
-  version: 0.1.0
+  version: 0.2.0
   description: |
     A synchronous, stateless API for converting supported input into Vizb Datasets,
     merging Datasets, and generating a self-contained Vizb UI. The server exposes

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5,7 +5,7 @@ info:
   description: |
     A synchronous, stateless API for converting supported input into Vizb Datasets,
     merging Datasets, and generating a self-contained Vizb UI. The server exposes
-    exactly the three operations in this document; it has no authentication,
+    exactly the four operations in this document; it has no authentication,
     persistence, asynchronous jobs, remote URL ingestion, or server-side command
     execution.
   license:
@@ -23,6 +23,8 @@ servers:
         description: Listener port configured with `--port`.
 security: []
 tags:
+  - name: health
+    description: Report whether the server is accepting requests.
   - name: conversion
     description: Convert inline supported input into a Dataset or HTML.
   - name: datasets
@@ -30,6 +32,31 @@ tags:
   - name: ui
     description: Render complete Vizb Dataset objects as self-contained HTML.
 paths:
+  /health:
+    get:
+      tags: [health]
+      operationId: health
+      summary: Report whether the server is accepting requests.
+      responses:
+        '200':
+          description: The server is accepting requests.
+          content:
+            text/plain:
+              schema:
+                type: string
+                const: ok
+              example: ok
+        '405':
+          description: The method is not supported for this route.
+          headers:
+            Allow:
+              schema:
+                type: string
+                const: GET
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
   /:
     post:
       tags: [conversion]

--- a/api/openapi_test.go
+++ b/api/openapi_test.go
@@ -34,8 +34,8 @@ func (s *OpenAPISuite) TestOpenAPIContract() {
 	}
 
 	paths := mustMap(t, contract["paths"], "paths")
-	if len(paths) != 3 {
-		t.Fatalf("paths has %d entries, want exactly three", len(paths))
+	if len(paths) != 4 {
+		t.Fatalf("paths has %d entries, want exactly four", len(paths))
 	}
 	for _, path := range []string{"/", "/merge", "/ui"} {
 		pathItem := mustMap(t, paths[path], "paths."+path)
@@ -46,6 +46,28 @@ func (s *OpenAPISuite) TestOpenAPIContract() {
 
 	verifyReferences(t, contract, contract, "#")
 	verifyOperationExamples(t, contract)
+}
+
+func (s *OpenAPISuite) TestHealthContract() {
+	contract := readContract(s.T())
+	paths := mustMap(s.T(), contract["paths"], "paths")
+	path := mustMap(s.T(), paths["/health"], "paths./health")
+	s.Len(path, 1)
+	operation := mustMap(s.T(), path["get"], "paths./health.get")
+	responses := mustMap(s.T(), operation["responses"], "paths./health.get.responses")
+	s.Equal([]string{"200", "405"}, sortedMapKeys(responses))
+	success := mustMap(s.T(), responses["200"], "paths./health.get.responses.200")
+	content := mustMap(s.T(), success["content"], "paths./health.get.responses.200.content")
+	text := mustMap(s.T(), content["text/plain"], "health text response")
+	schema := mustMap(s.T(), text["schema"], "health text response schema")
+	s.Equal("string", schema["type"])
+	s.Equal("ok", schema["const"])
+
+	methodNotAllowed := mustMap(s.T(), responses["405"], "paths./health.get.responses.405")
+	headers := mustMap(s.T(), methodNotAllowed["headers"], "health method-not-allowed headers")
+	allow := mustMap(s.T(), headers["Allow"], "health Allow header")
+	allowSchema := mustMap(s.T(), allow["schema"], "health Allow header schema")
+	s.Equal("GET", allowSchema["const"])
 }
 
 func (s *OpenAPISuite) TestReusableSchemasMatchGoWireTypes() {
@@ -265,10 +287,12 @@ func verifyOperationExamples(t *testing.T, root map[string]any) {
 	seen := map[string]bool{}
 	paths := mustMap(t, root["paths"], "paths")
 	for path, rawPathItem := range paths {
-		operation := mustMap(t, mustMap(t, rawPathItem, "paths."+path)["post"], "paths."+path+".post")
-		verifyContentExamples(t, root, operation["requestBody"], "request "+path, seen)
-		for status, response := range mustMap(t, operation["responses"], path+".responses") {
-			verifyContentExamples(t, root, response, "response "+path+" "+status, seen)
+		for method, rawOperation := range mustMap(t, rawPathItem, "paths."+path) {
+			operation := mustMap(t, rawOperation, "paths."+path+"."+method)
+			verifyContentExamples(t, root, operation["requestBody"], "request "+path, seen)
+			for status, response := range mustMap(t, operation["responses"], path+".responses") {
+				verifyContentExamples(t, root, response, "response "+path+" "+status, seen)
+			}
 		}
 	}
 	for _, name := range []string{

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -64,48 +64,61 @@ func init() {
 	rootCmd.AddCommand(serveCmd)
 }
 
-// restHandlers is the composition point for the REST API. Keeping the three
+// restHandlers is the composition point for the REST API. Keeping the
 // operations as explicit handlers makes the route map testable and lets future
 // transports reuse the request-scoped core without changing server lifecycle
 // code.
 type restHandlers struct {
 	convert http.Handler
+	health  http.Handler
 	merge   http.Handler
 	ui      http.Handler
 }
 
+type restRoute struct {
+	method  string
+	handler http.Handler
+}
+
 type restRouter struct {
-	routes map[string]http.Handler
+	routes map[string]restRoute
 }
 
 func newRESTHandler() http.Handler {
 	return composeRESTRoutes(restHandlers{
 		convert: http.HandlerFunc(handleConvert),
+		health:  http.HandlerFunc(handleHealth),
 		merge:   http.HandlerFunc(handleMerge),
 		ui:      http.HandlerFunc(handleUI),
 	})
 }
 
 func composeRESTRoutes(handlers restHandlers) http.Handler {
-	return restRouter{routes: map[string]http.Handler{
-		"/":      handlers.convert,
-		"/merge": handlers.merge,
-		"/ui":    handlers.ui,
+	return restRouter{routes: map[string]restRoute{
+		"/":       {method: http.MethodPost, handler: handlers.convert},
+		"/health": {method: http.MethodGet, handler: handlers.health},
+		"/merge":  {method: http.MethodPost, handler: handlers.merge},
+		"/ui":     {method: http.MethodPost, handler: handlers.ui},
 	}}
 }
 
 func (router restRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	handler, ok := router.routes[r.URL.Path]
+	route, ok := router.routes[r.URL.Path]
 	if !ok {
 		writeAPIProblem(w, r, http.StatusNotFound, "Not found", "The requested operation does not exist.")
 		return
 	}
-	if r.Method != http.MethodPost {
-		w.Header().Set("Allow", http.MethodPost)
-		writeAPIProblem(w, r, http.StatusMethodNotAllowed, "Method not allowed", "This operation only supports POST.")
+	if r.Method != route.method {
+		w.Header().Set("Allow", route.method)
+		writeAPIProblem(w, r, http.StatusMethodNotAllowed, "Method not allowed", "This operation only supports "+route.method+".")
 		return
 	}
-	handler.ServeHTTP(w, r)
+	route.handler.ServeHTTP(w, r)
+}
+
+func handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = io.WriteString(w, "ok")
 }
 
 // newServeCommand wires a configured HTTP server to Cobra. Its dependencies

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -75,11 +75,15 @@ func (s *ServeSuite) TestDefaultsAndHTTPPolicy() {
 	s.False(applicationCalled.Load())
 }
 
-func (s *ServeSuite) TestRoutesRegisterOnlyTheThreePOSTOperations() {
+func (s *ServeSuite) TestRoutesRegisterDocumentedOperations() {
 	called := make(map[string]bool)
 	routes := composeRESTRoutes(restHandlers{
 		convert: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			called["convert"] = true
+			w.WriteHeader(http.StatusNoContent)
+		}),
+		health: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called["health"] = true
 			w.WriteHeader(http.StatusNoContent)
 		}),
 		merge: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -90,15 +94,17 @@ func (s *ServeSuite) TestRoutesRegisterOnlyTheThreePOSTOperations() {
 	})
 
 	for _, test := range []struct {
-		path string
-		name string
+		method string
+		path   string
+		name   string
 	}{
-		{path: "/", name: "convert"},
-		{path: "/merge", name: "merge"},
-		{path: "/ui", name: "ui"},
+		{method: http.MethodPost, path: "/", name: "convert"},
+		{method: http.MethodGet, path: "/health", name: "health"},
+		{method: http.MethodPost, path: "/merge", name: "merge"},
+		{method: http.MethodPost, path: "/ui", name: "ui"},
 	} {
 		recorder := httptest.NewRecorder()
-		routes.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, test.path, nil))
+		routes.ServeHTTP(recorder, httptest.NewRequest(test.method, test.path, nil))
 		s.Equal(http.StatusNoContent, recorder.Code, test.path)
 		s.True(called[test.name])
 	}
@@ -124,6 +130,19 @@ func (s *ServeSuite) TestRoutesRegisterOnlyTheThreePOSTOperations() {
 			}`,
 		},
 		{
+			name:    "wrong health method",
+			request: httptest.NewRequest(http.MethodPost, "/health", nil),
+			status:  http.StatusMethodNotAllowed,
+			allow:   http.MethodGet,
+			body: `{
+				"type":"https://vizb.goptics.org/problems/method-not-allowed",
+				"title":"Method not allowed",
+				"status":405,
+				"detail":"This operation only supports GET.",
+				"instance":"/health"
+			}`,
+		},
+		{
 			name:    "unknown path",
 			request: httptest.NewRequest(http.MethodPost, "/unknown", nil),
 			status:  http.StatusNotFound,
@@ -145,6 +164,18 @@ func (s *ServeSuite) TestRoutesRegisterOnlyTheThreePOSTOperations() {
 			s.JSONEq(test.body, recorder.Body.String())
 		})
 	}
+}
+
+func (s *ServeSuite) TestHealthEndpoint() {
+	request := httptest.NewRequest(http.MethodGet, "/health", nil)
+	request.Header.Set("Accept", "application/json")
+	recorder := httptest.NewRecorder()
+
+	newRESTHandler().ServeHTTP(recorder, request)
+
+	s.Equal(http.StatusOK, recorder.Code)
+	s.Equal("text/plain; charset=utf-8", recorder.Header().Get("Content-Type"))
+	s.Equal("ok", recorder.Body.String())
 }
 
 func (s *ServeSuite) TestInvalidConfigurationReturnsCommandError() {


### PR DESCRIPTION
## Related Issue
Closes #270 

## Changes
• - Add GET /health, returning 200 OK with plain-text ok.
- Return 405 with Allow: GET for unsupported /health methods.
- Preserve existing POST-only routing behavior.
- Document the endpoint in OpenAPI and API README.
- Add focused server and contract tests.

## Test Result
```bash
# command
curl -i http://127.0.0.1:8080/health

# result 
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
Date: Sat, 25 Jul 2026 04:02:10 GMT
Content-Length: 2

ok
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `GET /health` endpoint that returns `ok` as plain text.
  * Expanded the documented API contract to include four supported operations (including `/health`).

* **Bug Fixes**
  * Method-not-allowed responses now set the `Allow` header to the route’s supported method(s).

* **Tests**
  * Updated OpenAPI and server route tests to cover the full documented REST surface, including `/health` and method-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->