### PR TITLE
build(ui): add explicit embed build command

### DIFF
--- a/.github/actions/setup-embed-ui/action.yml
+++ b/.github/actions/setup-embed-ui/action.yml
@@ -22,4 +22,4 @@ runs:
     - name: Build embed UI
       shell: bash
       working-directory: ui
-      run: EMBED_UI=True pnpm build
+      run: pnpm build:embed

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -141,5 +141,5 @@ jobs:
 
       # Smoke: prove embed generation still works. Tracked gen on main is
       # updated by sync-embed-ui.yml after ui/ merges; PRs must not commit gen.
-      - run: EMBED_UI=True pnpm build
+      - run: pnpm build:embed
         working-directory: ui

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN corepack enable && corepack prepare pnpm@9.12.0 --activate && pnpm install -
 
 COPY ui .
 COPY pkg /src/pkg
-RUN EMBED_UI=True pnpm build
+RUN pnpm build:embed
 
 FROM golang:1.26-bookworm AS build
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,7 +43,7 @@ tasks:
     generates:
       - pkg/template/vizb-ui.gen.go
     cmds:
-      - cd ui; [ -d node_modules ] || pnpm install; EMBED_UI=True pnpm build; cd -
+      - cd ui; [ -d node_modules ] || pnpm install; pnpm build:embed; cd -
 
   build:ui:
     desc: Build Vue UI (no CLI embed)

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
+    "build:embed": "vue-tsc -b && vite build --mode embed",
     "preview": "vite preview",
     "test": "vitest run",
     "test:unit": "vitest run --project unit",

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -4,20 +4,17 @@ import { createHtmlPlugin } from 'vite-plugin-html'
 import path from 'path'
 import { createEmbedPlugins, embedBuildOptions } from './embed-build/index.ts'
 
-const embedUi = process.env.EMBED_UI === 'True'
-console.info('EMBED_UI env var:', process.env.EMBED_UI)
-
 const esbuildOptions = {
   legalComments: 'none',
   pure: ['console.log', 'console.info', 'console.warn', 'console.debug', 'console.trace'],
 } as ESBuildOptions
 
 // https://vite.dev/config/
-export default defineConfig(({ command }) => ({
-  build: embedUi ? embedBuildOptions : undefined,
+export default defineConfig(({ command, mode }) => ({
+  build: mode === 'embed' ? embedBuildOptions : undefined,
   plugins: [
     vue(),
-    ...(embedUi ? createEmbedPlugins(__dirname) : []),
+    ...(mode === 'embed' ? createEmbedPlugins(__dirname) : []),
     createHtmlPlugin({
       minify: {
         removeComments: true,


### PR DESCRIPTION
## Summary

- add a UI-owned `pnpm build:embed` command using Vite embed mode
- route Task, Docker, and CI embed builds through the UI command
- keep regular `pnpm build` as a non-embedding Vue build
- leave `pkg/template/vizb-ui.gen.go` out of the feature PR

## Verification

- `task test`
- `task lint`
- `task format:check`
- `cd ui && pnpm build:embed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Added a dedicated embed UI build command.
  * Updated embed UI build workflows to use the dedicated command consistently.
  * Improved embed-mode detection through the build configuration, providing a more reliable and streamlined build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->