### PR TITLE
ci: push embed sync commits as vizb-bot

### DIFF
--- a/.github/workflows/sync-embed-ui.yml
+++ b/.github/workflows/sync-embed-ui.yml
@@ -2,11 +2,18 @@
 # Humans must not commit this file on feature branches (lefthook + CLI PR guard).
 #
 # Privilege split: generate runs with contents:read and no push credentials;
-# only the commit job gets contents:write and only touches the regular gen file.
+# commit mints a vizb-bot installation token so the push can bypass the main
+# PR-required ruleset (GITHUB_TOKEN / github-actions[bot] cannot).
 #
-# No infinite loop: this workflow only watches ui/** and the embed action; the
-# bot commits only the gen file. Additionally, commits made with GITHUB_TOKEN
-# do not re-trigger workflows (GitHub platform rule).
+# Secrets (repo Actions secrets):
+#   VIZB_BOT_APP_ID       — App ID from https://github.com/apps/vizb-bot
+#   VIZB_BOT_PRIVATE_KEY  — private key PEM generated on the app settings page
+#
+# Also add vizb-bot to Main rules bypass list (Apps → vizb-bot → Always).
+#
+# No infinite loop: path filters watch ui/** / setup action only; bot commits
+# only the gen file. App-token commits can re-fire other workflows (unlike
+# GITHUB_TOKEN); that is intentional for CLI on **.go.
 name: Sync embed UI
 
 on:
@@ -57,9 +64,18 @@ jobs:
     needs: generate
     runs-on: ubuntu-slim
     permissions:
-      contents: write
+      contents: read
     steps:
+      - name: Create vizb-bot token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.VIZB_BOT_APP_ID }}
+          private-key: ${{ secrets.VIZB_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Download generated embed
         uses: actions/download-artifact@v8
@@ -72,5 +88,5 @@ jobs:
         with:
           commit_message: "chore(ui): sync vizb-ui.gen.go"
           file_pattern: pkg/template/vizb-ui.gen.go
-          commit_user_name: github-actions[bot]
-          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          commit_user_name: vizb-bot[bot]
+          commit_user_email: 4463084+vizb-bot[bot]@users.noreply.github.com

--- a/.github/workflows/sync-embed-ui.yml
+++ b/.github/workflows/sync-embed-ui.yml
@@ -72,10 +72,14 @@ jobs:
         with:
           app-id: ${{ secrets.VIZB_BOT_APP_ID }}
           private-key: ${{ secrets.VIZB_BOT_PRIVATE_KEY }}
+          # Downscope: install may grant more; this token only needs push.
+          permission-contents: write
 
+      # persist-credentials true (default): git-auto-commit pushes with app token.
       - uses: actions/checkout@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
 
       - name: Download generated embed
         uses: actions/download-artifact@v8
@@ -89,4 +93,7 @@ jobs:
           commit_message: "chore(ui): sync vizb-ui.gen.go"
           file_pattern: pkg/template/vizb-ui.gen.go
           commit_user_name: vizb-bot[bot]
-          commit_user_email: 4463084+vizb-bot[bot]@users.noreply.github.com
+          # Bot user id 312060874 (not App ID 4463084) so GitHub links the bot badge.
+          commit_user_email: 312060874+vizb-bot[bot]@users.noreply.github.com
+          # Avoid defaulting author to the human who pushed the ui/ change.
+          commit_author: vizb-bot[bot] <312060874+vizb-bot[bot]@users.noreply.github.com>


### PR DESCRIPTION
## Summary

Wires the installed **vizb-bot** GitHub App into `sync-embed-ui` so gen commits can push to `main` under the ruleset bypass (built-in `github-actions[bot]` / `GITHUB_TOKEN` cannot).

- **generate:** still `contents: read` + `persist-credentials: false`
- **commit:** `actions/create-github-app-token@v2` → checkout with app token → download artifact → `git-auto-commit-action`

### Before merge — required setup

1. **Secrets** on `goptics/vizb` (Settings → Secrets and variables → Actions):
   - `VIZB_BOT_APP_ID` = `4463084` (App ID)
   - `VIZB_BOT_PRIVATE_KEY` = full PEM of the private key from the vizb-bot app settings
2. **Ruleset bypass** on [Main rules](https://github.com/goptics/vizb/rules/8103442): Bypass list → Apps → **vizb-bot** → Always
3. App install: only **vizb**, **Contents: Read and write**

### Test plan

- [ ] Secrets present
- [ ] vizb-bot on ruleset bypass
- [ ] After merge, re-run Sync embed UI or land a small `ui/` change
- [ ] Bot commit lands on main as `vizb-bot[bot]` without GH013

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated embed UI synchronization to use the `vizb-bot` GitHub App for authentication.
  * Synchronization commits are now attributed to `vizb-bot` rather than the generic GitHub Actions account.
  * Improved workflow permissions by removing unnecessary write access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->