### PR TITLE
ci: sync vizb-ui.gen.go on main after ui/ changes

### DIFF
--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -4,33 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  embed-ui:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-go@v7
-        if: env.ACT != 'true'
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Setup embed UI
-        if: env.ACT != 'true'
-        uses: ./.github/actions/setup-embed-ui
-
-      - name: Upload embedded UI
-        if: env.ACT != 'true'
-        uses: actions/upload-artifact@v7
-        with:
-          name: cli-embedded-ui-${{ github.sha }}
-          path: pkg/template/vizb-ui.gen.go
-          if-no-files-found: error
-
   stateless:
-    needs: embed-ui
-    if: ${{ always() && (needs.embed-ui.result == 'success' || needs.embed-ui.result == 'skipped') }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -45,12 +19,11 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Download embedded UI
-        if: env.ACT != 'true'
-        uses: actions/download-artifact@v8
-        with:
-          name: cli-embedded-ui-${{ github.sha }}
-          path: pkg/template
+      # PRs and manual dispatch: rebuild so action tests see current ui/.
+      # workflow_call from main/release: tracked gen is enough.
+      - name: Rebuild embed for PR or dispatch
+        if: env.ACT != 'true' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+        uses: ./.github/actions/setup-embed-ui
 
       - name: Build vizb
         if: env.ACT != 'true'
@@ -74,8 +47,6 @@ jobs:
         run: node scripts/verify-action-output.mjs
 
   stateful:
-    needs: embed-ui
-    if: ${{ always() && (needs.embed-ui.result == 'success' || needs.embed-ui.result == 'skipped') }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -90,12 +61,9 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Download embedded UI
-        if: env.ACT != 'true'
-        uses: actions/download-artifact@v8
-        with:
-          name: cli-embedded-ui-${{ github.sha }}
-          path: pkg/template
+      - name: Rebuild embed for PR or dispatch
+        if: env.ACT != 'true' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+        uses: ./.github/actions/setup-embed-ui
 
       - name: Build vizb
         if: env.ACT != 'true'

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -50,77 +50,21 @@ jobs:
           fi
           echo "OK: gen file not modified in this PR"
 
-  embed-ui:
-    needs: [forbid-gen-commit]
-    # needs.forbid-gen-commit is skipped on push/workflow_call; still run embed.
-    if: ${{ always() && (needs.forbid-gen-commit.result == 'success' || needs.forbid-gen-commit.result == 'skipped') }}
+  lint:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7
-        with:
-          # PRs need history to detect ui/ changes against the base tip.
-          fetch-depth: 0
 
-      - name: Decide whether to rebuild embed
-        id: embed
-        run: |
-          set -euo pipefail
-          # Always rebuild on push/main and reusable workflow_call (release).
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "rebuild=true" >> "$GITHUB_OUTPUT"
-            echo "reason=non-PR event (${{ github.event_name }})"
-            exit 0
-          fi
-
-          base="${{ github.event.pull_request.base.sha }}"
-          head="${{ github.event.pull_request.head.sha }}"
-          if [ -z "$base" ] || [ -z "$head" ]; then
-            echo "rebuild=true" >> "$GITHUB_OUTPUT"
-            echo "reason=missing PR base/head; rebuild to be safe"
-            exit 0
-          fi
-
-          if git diff --name-only "$base"..."$head" | grep -qE '^(ui/|\.github/actions/setup-embed-ui/)'; then
-            echo "rebuild=true" >> "$GITHUB_OUTPUT"
-            echo "reason=PR touches ui/ or setup-embed-ui"
-          else
-            echo "rebuild=false" >> "$GITHUB_OUTPUT"
-            echo "reason=pure Go PR; use committed gen"
-          fi
-
-      - uses: actions/setup-go@v7
-        if: steps.embed.outputs.rebuild == 'true'
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Setup embed UI
-        if: steps.embed.outputs.rebuild == 'true'
+      # PRs: ephemeral re-embed so CLI tests see unmerged ui/ changes.
+      # main / release (workflow_call): use tracked gen (sync-embed-ui keeps main current).
+      - name: Rebuild embed for PR
+        if: github.event_name == 'pull_request'
         uses: ./.github/actions/setup-embed-ui
 
-      - name: Upload embedded UI
-        uses: actions/upload-artifact@v7
-        with:
-          name: cli-embedded-ui-${{ github.sha }}
-          path: pkg/template/vizb-ui.gen.go
-          if-no-files-found: error
-
-  lint:
-    needs: embed-ui
-    runs-on: ubuntu-slim
-    steps:
-      - uses: actions/checkout@v7
-
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
-
-      - name: Download embedded UI
-        uses: actions/download-artifact@v8
-        with:
-          name: cli-embedded-ui-${{ github.sha }}
-          path: pkg/template
 
       - uses: golangci/golangci-lint-action@v9
         with:
@@ -146,21 +90,18 @@ jobs:
           fi
 
   test:
-    needs: embed-ui
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7
+
+      - name: Rebuild embed for PR
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/setup-embed-ui
 
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
-
-      - name: Download embedded UI
-        uses: actions/download-artifact@v8
-        with:
-          name: cli-embedded-ui-${{ github.sha }}
-          path: pkg/template
 
       - run: go mod download
 

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,6 +17,7 @@ on:
     branches: [main]
     paths:
       - '**.go'
+      - 'ui/**'
       - go.mod
       - go.sum
       - .goreleaser.yml
@@ -26,17 +27,75 @@ on:
       - .github/actions/setup-embed-ui/**
 
 jobs:
-  embed-ui:
+  # Feature branches must not land gen churn; main is owned by sync-embed-ui.
+  forbid-gen-commit:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Reject pkg/template/vizb-ui.gen.go in PR diffs
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          if git diff --name-only "$base"..."$head" | grep -qx 'pkg/template/vizb-ui.gen.go'; then
+            echo "error: do not commit pkg/template/vizb-ui.gen.go"
+            echo "  The tracked snapshot on main is updated by .github/workflows/sync-embed-ui.yml (#319)."
+            echo "  Unstage with: git restore --staged pkg/template/vizb-ui.gen.go"
+            echo "  Discard local rewrite: git restore pkg/template/vizb-ui.gen.go"
+            exit 1
+          fi
+          echo "OK: gen file not modified in this PR"
+
+  embed-ui:
+    needs: [forbid-gen-commit]
+    # needs.forbid-gen-commit is skipped on push/workflow_call; still run embed.
+    if: ${{ always() && (needs.forbid-gen-commit.result == 'success' || needs.forbid-gen-commit.result == 'skipped') }}
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # PRs need history to detect ui/ changes against the base tip.
+          fetch-depth: 0
+
+      - name: Decide whether to rebuild embed
+        id: embed
+        run: |
+          set -euo pipefail
+          # Always rebuild on push/main and reusable workflow_call (release).
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "rebuild=true" >> "$GITHUB_OUTPUT"
+            echo "reason=non-PR event (${{ github.event_name }})"
+            exit 0
+          fi
+
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          if [ -z "$base" ] || [ -z "$head" ]; then
+            echo "rebuild=true" >> "$GITHUB_OUTPUT"
+            echo "reason=missing PR base/head; rebuild to be safe"
+            exit 0
+          fi
+
+          if git diff --name-only "$base"..."$head" | grep -qE '^(ui/|\.github/actions/setup-embed-ui/)'; then
+            echo "rebuild=true" >> "$GITHUB_OUTPUT"
+            echo "reason=PR touches ui/ or setup-embed-ui"
+          else
+            echo "rebuild=false" >> "$GITHUB_OUTPUT"
+            echo "reason=pure Go PR; use committed gen"
+          fi
 
       - uses: actions/setup-go@v7
+        if: steps.embed.outputs.rebuild == 'true'
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Setup embed UI
+        if: steps.embed.outputs.rebuild == 'true'
         uses: ./.github/actions/setup-embed-ui
 
       - name: Upload embedded UI

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -26,6 +26,9 @@ on:
       - .github/workflows/cli.yml
       - .github/actions/setup-embed-ui/**
 
+permissions:
+  contents: read
+
 jobs:
   # Feature branches must not land gen churn; main is owned by sync-embed-ui.
   forbid-gen-commit:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,7 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Download embedded UI
-        uses: actions/download-artifact@v8
-        with:
-          name: cli-embedded-ui-${{ github.sha }}
-          path: pkg/template
-
+      # Tracked gen on the tag (kept current on main by sync-embed-ui).
       - name: Download dependencies
         run: go mod download
 

--- a/.github/workflows/sync-embed-ui.yml
+++ b/.github/workflows/sync-embed-ui.yml
@@ -1,6 +1,9 @@
 # Sole routine writer of pkg/template/vizb-ui.gen.go on main.
 # Humans must not commit this file on feature branches (lefthook + CLI PR guard).
 #
+# Privilege split: generate runs with contents:read and no push credentials;
+# only the commit job gets contents:write and only touches the regular gen file.
+#
 # No infinite loop: this workflow only watches ui/** and the embed action; the
 # bot commits only the gen file. Additionally, commits made with GITHUB_TOKEN
 # do not re-trigger workflows (GitHub platform rule).
@@ -20,13 +23,17 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  sync:
+  generate:
     runs-on: ubuntu-slim
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup embed UI
         uses: ./.github/actions/setup-embed-ui
@@ -38,6 +45,27 @@ jobs:
 
       - name: Verify pure-Go build with regenerated embed
         run: go build -o /tmp/vizb-sync-check .
+
+      - name: Upload generated embed
+        uses: actions/upload-artifact@v7
+        with:
+          name: sync-embed-ui-gen
+          path: pkg/template/vizb-ui.gen.go
+          if-no-files-found: error
+
+  commit:
+    needs: generate
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download generated embed
+        uses: actions/download-artifact@v8
+        with:
+          name: sync-embed-ui-gen
+          path: pkg/template
 
       - name: Commit gen if changed
         uses: stefanzweifel/git-auto-commit-action@v7

--- a/.github/workflows/sync-embed-ui.yml
+++ b/.github/workflows/sync-embed-ui.yml
@@ -1,0 +1,48 @@
+# Sole routine writer of pkg/template/vizb-ui.gen.go on main.
+# Humans must not commit this file on feature branches (lefthook + CLI PR guard).
+#
+# No infinite loop: this workflow only watches ui/** and the embed action; the
+# bot commits only the gen file. Additionally, commits made with GITHUB_TOKEN
+# do not re-trigger workflows (GitHub platform rule).
+name: Sync embed UI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "ui/**"
+      - "ui/pnpm-lock.yaml"
+      - ".github/actions/setup-embed-ui/**"
+      - ".github/workflows/sync-embed-ui.yml"
+
+concurrency:
+  group: sync-embed-ui
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup embed UI
+        uses: ./.github/actions/setup-embed-ui
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify pure-Go build with regenerated embed
+        run: go build -o /tmp/vizb-sync-check .
+
+      - name: Commit gen if changed
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: "chore(ui): sync vizb-ui.gen.go"
+          file_pattern: pkg/template/vizb-ui.gen.go
+          commit_user_name: github-actions[bot]
+          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -141,6 +141,5 @@ jobs:
 
       # Smoke: prove embed generation still works. Tracked gen on main is
       # updated by sync-embed-ui.yml after ui/ merges; PRs must not commit gen.
-      # Release downloads cli-embedded-ui from the CLI workflow instead.
       - run: EMBED_UI=True pnpm build
         working-directory: ui

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -139,7 +139,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
         working-directory: ui
 
-      # Smoke: prove embed generation works. gen.go is gitignored; no sync check.
+      # Smoke: prove embed generation still works. Tracked gen on main is
+      # updated by sync-embed-ui.yml after ui/ merges; PRs must not commit gen.
       # Release downloads cli-embedded-ui from the CLI workflow instead.
       - run: EMBED_UI=True pnpm build
         working-directory: ui

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ Go-only contributors do **not** need Node.
 | Re-embed for CLI | Internal `embed:ui` (not in `task --list`); dep of `task build:cli` when `ui/` is newer than gen |
 | Clean tree after CLI build | `build:cli` runs `git restore` on gen after embed so feature branches do not keep dirty gen |
 | Pre-commit guard | Lefthook blocks staging/committing gen (`no-commit-ui-gen`); bypass only with `LEFTHOOK=0` when intentional |
+| CI PR guard | CLI workflow fails if a PR modifies the gen file |
+| Main sync | `.github/workflows/sync-embed-ui.yml` rebuilds and commits gen after `ui/` lands on main |
 | gofmt | Skipped for this file in Taskfile and CI format jobs |
 | golangci-lint | Still runs on it (no special exclude) |
 
@@ -53,9 +55,9 @@ After a fresh clone, the tracked gen file is enough for CLI builds and tests
 (`go build`, `go install`, or `task build:cli` with an up-to-date gen). UI
 work uses `task dev:ui` / `task build:ui` and does not own the gen file on the
 branch. **Do not commit** regenerated gen from feature branches; the snapshot on
-`main` is kept in sync by the follow-up CI bot (see #319). `task build:cli` may
-re-embed for a production binary, then restores the tracked gen so the working
-tree stays clean.
+`main` is updated by the sync-embed-ui workflow. `task build:cli` may re-embed
+for a production binary, then restores the tracked gen so the working tree stays
+clean.
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,9 @@ users do not install Node just to compile Vizb.
   updated by those tasks. `task build:cli` may re-embed when `ui/` is newer
   than gen (internal `embed:ui`), then **`git restore`s** the gen file so the
   working tree stays clean — **do not commit** regenerated gen from feature
-  branches. A Lefthook pre-commit hook fails if the gen file is staged. The
-  snapshot on `main` is kept in sync by CI when UI changes land (see tracking
-  issues under #316 / #319).
+  branches. A Lefthook pre-commit hook fails if the gen file is staged, and the
+  CLI PR workflow rejects diffs that touch it. The snapshot on `main` is updated
+  by `.github/workflows/sync-embed-ui.yml` after `ui/` merges.
 - `gofmt` (Task + CI format job) **skips** the gen file; `golangci-lint` still
   analyzes it.
 


### PR DESCRIPTION
## Summary

Implements #319 (final slice of #316 track-gen work).

- **`sync-embed-ui.yml`**: on `main` pushes that touch `ui/**` (or the embed action), rebuild via `setup-embed-ui`, `go build` smoke, then commit only `pkg/template/vizb-ui.gen.go` with [`stefanzweifel/git-auto-commit-action@v7`](https://github.com/stefanzweifel/git-auto-commit-action) as `github-actions[bot]` (`chore(ui): sync vizb-ui.gen.go`). No-op when gen is already current.
- **No loop**: path filters exclude the gen file; `GITHUB_TOKEN` commits also do not re-fire workflows.
- **CLI CI**: PR-only `forbid-gen-commit` job; pure Go PRs upload committed gen (skip Node); UI-touching PRs re-embed ephemerally; `pull_request` paths include `ui/**`; non-PR / `workflow_call` (release) always rebuilds.
- Docs/comments: AGENTS, CONTRIBUTING, `ui.yml` comment aligned with bot ownership.

## Test plan

- [ ] CI green on this PR (pure Go/docs/workflow change → uses committed gen; forbid-gen passes)
- [ ] After merge: next `ui/` change on main runs Sync embed UI and either no-ops or commits gen only
- [ ] Confirm bot commit does not re-run Sync embed UI
- [ ] Optional: open a throwaway PR that stages gen and confirm CLI fails the forbid job

Closes #319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI/CD**
  * Improved automated validation for embedded UI changes in pull requests.
  * UI updates are now rebuilt and synchronized automatically after merging to the main branch.
  * Streamlined checks for pull requests, manual runs, and releases, with more reliable build verification.

* **Documentation**
  * Updated contributor guidance covering UI generation, pull request validation, and automatic synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->