### PR TITLE
ci: rename embed sync bot identity to vizber

### DIFF
--- a/.github/workflows/sync-embed-ui.yml
+++ b/.github/workflows/sync-embed-ui.yml
@@ -2,14 +2,14 @@
 # Humans must not commit this file on feature branches (lefthook + CLI PR guard).
 #
 # Privilege split: generate runs with contents:read and no push credentials;
-# commit mints a vizb-bot installation token so the push can bypass the main
+# commit mints a vizber installation token so the push can bypass the main
 # PR-required ruleset (GITHUB_TOKEN / github-actions[bot] cannot).
 #
 # Secrets (repo Actions secrets):
-#   VIZB_BOT_APP_ID       — App ID from https://github.com/apps/vizb-bot
-#   VIZB_BOT_PRIVATE_KEY  — private key PEM generated on the app settings page
+#   VIZBER_APP_ID       — App ID from https://github.com/apps/vizber
+#   VIZBER_PRIVATE_KEY  — private key PEM generated on the app settings page
 #
-# Also add vizb-bot to Main rules bypass list (Apps → vizb-bot → Always).
+# Also add vizber to Main rules bypass list (Apps → vizber → Always).
 #
 # No infinite loop: path filters watch ui/** / setup action only; bot commits
 # only the gen file. App-token commits can re-fire other workflows (unlike
@@ -66,12 +66,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Create vizb-bot token
+      - name: Create vizber token
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.VIZB_BOT_APP_ID }}
-          private-key: ${{ secrets.VIZB_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.VIZBER_APP_ID }}
+          private-key: ${{ secrets.VIZBER_PRIVATE_KEY }}
           # Downscope: install may grant more; this token only needs push.
           permission-contents: write
 
@@ -92,8 +92,10 @@ jobs:
         with:
           commit_message: "chore(ui): sync vizb-ui.gen.go"
           file_pattern: pkg/template/vizb-ui.gen.go
-          commit_user_name: vizb-bot[bot]
-          # Bot user id 312060874 (not App ID 4463084) so GitHub links the bot badge.
-          commit_user_email: 312060874+vizb-bot[bot]@users.noreply.github.com
+          # GitHub Apps always get a [bot] suffix; name the app "vizber" so commits
+          # show as vizber[bot] (not vizb-bot[bot]).
+          commit_user_name: vizber[bot]
+          # Bot user id (not App ID) so GitHub links the bot badge.
+          commit_user_email: 312060874+vizber[bot]@users.noreply.github.com
           # Avoid defaulting author to the human who pushed the ui/ change.
-          commit_author: vizb-bot[bot] <312060874+vizb-bot[bot]@users.noreply.github.com>
+          commit_author: vizber[bot] <312060874+vizber[bot]@users.noreply.github.com>


### PR DESCRIPTION
## Summary

GitHub Apps always get a `[bot]` suffix on commits, so an app named `vizb-bot` shows as **`vizb-bot[bot]`**. Rename the identity to **`vizber`** so commits show as **`vizber[bot]`**.

Workflow updates:
- Commit author/name/email → `vizber[bot]`
- Secrets → `VIZBER_APP_ID` / `VIZBER_PRIVATE_KEY`

## Manual steps (you)

1. **Rename the GitHub App** (org settings → GitHub Apps → vizb-bot):
   - Name / slug → `vizber`  
   - URL becomes https://github.com/apps/vizber  
2. **Secrets** on `goptics/vizb`:
   - Add `VIZBER_APP_ID` (same value as before, App ID still `4463084` if unchanged)
   - Add `VIZBER_PRIVATE_KEY` (same PEM, or a newly generated key)
   - Optionally delete old `VIZB_BOT_*` secrets  
3. **Ruleset bypass**: Main rules → bypass list → ensure **vizber** is listed (re-add if rename drops the old entry)

Bot user id in the workflow stays `312060874` unless GitHub assigns a new bot user after rename — re-check with `gh api 'users/vizber[bot]' --jq .id` if badge/linking looks wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated synchronization workflows to use the current GitHub App identity.
  * Updated related authentication and commit attribution settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->