### PR TITLE
feat(release): publish multi-arch Docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
 
   goreleaser:
     needs: [cli, ui, api-contract]
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
             **What will happen after approval:**
             - GoReleaser builds binaries for linux/darwin/windows (amd64 + arm64)
             - Release is published to GitHub Releases
+            - Multi-arch Docker images are published to Docker Hub as goptics/vizb
             - Linux, macOS, and Windows installers smoke-test the published release
             - A PR is auto-submitted to microsoft/winget-pkgs
             - Docs and live examples at https://vizb.goptics.org/examples/live/ are rebuilt and published
@@ -59,6 +60,18 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -81,7 +94,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           # Workflow GITHUB_TOKEN has contents:write. A PAT in GORELEASER_TOKEN often

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,9 @@ before:
     - go mod tidy
 
 builds:
-  - env:
+  - id: vizb
+    binary: vizb
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
@@ -19,6 +21,30 @@ builds:
       - -s -w
       - -X github.com/goptics/vizb/version.Version={{.Tag}}
     main: .
+
+dockers_v2:
+  - id: vizb
+    ids:
+      - vizb
+    dockerfile: Dockerfile
+    images:
+      - goptics/vizb
+    tags:
+      - "{{ .Version }}"
+      - "{{ if not .IsSnapshot }}{{ .Major }}.{{ .Minor }}{{ end }}"
+      - "{{ if not .IsSnapshot }}{{ .Major }}{{ end }}"
+      - "{{ if not .IsSnapshot }}latest{{ end }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      org.opencontainers.image.source: https://github.com/goptics/vizb
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.licenses: MIT
+      org.opencontainers.image.description: A tabular data visualization engine for CSV, JSON, and benchmark output
+    flags:
+      - --target=release
 
 archives:
   - formats:
@@ -41,4 +67,3 @@ checksum:
 
 snapshot:
   version_template: "{{ .Tag }}-next"
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,13 @@ COPY --from=ui /src/pkg/template/vizb-ui.gen.go ./pkg/template/vizb-ui.gen.go
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o /vizb .
 
-FROM gcr.io/distroless/static-debian12:nonroot
-
-# Release wiring may replace this build stage with the GoReleaser Linux binary.
-COPY --from=build /vizb /vizb
-
+FROM gcr.io/distroless/static-debian12:nonroot AS runtime
 ENTRYPOINT ["/vizb"]
 CMD ["serve", "--host", "0.0.0.0", "--port", "8080"]
+
+FROM runtime AS release
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/vizb /vizb
+
+FROM runtime AS local
+COPY --from=build /vizb /vizb

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/perf v0.0.0-20250909190841-7e13e04d9366
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -33,5 +34,4 @@ require (
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/term v0.28.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
## Related issue

Closes #255

## Summary

- reuse GoReleaser-built Linux binaries in a dedicated distroless Docker target while preserving the existing local source-build path
- publish `linux/amd64` and `linux/arm64` images through GoReleaser `dockers_v2` with OCI metadata
- configure QEMU, Buildx, and Docker Hub authentication in the existing post-approval release job
- pin the GoReleaser action to v2 while `dockers_v2` remains the v2 configuration key

## Docker tags

| Release tag | Docker tags |
| --- | --- |
| `v0.x.y` | `0.x.y`, `0.x`, `0`, `latest` |

Snapshot releases build only platform-suffixed local images and do not publish floating tags.

## One-time setup required

- Create the Docker Hub repository `goptics/vizb`.
- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` as GitHub Actions secrets. The token must be able to push to `goptics/vizb`.

## Verification

- `goreleaser check`
- `goreleaser release --snapshot --clean` (built amd64 and arm64 images without publishing)
- `docker buildx build --check --target local .`
- full local Docker build plus CLI and API smoke tests
- `go test -count=1 ./...`
- `task format:check`
- `actionlint .github/workflows/release.yml`

The first real registry validation will occur on the next approved `v*.*.*` release after the Docker Hub repository and secrets are configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published multi-architecture Docker images (Linux AMD64 and ARM64) to Docker Hub under `goptics/vizb`.
  * Added versioned and `latest` image tags.
  * Included standardized container image metadata labels (source, version, revision, licenses, description).
* **Improvements**
  * Updated release automation to support cross-platform container builds and streamlined publishing.
  * Refreshed the production container layout using a dedicated runtime stage.
* **Chores**
  * Updated a dependency to be treated as a direct requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->