### PR TITLE
[bug]: round on-chart bar/line value labels to 2 decimals

### DIFF
--- a/ui/src/composables/charts/shared/3d.ts
+++ b/ui/src/composables/charts/shared/3d.ts
@@ -1,7 +1,7 @@
 import type { EChartsOption } from 'echarts'
 import type { Render3D, Point3D, ScaleType, Series3DData } from '@/types'
 import { valuePoints3DToSeries } from '@/lib/transform'
-import { getDefaultThemeColor, getNextColorFor } from '@/lib/utils'
+import { getDefaultThemeColor, getNextColorFor, round2 } from '@/lib/utils'
 import {
   formatTooltipValue,
   tooltipDivider,
@@ -12,7 +12,7 @@ import {
   type ChartStyling,
 } from './chartConfig'
 
-export const round2 = (v: number) => Math.round(v * 100) / 100
+export { round2 }
 
 /** Blue-to-red gradient for value-mode 3D visualMap (metric height). */
 export const VALUE_3D_COLOR_RANGE = [

--- a/ui/src/composables/charts/shared/chartConfig.test.ts
+++ b/ui/src/composables/charts/shared/chartConfig.test.ts
@@ -5,6 +5,7 @@ import {
   createDataZoomConfig,
   createGridConfig,
   createTooltipConfig,
+  createLabelConfig,
   createValueModeGridConfig,
   VALUE_MODE_GRID_TOP,
   createHeatmapLayoutConfig,
@@ -543,6 +544,32 @@ describe('final chartConfig branch cleanup', () => {
     ])
     expect(html).toContain('Σ X:')
     expect(html).not.toContain('<svg')
+  })
+})
+
+describe('createLabelConfig value formatter', () => {
+  const label = createLabelConfig(true, getChartStyling(false)) as {
+    formatter: (p: { value?: number | (number | null)[] | null }) => string
+  }
+
+  it('rounds numeric values to 2 decimals', () => {
+    expect(label.formatter({ value: 5941.380000000001 })).toBe('5941.38')
+    expect(label.formatter({ value: 3370.4500000000003 })).toBe('3370.45')
+    expect(label.formatter({ value: 2864.2999999999997 })).toBe('2864.3')
+  })
+
+  it('rounds the y value of a [x, y] tuple', () => {
+    expect(label.formatter({ value: [1, 4512.6900000000005] })).toBe('4512.69')
+  })
+
+  it('renders empty string for null/undefined values', () => {
+    expect(label.formatter({ value: null })).toBe('')
+    expect(label.formatter({ value: undefined })).toBe('')
+    expect(label.formatter({ value: [1, null] })).toBe('')
+  })
+
+  it('passes non-numeric values through unchanged', () => {
+    expect(label.formatter({ value: 'A' as unknown as number })).toBe('A')
   })
 })
 

--- a/ui/src/composables/charts/shared/chartConfig.test.ts
+++ b/ui/src/composables/charts/shared/chartConfig.test.ts
@@ -558,6 +558,13 @@ describe('createLabelConfig value formatter', () => {
     expect(label.formatter({ value: 2864.2999999999997 })).toBe('2864.3')
   })
 
+  it('rounds exact tie values half away from zero', () => {
+    expect(label.formatter({ value: 1.005 })).toBe('1.01')
+    expect(label.formatter({ value: -1.005 })).toBe('-1.01')
+    expect(label.formatter({ value: [1, 1.005] })).toBe('1.01')
+    expect(label.formatter({ value: [1, -1.005] })).toBe('-1.01')
+  })
+
   it('rounds the y value of a [x, y] tuple', () => {
     expect(label.formatter({ value: [1, 4512.6900000000005] })).toBe('4512.69')
   })

--- a/ui/src/composables/charts/shared/chartConfig.ts
+++ b/ui/src/composables/charts/shared/chartConfig.ts
@@ -843,7 +843,11 @@ export const createLabelConfig = (
     : orient === 'horizontal'
       ? ('right' as const)
       : ('top' as const),
-  formatter: '{c}',
+  formatter: (params: { value?: number | (number | null)[] | null }) => {
+    const raw = Array.isArray(params.value) ? params.value[1] : params.value
+    if (raw == null) return ''
+    return typeof raw === 'number' ? String(Math.round(raw * 100) / 100) : String(raw)
+  },
   fontSize,
   color: stacked ? '#fff' : styling.textColor,
   ...(stacked ? { textBorderColor: 'rgba(0,0,0,0.5)', textBorderWidth: 2 } : {}),

--- a/ui/src/composables/charts/shared/chartConfig.ts
+++ b/ui/src/composables/charts/shared/chartConfig.ts
@@ -2,6 +2,7 @@ import type { EChartsOption } from 'echarts/types/dist/shared'
 import type { ScaleType } from '@/types'
 import { fontSize } from './common'
 import { describe } from '@/lib/stats'
+import { round2 } from '@/lib/utils'
 
 export const LARGE_X_THRESHOLD = 50
 /** Initial visible share of a large category X-axis when dataZoom first renders. */
@@ -465,7 +466,7 @@ export function createHorizontalAxisConfig(
  */
 export function formatTooltipValue(value: any): string {
   if (value === null || value === undefined) return '—'
-  if (typeof value === 'number') return String(Math.round(value * 100) / 100)
+  if (typeof value === 'number') return String(round2(value))
   return String(value)
 }
 
@@ -571,7 +572,7 @@ export function tooltipSpreadRows(values: number[], isDark: boolean): string {
   const finite = values.filter((v) => Number.isFinite(v))
   if (finite.length < 2) return ''
   const s = describe(finite)
-  const num = (v: number) => (Number.isFinite(v) ? Math.round(v * 100) / 100 : '—')
+  const num = (v: number) => (Number.isFinite(v) ? round2(v) : '—')
   const cv = Number.isFinite(s.cv) ? `${(s.cv * 100).toFixed(1)}%` : '—'
   return (
     `${tooltipDivider(isDark)}` +
@@ -699,7 +700,7 @@ export function createTooltipConfig(
 
         const legendRows = present.map((cur) => {
           const seriesSum = seriesTotals?.get(cur.seriesName ?? '')
-          const sumTag = seriesSum === undefined ? '' : ` (Σ${Math.round(seriesSum * 100) / 100})`
+          const sumTag = seriesSum === undefined ? '' : ` (Σ${round2(seriesSum)})`
           return `${cur.marker} ${cur.seriesName}${sumTag}: ${formatTooltipValue(cur.value)}`
         })
         const body = `<strong>${params[0]?.name}</strong><br/>${renderTooltipLegendColumns(legendRows)}`
@@ -712,7 +713,7 @@ export function createTooltipConfig(
           0
         )
         const xName = params[0]?.name ?? ''
-        const sumLine = `${tooltipDivider(isDark)}Σ ${xName}: <b>${Math.round(total * 100) / 100}</b>`
+        const sumLine = `${tooltipDivider(isDark)}Σ ${xName}: <b>${round2(total)}</b>`
         const spread = tooltipSpreadRows(
           present.map((p) => (typeof p.value === 'number' ? p.value : NaN)),
           isDark
@@ -846,7 +847,7 @@ export const createLabelConfig = (
   formatter: (params: { value?: number | (number | null)[] | null }) => {
     const raw = Array.isArray(params.value) ? params.value[1] : params.value
     if (raw == null) return ''
-    return typeof raw === 'number' ? String(Math.round(raw * 100) / 100) : String(raw)
+    return typeof raw === 'number' ? String(round2(raw)) : String(raw)
   },
   fontSize,
   color: stacked ? '#fff' : styling.textColor,

--- a/ui/src/composables/charts/shared/mixedMode.ts
+++ b/ui/src/composables/charts/shared/mixedMode.ts
@@ -1,6 +1,6 @@
 import type { EChartsOption } from 'echarts'
 import type { ScaleType } from '@/types'
-import { getDefaultThemeColor, getNextColorFor } from '@/lib/utils'
+import { getDefaultThemeColor, getNextColorFor, round2 } from '@/lib/utils'
 import { type BaseChartConfig, getBaseOptions } from '../baseChartOptions'
 import {
   createAxisConfig,
@@ -127,7 +127,7 @@ export function buildMixedAxes2DOptions(
     ...createLabelConfig(showLabels.value, styling),
     formatter: (p: { data: [number, number | null] }) => {
       const y = p.data[1]
-      return y === null || y === undefined ? '' : String(Math.round(y * 100) / 100)
+      return y === null || y === undefined ? '' : String(round2(y))
     },
   }
 

--- a/ui/src/composables/charts/shared/valueMode.ts
+++ b/ui/src/composables/charts/shared/valueMode.ts
@@ -1,6 +1,6 @@
 import type { EChartsOption } from 'echarts'
 import type { ScaleType, ChartType } from '@/types'
-import { getNextColorFor, VALUE_CHART_TYPES } from '@/lib/utils'
+import { getNextColorFor, VALUE_CHART_TYPES, round2 } from '@/lib/utils'
 import { type BaseChartConfig, getBaseOptions } from '../baseChartOptions'
 import {
   createValueModeGridConfig,
@@ -93,7 +93,7 @@ export function buildValueAxes2DOptions(
     ...createLabelConfig(showLabels.value, styling),
     formatter: (p: { data: [number, number | null, number?] }) => {
       const y = p.data[1]
-      return y === null || y === undefined ? '' : String(Math.round(y * 100) / 100)
+      return y === null || y === undefined ? '' : String(round2(y))
     },
   }
 

--- a/ui/src/composables/charts/useHeatmapChartOptions.ts
+++ b/ui/src/composables/charts/useHeatmapChartOptions.ts
@@ -1,7 +1,7 @@
 import { computed } from 'vue'
 import type { EChartsOption } from 'echarts'
 import { type BaseChartConfig, getBaseOptions } from './baseChartOptions'
-import { getDefaultThemeColor, getNextColorFor, isGrouped3D } from '@/lib/utils'
+import { getDefaultThemeColor, getNextColorFor, isGrouped3D, round2 } from '@/lib/utils'
 import { resolveVisualMapColors } from '@/lib/themes'
 import {
   getChartStyling,
@@ -14,8 +14,6 @@ import {
   createHeatmapDataZoomConfig,
   createHeatmapLayoutConfig,
 } from './shared'
-
-const round2 = (v: number) => Math.round(v * 100) / 100
 
 function formatCellNumber(v: number): string {
   if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + 'M'

--- a/ui/src/lib/utils.test.ts
+++ b/ui/src/lib/utils.test.ts
@@ -11,6 +11,7 @@ import {
   datasetHasBothXY,
   datasetDimension,
   formatChartTotal,
+  round2,
   isValueMode,
   isMixedMode,
   isScatterTransformMode,
@@ -226,6 +227,23 @@ describe('computeChartGrandTotal', () => {
 describe('formatChartTotal', () => {
   it('rounds to two decimals', () => {
     expect(formatChartTotal(10.126)).toBe('10.13')
+  })
+})
+
+describe('round2', () => {
+  it('rounds to two decimals', () => {
+    expect(round2(10.126)).toBe(10.13)
+    expect(round2(3)).toBe(3)
+  })
+
+  it('rounds exact tie values half away from zero', () => {
+    expect(round2(1.005)).toBe(1.01)
+    expect(round2(-1.005)).toBe(-1.01)
+  })
+
+  it('passes through non-finite values', () => {
+    expect(round2(NaN)).toBe(NaN)
+    expect(round2(Infinity)).toBe(Infinity)
   })
 })
 

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -148,8 +148,20 @@ export const canOfferValue3D = (
   return builder.canOfferValue3D(chartType, data, hasZOnChart, cfg)
 }
 
+/**
+ * Round to 2 decimals for display. Decimal-aware: nudges by a relative epsilon
+ * so exact ties (e.g. 1.005 → 1.01, -1.005 → -1.01) round half away from zero
+ * deterministically instead of drifting on binary float error.
+ */
+export const round2 = (value: number): number => {
+  if (!Number.isFinite(value)) return value
+  const scaled = value * 100
+  const tieCorrected = scaled + Math.sign(scaled) * Number.EPSILON * Math.max(1, Math.abs(scaled))
+  return Math.round(tieCorrected) / 100
+}
+
 /** Round to 2 decimals — matches tooltip number formatting. */
-export const formatChartTotal = (value: number) => String(Math.round(value * 100) / 100)
+export const formatChartTotal = (value: number) => String(round2(value))
 
 export const isValueModeChart = (chart: ChartData): boolean => chart.statType === 'value'
 


### PR DESCRIPTION
## Summary

Fixes #337 . Round on-chart bar and line value labels to 2 decimals for cleaner display.

## Changes

- Rounds value labels on bar/line charts to two decimal places

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Enhancements

* Chart labels, tooltips, totals, and spread values now use consistent two-decimal rounding.
* Rounding handles positive and negative half-values more accurately.
* Tuple-based chart values use the relevant value for labeling.
* Missing values appear as blank labels, while nonnumeric and non-finite values remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->