### PR TITLE
[bug]: shared structured-spec parser for multi-value --chart props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adhere
 
 - **Data-owned themes** — repeatable `--theme` and `--theme-active` embed a theme catalog on the dataset (`themes[]`; `themes[0]` active; no separate active field on new output). Built-ins expand from the CLI; the UI ships only `default`. Structured custom syntax `name:colors=#hex,...;visualMapColors=#hex,#hex` and bare hex anonymous customs. Multi-theme selector only when the author provides 2+ themes; localStorage scoped to the available set ([#327](https://github.com/goptics/vizb/issues/327)).
 
+### Fixed
+
+- **`--chart` multi-value props** — multi-value props (e.g. `stat=a,b`) are no longer broken by comma prop splitting ([#328](https://github.com/goptics/vizb/issues/328)).
+
+### Changed
+
+- **cli** — shared structured CLI spec tokenizer (`internal/specparse`) used by `--chart` and structured `--theme`.
+
 # [v0.17.1] - 2026-08-02
 
 ### Fixed

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,8 +85,10 @@ func init() {
 	rootBag.Bind(rootCmd.Flags())
 	rootCmd.Flags().StringSliceVarP(&rootCharts, "charts", "c", defaultChartTypes, "Chart types to generate (bar, line, scatter, pie, heatmap, radar)")
 	rootCmd.Flags().StringArrayVar(&rootChartSpecs, "chart", nil,
-		"Per-chart settings override: <type>:<key>=<val>(,<key>=<val>)* or bare flags (labels, stack, 3d-rotate, 3d). "+
-			"Keys: swap, sort, scale, stack, labels, 3d-rotate, 3d, symbol, symbol-size, smooth, horizontal. E.g. --chart bar:stack --chart line:smooth")
+		"Per-chart settings override (repeatable): <type>:<key>=<val>(,<key>=<val>)* or bare flags. "+
+			"Comma separates single-value props; for multi-value props (e.g. stat=a,b) use semicolon between props or put the multi-value prop alone. "+
+			"Keys: swap, sort, scale, stack, labels, 3d-rotate, 3d, symbol, symbol-size, smooth, horizontal, stat. "+
+			"E.g. --chart bar:stack --chart 'bar:stat=center,spread;labels'")
 
 	// Build the chart subcommands (bar/line/pie/heatmap/radar/scatter) from the
 	// config/charts registry.

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -62,7 +62,9 @@ func init() {
 	// --charts lets `vizb ui` prune chart chunks (incl. --data-url, where it's the
 	// only source of the selection since the data is fetched at runtime).
 	uiCmd.Flags().StringSliceVarP(&uiOpts.Charts, "charts", "c", shared.DefaultChartTypes, "Chart types to bundle (bar, line, pie, heatmap, radar, scatter)")
-	uiCmd.Flags().StringArrayVar(&uiOpts.ChartSpecs, "chart", nil, "Per-chart type settings override: <type>:<key>=<val>,... (repeatable)")
+	uiCmd.Flags().StringArrayVar(&uiOpts.ChartSpecs, "chart", nil,
+		"Per-chart settings override (repeatable): <type>:<key>=<val>,... or bare flags; "+
+			"use semicolon between props when a value contains commas (e.g. bar:stat=center,spread;labels)")
 	uiCmd.Flags().BoolVar(&uiOpts.Enable3D, "3d", false, "Bundle the 3D renderer for --data-url (remote data shape is unknown at build time)")
 	cli.BindStatFlag(uiCmd.Flags(), &uiOpts.Stat)
 }

--- a/docs/src/content/docs/ci-cd/github-action.mdx
+++ b/docs/src/content/docs/ci-cd/github-action.mdx
@@ -61,7 +61,7 @@ The action:
 | `col-axis` | `""` | **csv/json + group:** place numeric column names on this axis (`n`, `x`, `y`, or `z`) so all columns share one chart (`--col-axis` / `-A` flag). Requires group; target axis must not already be used by `group-pattern`. |
 | `json-path` | `""` | **json only:** select a nested array to chart via a jq-like dot path (e.g. `.data.results`) (`--json-path` flag). |
 | `stat` | `""` | Enable stats panel (`--stat` flag). Empty = disabled; `all` or `true` = all categories; otherwise comma-separated from: `counts`, `center`, `spread`, `extremes`, `shape`, `percentiles`, `confidence`, `correlations`. |
-| `chart` | `""` | Per-chart overrides (`--chart` flag, repeatable). One override per line: `<type>:<key>=<val>,...`. Keys: `swap`, `sort`, `scale`, `labels`, `3d-rotate`, `3d`. E.g. `bar:scale=log` or `pie:labels`. Blank lines and `#`-prefixed lines are ignored. |
+| `chart` | `""` | Per-chart overrides (`--chart` flag, repeatable). One override per line: `<type>:<props>`. Comma separates single-value props; for multi-value props (e.g. `stat=center,spread`) use semicolon between props or put the multi-value prop alone. E.g. `bar:scale=log`, `pie:labels`, `bar:stat=center,spread;labels`. Blank lines and `#`-prefixed lines are ignored. |
 | `charts` | `"bar,line,pie"` | Chart types to generate (`-c` flag): `bar`, `line`, `scatter`, `pie`, `heatmap`, `radar`. |
 | `parser` | `"auto"` | Parser to use: `csv`, `json`, `go`, `js:tinybench`, `js:vitest`, `rs:criterion`, `rs:divan` (`-P` flag). |
 | `show-labels` | `"false"` | **Deprecated:** use `chart` input instead (e.g. `chart: 'pie:labels'`). Show labels on charts (`-l` flag). |

--- a/docs/src/content/docs/commands/root.mdx
+++ b/docs/src/content/docs/commands/root.mdx
@@ -87,7 +87,7 @@ See the [Parser Guide](/guides/parsers) for each parser's metrics, and the
 | `--json-path` | | `""` | json only: select a nested array to chart via a jq-like dot path (e.g. `--json-path '.data.results'`) |
 | `--sort` | `-s` | `""` | **Deprecated on root:** use `--chart <type>:sort=<asc\|desc>`. Sort order: `asc` or `desc` (default: as-is) |
 | `--charts` | `-c` | `bar,line,pie` | Chart types to generate (`bar`, `line`, `scatter`, `pie`, `heatmap`, `radar`) |
-| `--chart` | | | Per-chart type settings override (repeatable): `<type>:<key>=<val>,...` — see below |
+| `--chart` | | | Per-chart type settings override (repeatable): `<type>:<props>` — comma or semicolon between props; see below |
 | `--show-labels` | `-l` | `false` | **Deprecated on root:** use `--chart <type>:labels`. Show value labels on charts |
 | `--filter` | `-f` | `""` | Regex to include only matching rows (CSV/JSON: `--group` label) or benchmark names |
 | `--mem-unit` | `-M` | `B` | Memory unit: `b`, `B`, `KB`, `MB`, `GB` |
@@ -221,7 +221,22 @@ See [UI Overview → Output File Size](/ui#output-file-size) for a size referenc
 
 ### Per-chart settings
 
-Use `--chart` (repeatable) to override settings for a specific chart type. Each spec is `<type>:<key>=<val>,...` or `<type>:<bare-flag>,...`.
+Use `--chart` (repeatable) to override settings for a specific chart type. Each
+spec is `<type>:<props>` where props are `key=value` pairs or bare flags
+(`labels`, `stack`, …).
+
+**Prop separators**
+
+- **Comma** still separates single-value props. Existing examples stay valid:
+  `bar:swap=yx,sort=asc`, `pie:sort=desc,labels`.
+- When a value itself contains commas (multi-value keys such as `stat`), either:
+  - Put that prop alone (or only before further `key=value` forms):
+    `--chart bar:stat=center,spread`
+  - Or separate props with **semicolons** so commas stay inside the value:
+    `--chart 'bar:stat=center,spread;labels'`
+
+Semicolon mode matches structured `--theme` specs
+(`name:colors=#hex,...;visualMapColors=...`); both use the same prop grammar.
 
 ```bash
 # Bar chart: swap axes to yx, sort ascending
@@ -235,6 +250,12 @@ vizb bench.txt -p n/x/y/z --chart bar:3d-rotate --chart line:labels=false -o out
 
 # Horizontal grouped bars (bar:horizontal)
 vizb sales.csv -g region,category -p x,y --chart bar:horizontal -o out.html
+
+# Multi-value stat categories (comma inside the value)
+vizb sales.csv -c bar --chart bar:stat=center,spread -o out.html
+
+# Multi-value + another prop: use semicolon between props
+vizb sales.csv -c bar --chart 'bar:stat=center,spread;labels' -o out.html
 ```
 
 **Supported keys:**
@@ -246,6 +267,7 @@ vizb sales.csv -g region,category -p x,y --chart bar:horizontal -o out.html
 | `labels` | `labels` | `true`, `false` | all |
 | `scale` | — | `linear`, `log` | `bar`, `line` only |
 | `3d-rotate` | `3d-rotate` | `true`, `false` | `bar`, `line` 3D only |
+| `stat` | `stat` | `all`, or comma-separated categories (`center,spread`, …) | all |
 
 Bare flags (no `=`) default to `true`. Per-chart settings override the chart's own defaults. The root-level `--sort` and `--show-labels` flags are deprecated — use `--chart` overrides instead.
 

--- a/docs/src/content/docs/ui/themes.mdx
+++ b/docs/src/content/docs/ui/themes.mdx
@@ -49,7 +49,9 @@ on load; re-marshalled output drops the legacy field.
    - `colors` is required (≥2 hex colors)
    - `visualMapColors` is optional (exactly two hex colors); when omitted, Vizb
      uses the first and last color from `colors`
-   - Properties are semicolon-separated; order does not matter
+   - Properties are semicolon-separated (same structured prop grammar as
+     multi-value [`--chart`](/commands/root#per-chart-settings) specs); order
+     does not matter
 3. **Bare hex palette**: `#hex,#hex,...` (≥2 colors) — anonymous custom named
    `custom`, `custom-2`, … when multiple bare palettes are embedded
 

--- a/internal/specparse/parse.go
+++ b/internal/specparse/parse.go
@@ -1,0 +1,213 @@
+// Package specparse tokenizes structured CLI specs of the form:
+//
+//	prefix:prop(;prop)*
+//	prop = key | key=value
+//
+// In legacy mode (no ';'), props are also comma-separated. MultiValueKeys and
+// KnownKeys control how comma-bearing values are reassembled in that mode.
+package specparse
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Prop is one key or key=value entry in a structured spec.
+type Prop struct {
+	Key      string // trimmed, original casing preserved
+	Value    string // trimmed; empty if bare
+	HasValue bool   // true when '=' was present (even if value empty)
+}
+
+// Spec is a parsed prefix:props structured CLI token.
+type Spec struct {
+	Prefix string
+	Props  []Prop // order preserved
+}
+
+// Options configures Parse behaviour.
+type Options struct {
+	// MultiValueKeys: in legacy comma mode, values for these keys may contain
+	// commas. Matching is case-sensitive on the raw key (callers normalize).
+	MultiValueKeys map[string]struct{}
+
+	// KnownKeys: when non-empty, in legacy comma multi-value scanning, a token
+	// that is `k` or `k=...` with k in KnownKeys starts a new prop.
+	// When empty, multi-value consumption stops only at the next `k=...` token
+	// (key= form), not bare keys — so `stat=center,spread` works alone but
+	// `stat=center,spread,labels` needs KnownKeys or semicolon mode.
+	KnownKeys map[string]struct{}
+
+	// AllowBareKeys: allow key without '=' (chart). Default false means bare keys error.
+	AllowBareKeys bool
+
+	// RequireProps: error if prefix has no props after ':'.
+	RequireProps bool
+}
+
+// Parse splits "prefix:props" into Spec. Does not validate domain keys/values.
+func Parse(input string, opts Options) (Spec, error) {
+	colon := strings.Index(input, ":")
+	if colon < 0 {
+		return Spec{}, fmt.Errorf("specparse: missing ':' in structured spec %q", input)
+	}
+
+	prefix := strings.TrimSpace(input[:colon])
+	if prefix == "" {
+		return Spec{}, fmt.Errorf("specparse: empty prefix in structured spec %q", input)
+	}
+
+	rest := strings.TrimSpace(input[colon+1:])
+	if rest == "" {
+		if opts.RequireProps {
+			return Spec{}, fmt.Errorf("specparse: prefix %q requires at least one prop", prefix)
+		}
+		return Spec{Prefix: prefix}, nil
+	}
+
+	var props []Prop
+	var err error
+	if strings.Contains(rest, ";") {
+		props, err = parseSemicolonProps(rest, opts)
+	} else {
+		props, err = parseLegacyCommaProps(rest, opts)
+	}
+	if err != nil {
+		return Spec{}, err
+	}
+
+	if len(props) == 0 && opts.RequireProps {
+		return Spec{}, fmt.Errorf("specparse: prefix %q requires at least one prop", prefix)
+	}
+
+	return Spec{Prefix: prefix, Props: props}, nil
+}
+
+// SplitList comma-splits value, trims each part, and drops empty strings.
+func SplitList(value string) []string {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func parseSemicolonProps(rest string, opts Options) ([]Prop, error) {
+	parts := strings.Split(rest, ";")
+	props := make([]Prop, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		prop, err := parsePropSegment(part, opts)
+		if err != nil {
+			return nil, err
+		}
+		props = append(props, prop)
+	}
+	return props, nil
+}
+
+func parseLegacyCommaProps(rest string, opts Options) ([]Prop, error) {
+	tokens := strings.Split(rest, ",")
+	props := make([]Prop, 0, len(tokens))
+
+	for i := 0; i < len(tokens); {
+		tok := strings.TrimSpace(tokens[i])
+		if tok == "" {
+			i++
+			continue
+		}
+
+		prop, err := parsePropSegment(tok, opts)
+		if err != nil {
+			return nil, err
+		}
+		i++
+
+		if prop.HasValue && keyInSet(prop.Key, opts.MultiValueKeys) {
+			for i < len(tokens) {
+				next := strings.TrimSpace(tokens[i])
+				if next == "" {
+					i++
+					continue
+				}
+				if isPropStart(next, opts) {
+					break
+				}
+				if prop.Value == "" {
+					prop.Value = next
+				} else {
+					prop.Value = prop.Value + "," + next
+				}
+				i++
+			}
+		}
+
+		props = append(props, prop)
+	}
+
+	return props, nil
+}
+
+func parsePropSegment(segment string, opts Options) (Prop, error) {
+	eq := strings.Index(segment, "=")
+	if eq < 0 {
+		key := strings.TrimSpace(segment)
+		if key == "" {
+			return Prop{}, fmt.Errorf("specparse: empty key in prop %q", segment)
+		}
+		if !opts.AllowBareKeys {
+			return Prop{}, fmt.Errorf("specparse: bare key %q not allowed (use key=value)", key)
+		}
+		return Prop{Key: key, HasValue: false}, nil
+	}
+
+	key := strings.TrimSpace(segment[:eq])
+	if key == "" {
+		return Prop{}, fmt.Errorf("specparse: empty key in prop %q", segment)
+	}
+	value := strings.TrimSpace(segment[eq+1:])
+	return Prop{Key: key, Value: value, HasValue: true}, nil
+}
+
+// isPropStart reports whether token should begin a new prop while scanning a
+// multi-value value in legacy comma mode.
+func isPropStart(token string, opts Options) bool {
+	key, hasEq := splitPropKey(token)
+	if key == "" {
+		return false
+	}
+	if len(opts.KnownKeys) > 0 {
+		return keyInSet(key, opts.KnownKeys)
+	}
+	// No KnownKeys: only a key= form starts a new prop.
+	return hasEq
+}
+
+func splitPropKey(token string) (key string, hasEq bool) {
+	eq := strings.Index(token, "=")
+	if eq < 0 {
+		return strings.TrimSpace(token), false
+	}
+	return strings.TrimSpace(token[:eq]), true
+}
+
+func keyInSet(key string, set map[string]struct{}) bool {
+	if len(set) == 0 {
+		return false
+	}
+	_, ok := set[key]
+	return ok
+}

--- a/internal/specparse/parse_test.go
+++ b/internal/specparse/parse_test.go
@@ -1,0 +1,222 @@
+package specparse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type SpecParseSuite struct {
+	suite.Suite
+}
+
+func TestSpecParseSuite(t *testing.T) {
+	suite.Run(t, new(SpecParseSuite))
+}
+
+func (s *SpecParseSuite) TestParseLegacyCommaTwoProps() {
+	spec, err := Parse("bar:swap=yxn,sort=asc", Options{})
+	s.Require().NoError(err)
+	s.Equal("bar", spec.Prefix)
+	s.Require().Len(spec.Props, 2)
+	s.Equal(Prop{Key: "swap", Value: "yxn", HasValue: true}, spec.Props[0])
+	s.Equal(Prop{Key: "sort", Value: "asc", HasValue: true}, spec.Props[1])
+}
+
+func (s *SpecParseSuite) TestParseSemicolonKeepsCommasInValues() {
+	spec, err := Parse("bar:stat=center,spread;labels", Options{AllowBareKeys: true})
+	s.Require().NoError(err)
+	s.Equal("bar", spec.Prefix)
+	s.Require().Len(spec.Props, 2)
+	s.Equal(Prop{Key: "stat", Value: "center,spread", HasValue: true}, spec.Props[0])
+	s.Equal(Prop{Key: "labels", Value: "", HasValue: false}, spec.Props[1])
+}
+
+func (s *SpecParseSuite) TestParseOceanColorsSemicolon() {
+	spec, err := Parse("ocean:colors=#0ff,#00f;visualMapColors=#111,#222", Options{})
+	s.Require().NoError(err)
+	s.Equal("ocean", spec.Prefix)
+	s.Require().Len(spec.Props, 2)
+	s.Equal(Prop{Key: "colors", Value: "#0ff,#00f", HasValue: true}, spec.Props[0])
+	s.Equal(Prop{Key: "visualMapColors", Value: "#111,#222", HasValue: true}, spec.Props[1])
+}
+
+func (s *SpecParseSuite) TestParseBareKeyAllowed() {
+	spec, err := Parse("bar:labels", Options{AllowBareKeys: true})
+	s.Require().NoError(err)
+	s.Equal("bar", spec.Prefix)
+	s.Require().Len(spec.Props, 1)
+	s.Equal(Prop{Key: "labels", Value: "", HasValue: false}, spec.Props[0])
+}
+
+func (s *SpecParseSuite) TestParseBareKeyErrorsWithoutAllowBareKeys() {
+	_, err := Parse("bar:labels", Options{})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "bare")
+}
+
+func (s *SpecParseSuite) TestParseMultiValueWithKnownKeys() {
+	opts := Options{
+		MultiValueKeys: map[string]struct{}{"stat": {}},
+		KnownKeys:      map[string]struct{}{"stat": {}, "labels": {}},
+		AllowBareKeys:  true,
+	}
+	spec, err := Parse("bar:stat=center,spread,labels", opts)
+	s.Require().NoError(err)
+	s.Equal("bar", spec.Prefix)
+	s.Require().Len(spec.Props, 2)
+	s.Equal(Prop{Key: "stat", Value: "center,spread", HasValue: true}, spec.Props[0])
+	s.Equal(Prop{Key: "labels", Value: "", HasValue: false}, spec.Props[1])
+}
+
+func (s *SpecParseSuite) TestParseMultiValueAlone() {
+	opts := Options{
+		MultiValueKeys: map[string]struct{}{"stat": {}},
+	}
+	spec, err := Parse("bar:stat=center,spread", opts)
+	s.Require().NoError(err)
+	s.Equal("bar", spec.Prefix)
+	s.Require().Len(spec.Props, 1)
+	s.Equal(Prop{Key: "stat", Value: "center,spread", HasValue: true}, spec.Props[0])
+}
+
+func (s *SpecParseSuite) TestParseMultiValueAloneContinuesThroughBareTokens() {
+	// Without KnownKeys, multi-value consumption only stops at key= form,
+	// so a trailing bare token is absorbed into the multi-value.
+	opts := Options{
+		MultiValueKeys: map[string]struct{}{"stat": {}},
+	}
+	spec, err := Parse("bar:stat=center,spread,labels", opts)
+	s.Require().NoError(err)
+	s.Require().Len(spec.Props, 1)
+	s.Equal(Prop{Key: "stat", Value: "center,spread,labels", HasValue: true}, spec.Props[0])
+}
+
+func (s *SpecParseSuite) TestParseMultiValueStopsAtNextKeyEquals() {
+	opts := Options{
+		MultiValueKeys: map[string]struct{}{"stat": {}},
+	}
+	spec, err := Parse("bar:stat=center,spread,sort=asc", opts)
+	s.Require().NoError(err)
+	s.Require().Len(spec.Props, 2)
+	s.Equal(Prop{Key: "stat", Value: "center,spread", HasValue: true}, spec.Props[0])
+	s.Equal(Prop{Key: "sort", Value: "asc", HasValue: true}, spec.Props[1])
+}
+
+func (s *SpecParseSuite) TestParseErrors() {
+	s.Run("empty", func() {
+		_, err := Parse("", Options{})
+		s.Require().Error(err)
+	})
+	s.Run("no colon", func() {
+		_, err := Parse("bar", Options{})
+		s.Require().Error(err)
+		s.Contains(err.Error(), ":")
+	})
+	s.Run("empty prefix", func() {
+		_, err := Parse(":swap=yxn", Options{})
+		s.Require().Error(err)
+		s.Contains(err.Error(), "prefix")
+	})
+	s.Run("whitespace prefix", func() {
+		_, err := Parse("  :swap=yxn", Options{})
+		s.Require().Error(err)
+	})
+	s.Run("require props empty rest", func() {
+		_, err := Parse("bar:", Options{RequireProps: true})
+		s.Require().Error(err)
+	})
+	s.Run("require props whitespace rest", func() {
+		_, err := Parse("bar:   ", Options{RequireProps: true})
+		s.Require().Error(err)
+	})
+	s.Run("empty key", func() {
+		_, err := Parse("bar:=value", Options{})
+		s.Require().Error(err)
+		s.Contains(err.Error(), "key")
+	})
+	s.Run("empty key after separator", func() {
+		_, err := Parse("bar:swap=yxn,=bad", Options{})
+		s.Require().Error(err)
+	})
+}
+
+func (s *SpecParseSuite) TestParseEmptyPropsAllowedWithoutRequire() {
+	spec, err := Parse("bar:", Options{})
+	s.Require().NoError(err)
+	s.Equal("bar", spec.Prefix)
+	s.Empty(spec.Props)
+
+	spec, err = Parse("bar:   ", Options{})
+	s.Require().NoError(err)
+	s.Equal("bar", spec.Prefix)
+	s.Empty(spec.Props)
+}
+
+func (s *SpecParseSuite) TestParsePreservesOrderAndKeyCasing() {
+	spec, err := Parse("ocean:colors=#0ff;visualMapColors=#111;swap=yxn", Options{})
+	s.Require().NoError(err)
+	s.Require().Len(spec.Props, 3)
+	s.Equal("colors", spec.Props[0].Key)
+	s.Equal("visualMapColors", spec.Props[1].Key)
+	s.Equal("swap", spec.Props[2].Key)
+}
+
+func (s *SpecParseSuite) TestParseTrimsKeyAndValue() {
+	spec, err := Parse(" bar : swap = yxn , sort = asc ", Options{})
+	s.Require().NoError(err)
+	s.Equal("bar", spec.Prefix)
+	s.Require().Len(spec.Props, 2)
+	s.Equal(Prop{Key: "swap", Value: "yxn", HasValue: true}, spec.Props[0])
+	s.Equal(Prop{Key: "sort", Value: "asc", HasValue: true}, spec.Props[1])
+}
+
+func (s *SpecParseSuite) TestParseEmptyValueWithEquals() {
+	spec, err := Parse("bar:labels=", Options{})
+	s.Require().NoError(err)
+	s.Require().Len(spec.Props, 1)
+	s.Equal(Prop{Key: "labels", Value: "", HasValue: true}, spec.Props[0])
+}
+
+func (s *SpecParseSuite) TestParseMultiValueCaseSensitiveKeys() {
+	opts := Options{
+		MultiValueKeys: map[string]struct{}{"stat": {}},
+		KnownKeys:      map[string]struct{}{"stat": {}, "Stat": {}, "labels": {}},
+		AllowBareKeys:  true,
+	}
+	// "Stat" is not in MultiValueKeys (case-sensitive), so no multi-value join.
+	spec, err := Parse("bar:Stat=center,spread,labels", opts)
+	s.Require().NoError(err)
+	// Without multi-value, each comma segment is a prop start attempt.
+	// "spread" is bare and not allowed... actually AllowBareKeys is true.
+	// Stat=center, then bare spread, then bare labels.
+	s.Require().Len(spec.Props, 3)
+	s.Equal(Prop{Key: "Stat", Value: "center", HasValue: true}, spec.Props[0])
+	s.Equal(Prop{Key: "spread", Value: "", HasValue: false}, spec.Props[1])
+	s.Equal(Prop{Key: "labels", Value: "", HasValue: false}, spec.Props[2])
+}
+
+func (s *SpecParseSuite) TestParseKnownKeysStopsOnlyMatchingKeys() {
+	opts := Options{
+		MultiValueKeys: map[string]struct{}{"stat": {}},
+		KnownKeys:      map[string]struct{}{"stat": {}, "labels": {}},
+		AllowBareKeys:  true,
+	}
+	// "other" is not known, so absorbed into multi-value even as bare token.
+	spec, err := Parse("bar:stat=center,other,labels", opts)
+	s.Require().NoError(err)
+	s.Require().Len(spec.Props, 2)
+	s.Equal(Prop{Key: "stat", Value: "center,other", HasValue: true}, spec.Props[0])
+	s.Equal(Prop{Key: "labels", Value: "", HasValue: false}, spec.Props[1])
+}
+
+func (s *SpecParseSuite) TestSplitList() {
+	s.Equal([]string{"a", "b", "c"}, SplitList("a,b,c"))
+	s.Equal([]string{"a", "b", "c"}, SplitList(" a , b , c "))
+	s.Equal([]string{"center", "spread"}, SplitList("center,spread"))
+	s.Empty(SplitList(""))
+	s.Empty(SplitList("   "))
+	s.Empty(SplitList(",,,"))
+	s.Equal([]string{"a", "c"}, SplitList("a,,c"))
+	s.Equal([]string{"#0ff", "#00f"}, SplitList("#0ff,#00f"))
+}

--- a/pkg/style/style.go
+++ b/pkg/style/style.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/goptics/vizb/internal/specparse"
 )
 
 var (
@@ -48,8 +49,15 @@ func NormalizeTheme(value string) string {
 	if _, ok := themeCatalog[strings.ToLower(trimmed)]; ok {
 		return strings.ToLower(trimmed)
 	}
-	if name, props, ok := splitStructured(trimmed); ok {
-		return normalizeStructured(name, props)
+	// Prefer shared tokenizer when the value is a structured theme spec.
+	if strings.Contains(trimmed, ":") {
+		if parsed, err := specparse.Parse(trimmed, themeSpecParseOptions(trimmed)); err == nil {
+			return normalizeStructuredSpec(parsed)
+		}
+		// Best-effort fallback for structured-looking input that fails tokenization.
+		if name, props, ok := splitStructured(trimmed); ok {
+			return normalizeStructured(name, props)
+		}
 	}
 	// Bare hex (or anything comma-separated): trim each segment.
 	colors := strings.Split(trimmed, ",")
@@ -59,6 +67,31 @@ func NormalizeTheme(value string) string {
 	return strings.Join(colors, ",")
 }
 
+func normalizeStructuredSpec(parsed specparse.Spec) string {
+	parts := make([]string, 0, len(parsed.Props))
+	for _, prop := range parsed.Props {
+		key := prop.Key
+		switch strings.ToLower(key) {
+		case "colors":
+			key = "colors"
+		case "visualmapcolors":
+			key = "visualMapColors"
+		}
+		if !prop.HasValue {
+			parts = append(parts, key)
+			continue
+		}
+		segments := strings.Split(prop.Value, ",")
+		for i := range segments {
+			segments[i] = strings.TrimSpace(segments[i])
+		}
+		parts = append(parts, fmt.Sprintf("%s=%s", key, strings.Join(segments, ",")))
+	}
+	return parsed.Prefix + ":" + strings.Join(parts, ";")
+}
+
+// normalizeStructured is a best-effort semicolon re-serializer used when
+// specparse.Parse fails but the input still looks structured.
 func normalizeStructured(name, props string) string {
 	var parts []string
 	// Preserve property order from input while normalizing values.

--- a/pkg/style/themes.go
+++ b/pkg/style/themes.go
@@ -3,6 +3,8 @@ package style
 import (
 	"fmt"
 	"strings"
+
+	"github.com/goptics/vizb/internal/specparse"
 )
 
 // Theme is a fully expanded color theme for embedding on datasets.
@@ -160,8 +162,11 @@ func parseThemeSpec(value string) (Theme, bool, error) {
 	}
 
 	// 2. Structured form: name:prop=...;prop=...
-	if name, props, ok := splitStructured(trimmed); ok {
-		theme, err := parseStructured(name, props)
+	// Bare hex palettes never contain ':', so a missing colon falls through.
+	// Specs that contain ':' are treated as structured: prop-rule failures
+	// return an error rather than falling through to the hex path.
+	if strings.Contains(trimmed, ":") {
+		theme, err := parseStructuredTheme(trimmed)
 		return theme, false, err
 	}
 
@@ -177,8 +182,87 @@ func parseThemeSpec(value string) (Theme, bool, error) {
 	return Theme{}, false, fmt.Errorf("expected a built-in theme, structured theme, or at least two comma-separated hex colors")
 }
 
-// splitStructured splits "name:props" when the value looks structured
-// (contains ':' and a colors= property). Returns false for bare names.
+// themeSpecParseOptions builds specparse options for theme specs.
+// Theme prop values are comma-separated hex lists; in legacy (no ';') mode the
+// first key must be multi-value so commas stay in the value.
+func themeSpecParseOptions(input string) specparse.Options {
+	opts := specparse.Options{
+		AllowBareKeys: false,
+		RequireProps:  true,
+	}
+	if colon := strings.Index(input, ":"); colon >= 0 {
+		rest := input[colon+1:]
+		if !strings.Contains(rest, ";") {
+			if eq := strings.Index(rest, "="); eq >= 0 {
+				key := strings.TrimSpace(rest[:eq])
+				if key != "" {
+					opts.MultiValueKeys = map[string]struct{}{key: {}}
+				}
+			}
+		}
+	}
+	return opts
+}
+
+// parseStructuredTheme tokenizes via specparse then maps domain props.
+func parseStructuredTheme(trimmed string) (Theme, error) {
+	parsed, err := specparse.Parse(trimmed, themeSpecParseOptions(trimmed))
+	if err != nil {
+		return Theme{}, err
+	}
+	return themeFromSpec(parsed)
+}
+
+func themeFromSpec(parsed specparse.Spec) (Theme, error) {
+	var colors []string
+	var visualMap []string
+	hasColors := false
+	hasVisualMap := false
+
+	for _, prop := range parsed.Props {
+		if !prop.HasValue {
+			return Theme{}, fmt.Errorf("invalid structured theme property %q", prop.Key)
+		}
+		switch strings.ToLower(prop.Key) {
+		case "colors":
+			list, err := parseHexList(prop.Value)
+			if err != nil {
+				return Theme{}, fmt.Errorf("colors: %w", err)
+			}
+			colors = list
+			hasColors = true
+		case "visualmapcolors":
+			list, err := parseHexList(prop.Value)
+			if err != nil {
+				return Theme{}, fmt.Errorf("visualMapColors: %w", err)
+			}
+			if len(list) != 2 {
+				return Theme{}, fmt.Errorf("visualMapColors requires exactly two hex colors")
+			}
+			visualMap = list
+			hasVisualMap = true
+		default:
+			return Theme{}, fmt.Errorf("unknown structured theme property %q", prop.Key)
+		}
+	}
+
+	if !hasColors {
+		return Theme{}, fmt.Errorf("structured theme requires colors with at least two hex values")
+	}
+	if !hasVisualMap {
+		visualMap = visualMapFromColors(colors)
+	}
+
+	return Theme{
+		Name:            parsed.Prefix,
+		Colors:          colors,
+		VisualMapColors: visualMap,
+	}, nil
+}
+
+// splitStructured reports whether value looks like "name:key=...;..." and
+// returns the split name/props. Used by NormalizeTheme for best-effort
+// canonicalization when domain validation is not required.
 func splitStructured(value string) (name, props string, ok bool) {
 	idx := strings.Index(value, ":")
 	if idx < 0 {
@@ -195,60 +279,6 @@ func splitStructured(value string) (name, props string, ok bool) {
 		return "", "", false
 	}
 	return name, props, true
-}
-
-func parseStructured(name, props string) (Theme, error) {
-	var colors []string
-	var visualMap []string
-	hasColors := false
-	hasVisualMap := false
-
-	for _, part := range strings.Split(props, ";") {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		key, val, found := strings.Cut(part, "=")
-		if !found {
-			return Theme{}, fmt.Errorf("invalid structured theme property %q", part)
-		}
-		key = strings.TrimSpace(key)
-		val = strings.TrimSpace(val)
-		switch strings.ToLower(key) {
-		case "colors":
-			parsed, err := parseHexList(val)
-			if err != nil {
-				return Theme{}, fmt.Errorf("colors: %w", err)
-			}
-			colors = parsed
-			hasColors = true
-		case "visualmapcolors":
-			parsed, err := parseHexList(val)
-			if err != nil {
-				return Theme{}, fmt.Errorf("visualMapColors: %w", err)
-			}
-			if len(parsed) != 2 {
-				return Theme{}, fmt.Errorf("visualMapColors requires exactly two hex colors")
-			}
-			visualMap = parsed
-			hasVisualMap = true
-		default:
-			return Theme{}, fmt.Errorf("unknown structured theme property %q", key)
-		}
-	}
-
-	if !hasColors {
-		return Theme{}, fmt.Errorf("structured theme requires colors with at least two hex values")
-	}
-	if !hasVisualMap {
-		visualMap = visualMapFromColors(colors)
-	}
-
-	return Theme{
-		Name:            name,
-		Colors:          colors,
-		VisualMapColors: visualMap,
-	}, nil
 }
 
 // parseHexList parses a comma-separated list of ≥2 #rgb/#rrggbb colors.

--- a/shared/chart_spec.go
+++ b/shared/chart_spec.go
@@ -10,6 +10,7 @@ import (
 
 	internal_charts "github.com/goptics/vizb/internal/charts"
 	"github.com/goptics/vizb/internal/flags"
+	"github.com/goptics/vizb/internal/specparse"
 )
 
 // axisChar returns the single character that represents an axis key in a swap
@@ -113,14 +114,16 @@ func ParseOverrides(specs []string, charts []string, axes []Axis) (map[string]in
 	var warnings []string
 
 	for _, spec := range specs {
-		chartType, rest, ok := strings.Cut(spec, ":")
+		// Chart type is needed before tokenization so MultiValueKeys / KnownKeys
+		// can be built from that chart's flag registry.
+		chartType, _, ok := strings.Cut(spec, ":")
 		if !ok {
 			return nil, nil, fmt.Errorf("--chart: malformed spec %q: expected <type>:<key>=<val>,... or <type>:<flag>", spec)
 		}
-		if rest == "" {
-			return nil, nil, fmt.Errorf("--chart: spec %q has no settings after ':'; expected <type>:<key>=<val> or <type>:<flag>", spec)
+		chartType = strings.ToLower(strings.TrimSpace(chartType))
+		if chartType == "" {
+			return nil, nil, fmt.Errorf("--chart: malformed spec %q: expected <type>:<key>=<val>,... or <type>:<flag>", spec)
 		}
-		chartType = strings.ToLower(chartType)
 
 		// Validate the chart type is registered.
 		if _, err := internal_charts.New(chartType); err != nil {
@@ -144,6 +147,11 @@ func ParseOverrides(specs []string, charts []string, axes []Axis) (map[string]in
 			flagByName[f.EffectiveKey()] = f
 		}
 
+		parsed, err := specparse.Parse(spec, chartSpecParseOptions(chartFlags))
+		if err != nil {
+			return nil, nil, formatChartSpecParseError(spec, err)
+		}
+
 		payload, ok := payloads[chartType]
 		if !ok {
 			payload = map[string]any{"type": chartType}
@@ -151,16 +159,8 @@ func ParseOverrides(specs []string, charts []string, axes []Axis) (map[string]in
 			order = append(order, chartType)
 		}
 
-		for token := range strings.SplitSeq(rest, ",") {
-			token = strings.TrimSpace(token)
-			if token == "" {
-				continue
-			}
-
-			key, val, hasEq := strings.Cut(token, "=")
-			key = strings.TrimSpace(key)
-			val = strings.TrimSpace(val)
-
+		for _, prop := range parsed.Props {
+			key := prop.Key
 			f, known := flagByName[key]
 			if !known {
 				// Valid for another chart → drop with a warning; valid nowhere → typo.
@@ -168,13 +168,13 @@ func ParseOverrides(specs []string, charts []string, axes []Axis) (map[string]in
 					warnings = append(warnings, fmt.Sprintf("--chart: key %q is not applicable to %s charts; ignored", key, chartType))
 					continue
 				}
-				if !hasEq {
-					return nil, nil, fmt.Errorf("--chart: malformed token %q in spec %q: unknown bare flag (valid: %s)", token, spec, flagNameList(chartFlags))
+				if !prop.HasValue {
+					return nil, nil, fmt.Errorf("--chart: malformed token %q in spec %q: unknown bare flag (valid: %s)", key, spec, flagNameList(chartFlags))
 				}
 				return nil, nil, fmt.Errorf("--chart: unknown key %q in spec %q (valid keys: %s)", key, spec, flagNameList(chartFlags))
 			}
 
-			pv, err := convertFlagValue(f, val, hasEq, axes)
+			pv, err := convertFlagValue(f, prop.Value, prop.HasValue, axes)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -221,13 +221,9 @@ func convertFlagValue(f flags.Flag, val string, hasEq bool, axes []Axis) (any, e
 			return map[string]any{"enabled": true, "math": []string{}}, nil
 		}
 		// stat=a,b — validate each category and produce the typed payload
-		parts := strings.Split(val, ",")
+		parts := specparse.SplitList(val)
 		math := make([]string, 0, len(parts))
 		for _, p := range parts {
-			p = strings.TrimSpace(p)
-			if p == "" {
-				continue
-			}
 			if !slices.Contains(ValidStatMath, p) {
 				return nil, fmt.Errorf("--chart: stat category %q is invalid (valid: %s)", p, strings.Join(ValidStatMath, ", "))
 			}
@@ -269,6 +265,42 @@ func encode(f flags.Flag, v any) any {
 		return f.Encode(v)
 	}
 	return v
+}
+
+// chartSpecParseOptions builds tokenizer options for a chart's --chart specs.
+// KnownKeys are all EffectiveKey values; MultiValueKeys are flags whose values
+// may contain commas (KindStat today; KindStringSlice for forward safety).
+func chartSpecParseOptions(chartFlags []flags.Flag) specparse.Options {
+	known := make(map[string]struct{}, len(chartFlags))
+	multi := make(map[string]struct{})
+	for _, f := range chartFlags {
+		key := f.EffectiveKey()
+		known[key] = struct{}{}
+		switch f.Kind {
+		case flags.KindStat, flags.KindStringSlice:
+			multi[key] = struct{}{}
+		}
+	}
+	return specparse.Options{
+		AllowBareKeys:  true,
+		RequireProps:   true,
+		KnownKeys:      known,
+		MultiValueKeys: multi,
+	}
+}
+
+// formatChartSpecParseError maps structural tokenizer errors to user-facing
+// --chart messages without leaking the "specparse:" prefix.
+func formatChartSpecParseError(spec string, err error) error {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "missing ':'"):
+		return fmt.Errorf("--chart: malformed spec %q: expected <type>:<key>=<val>,... or <type>:<flag>", spec)
+	case strings.Contains(msg, "requires at least one prop"):
+		return fmt.Errorf("--chart: spec %q has no settings after ':'; expected <type>:<key>=<val> or <type>:<flag>", spec)
+	default:
+		return fmt.Errorf("--chart: malformed spec %q: %s", spec, strings.TrimPrefix(msg, "specparse: "))
+	}
 }
 
 // flagNameList renders the comma-separated valid key names for an error message.

--- a/shared/chart_spec_test.go
+++ b/shared/chart_spec_test.go
@@ -239,6 +239,61 @@ func (s *ChartSpecSuite) TestParseOverridesBarStatValue() {
 	s.Equal("center", math[0])
 }
 
+// TestParseOverrides_BarStatMultiValue confirms comma-separated stat categories
+// stay on the stat key (legacy multi-value) instead of becoming extra tokens.
+func (s *ChartSpecSuite) TestParseOverridesBarStatMultiValue() {
+	got, warnings, err := ParseOverrides([]string{"bar:stat=center,spread"}, []string{"bar"}, s.xynAxes)
+	s.Require().NoError(err)
+	s.Empty(warnings)
+	m := s.payload(got["bar"])
+	stat, ok := m["stat"].(map[string]any)
+	s.Require().True(ok, "expected stat to be a map")
+	s.Equal(true, stat["enabled"])
+	math, _ := stat["math"].([]any)
+	s.Require().Len(math, 2)
+	s.Equal("center", math[0])
+	s.Equal("spread", math[1])
+}
+
+// TestParseOverrides_BarStatMultiValueWithBareLabels confirms multi-value stat
+// followed by a bare known key works in both legacy-comma and semicolon forms.
+func (s *ChartSpecSuite) TestParseOverridesBarStatMultiValueWithBareLabels() {
+	// Semicolon form: unambiguous prop boundary after multi-value stat.
+	got, warnings, err := ParseOverrides(
+		[]string{"bar:stat=center,spread;labels"},
+		[]string{"bar"},
+		s.xynAxes,
+	)
+	s.Require().NoError(err)
+	s.Empty(warnings)
+	m := s.payload(got["bar"])
+	stat, ok := m["stat"].(map[string]any)
+	s.Require().True(ok, "expected stat to be a map")
+	s.Equal(true, stat["enabled"])
+	math, _ := stat["math"].([]any)
+	s.Require().Len(math, 2)
+	s.Equal("center", math[0])
+	s.Equal("spread", math[1])
+	s.Equal(true, m["showLabels"])
+
+	// Legacy comma form: KnownKeys lets "labels" start a new prop after multi-value.
+	got, warnings, err = ParseOverrides(
+		[]string{"bar:stat=center,spread,labels"},
+		[]string{"bar"},
+		s.xynAxes,
+	)
+	s.Require().NoError(err)
+	s.Empty(warnings)
+	m = s.payload(got["bar"])
+	stat, ok = m["stat"].(map[string]any)
+	s.Require().True(ok, "expected stat to be a map")
+	math, _ = stat["math"].([]any)
+	s.Require().Len(math, 2)
+	s.Equal("center", math[0])
+	s.Equal("spread", math[1])
+	s.Equal(true, m["showLabels"])
+}
+
 // TestParseOverrides_BarStatInvalid confirms `stat=<invalid>` is a hard error.
 func (s *ChartSpecSuite) TestParseOverridesBarStatInvalid() {
 	_, _, err := ParseOverrides([]string{"bar:stat=bogus"}, []string{"bar"}, s.xynAxes)


### PR DESCRIPTION
## Summary

Fixes `--chart` multi-value prop splitting by introducing a shared structured CLI tokenizer used by both `--chart` and structured `--theme`.

Closes: #328

### Problem

`--chart` split the entire prop list on commas, so values that themselves contain commas (e.g. `stat=center,spread`) were broken into extra tokens. Structured `--theme` avoided this with a separate semicolon-based parser.

### Solution

- New stdlib-only package **`internal/specparse`**: `prefix:key=val;…` with legacy comma prop mode when no `;` is present, plus multi-value key support for chart flags.
- **`shared.ParseOverrides`** tokenizes via `specparse` (registry / convert / warnings unchanged).
- **`style.ParseThemeSpec`** structured path uses the same tokenizer.
- Docs + CHANGELOG: multi-value examples; semicolon preferred when a value contains commas.

### Examples

```bash
# multi-value alone (KindStat)
vizb data.csv -c bar --chart 'bar:stat=center,spread' -o out.html

# multi-value + another prop (semicolon prop separator)
vizb data.csv -c bar --chart 'bar:stat=center,spread;labels' -o out.html

# existing single-value charts still work
vizb data.csv -c bar --chart 'bar:swap=yxn,sort=asc' -o out.html
```

### Stack

This is **layer 2** of a stack:

| Layer | PR | Branch | Base |
|-------|-----|--------|------|
| 1 | #329 | `feat/data-owned-themes` | `main` |
| 2 (this PR) | — | `fix/chart-structured-spec-parser` | `feat/data-owned-themes` |

**Merge order:** merge #329 first, then retarget this PR to `main` (or restack) and merge.

Depends on #329 for the theme structured syntax that this PR also migrates onto `specparse`.

## Test plan

- [ ] `go test ./internal/specparse/ ./shared/ ./pkg/style/ -count=1`
- [ ] Regression: `bar:stat=center,spread` and `bar:stat=center,spread;labels` in chart_spec tests
- [ ] Existing `--chart` examples (`swap`, bare `labels`, etc.) still pass
- [ ] Structured `--theme` specs still parse (style tests)
- [ ] CI green after base branch merges