### PR TITLE
fix(ui): strip IEEE 754 display noise from chart numbers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,9 +77,13 @@ users do not install Node just to compile Vizb.
 Run deploy-example workflows locally with `task act:install` and Docker:
 
 ```bash
+task build:cli                         # optional if bin/vizb already exists
 task act:examples -- --only tabular-data,go
 task act:examples -- --reuse --no-open
 ```
+
+`act:examples` reuses `./bin/vizb` when present; otherwise it runs `task build:cli`
+(so UI changes are re-embedded). It never plain-`go build`s over a local binary.
 
 ## Layout
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/mod v0.38.0
 	golang.org/x/perf v0.0.0-20250909190841-7e13e04d9366
+	golang.org/x/sys v0.36.0
 	golang.org/x/term v0.28.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -34,6 +35,5 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b // indirect
-	golang.org/x/sys v0.36.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/scripts/act-examples.sh
+++ b/scripts/act-examples.sh
@@ -25,7 +25,8 @@ Options:
   --reuse        Reuse act containers between runs (faster reruns)
   -h, --help     Show this help
 
-Prerequisites: act (>= 0.2.50), Docker, Go 1.26+
+Prerequisites: act (>= 0.2.50), Docker. Uses ./bin/vizb when present;
+otherwise runs task build:cli (needs Task + Go, re-embeds UI if ui/ is newer).
 EOF
 }
 
@@ -60,7 +61,7 @@ else
   TOPICS=("${ONLY_TOPICS[@]}")
 fi
 
-for dep in act docker go; do
+for dep in act docker; do
   if ! command -v "$dep" >/dev/null 2>&1; then
     echo "Missing required tool: $dep" >&2
     exit 1
@@ -71,8 +72,18 @@ mkdir -p bin dist/examples/live .act/artifacts
 rm -rf .act/jsons
 mkdir -p .act/jsons
 
-echo "Building vizb..."
-go build -o bin/vizb .
+# Prefer a prebuilt binary so local UI/CLI work (task build:cli) is not wiped
+# by a plain go build that reuses the stale tracked embed.
+if [[ -x bin/vizb ]]; then
+  echo "Using existing bin/vizb"
+else
+  if ! command -v task >/dev/null 2>&1; then
+    echo "bin/vizb not found and task is missing; install Task or run: task build:cli" >&2
+    exit 1
+  fi
+  echo "bin/vizb missing; building with task build:cli..."
+  task build:cli
+fi
 
 ACT_ARGS=(workflow_dispatch --input publish=false)
 if $REUSE; then

--- a/ui/src/composables/charts/shared/chartConfig.test.ts
+++ b/ui/src/composables/charts/shared/chartConfig.test.ts
@@ -552,16 +552,16 @@ describe('createLabelConfig value formatter', () => {
     formatter: (p: { value?: number | (number | null)[] | null }) => string
   }
 
-  it('formats numeric values at full precision', () => {
-    expect(label.formatter({ value: 5941.380000000001 })).toBe('5941.380000000001')
-    expect(label.formatter({ value: 3370.4500000000003 })).toBe('3370.4500000000003')
-    expect(label.formatter({ value: 2864.2999999999997 })).toBe('2864.2999999999997')
+  it('formats numeric values without IEEE 754 display noise', () => {
+    expect(label.formatter({ value: 5941.380000000001 })).toBe('5941.38')
+    expect(label.formatter({ value: 3370.4500000000003 })).toBe('3370.45')
+    expect(label.formatter({ value: 2864.2999999999997 })).toBe('2864.3')
     expect(label.formatter({ value: 1.005 })).toBe('1.005')
     expect(label.formatter({ value: -1.005 })).toBe('-1.005')
   })
 
-  it('formats the y value of a [x, y] tuple at full precision', () => {
-    expect(label.formatter({ value: [1, 4512.6900000000005] })).toBe('4512.6900000000005')
+  it('formats the y value of a [x, y] tuple without IEEE 754 display noise', () => {
+    expect(label.formatter({ value: [1, 4512.6900000000005] })).toBe('4512.69')
     expect(label.formatter({ value: [1, 1.005] })).toBe('1.005')
     expect(label.formatter({ value: [1, -1.005] })).toBe('-1.005')
   })

--- a/ui/src/lib/utils.test.ts
+++ b/ui/src/lib/utils.test.ts
@@ -224,10 +224,18 @@ describe('computeChartGrandTotal', () => {
 })
 
 describe('formatChartNumber', () => {
-  it('preserves full precision', () => {
+  it('preserves meaningful precision', () => {
     expect(formatChartNumber(10.126)).toBe('10.126')
     expect(formatChartNumber(3)).toBe('3')
     expect(formatChartNumber(0.914273581)).toBe('0.914273581')
+  })
+
+  it('strips IEEE 754 display noise from sums and binary residues', () => {
+    expect(formatChartNumber(0.1 + 0.2)).toBe('0.3')
+    expect(formatChartNumber(39128072.70000001)).toBe('39128072.7')
+    expect(formatChartNumber(5941.380000000001)).toBe('5941.38')
+    expect(formatChartNumber(3370.4500000000003)).toBe('3370.45')
+    expect(formatChartNumber(2864.2999999999997)).toBe('2864.3')
   })
 
   it('stringifies non-finite values', () => {

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -149,10 +149,15 @@ export const canOfferValue3D = (
 }
 
 /**
- * Format a chart number for display. No rounding — values are shown as stored
- * in the dataset (CLI may have applied --round when building the file).
+ * Format a chart number for display. Strips IEEE 754 binary noise (e.g. sum
+ * artifacts like 39128072.70000001 → "39128072.7") while keeping ~15 significant
+ * digits — within double precision. CLI --round still applies when building data;
+ * CSV export uses raw String(v), not this formatter.
  */
-export const formatChartNumber = (value: number): string => String(value)
+export const formatChartNumber = (value: number): string => {
+  if (!Number.isFinite(value)) return String(value)
+  return String(Number(value.toPrecision(15)))
+}
 
 export const isValueModeChart = (chart: ChartData): boolean => chart.statType === 'value'
 


### PR DESCRIPTION
## Summary

- Chart **Total** badges and tooltip **Σ** lines could show binary float residue (`39128072.70000001`) after summing values.
- `formatChartNumber` now formats with `Number(value.toPrecision(15))`, which keeps ~15 significant digits (within double precision) and strips display noise.
- Updates unit tests for the formatter and label config.
- CSV export remains full precision (`String(v)`); CLI `--round` is unchanged.

## Test plan

- [x] `npx vitest run src/lib/utils.test.ts src/composables/charts/shared/chartConfig.test.ts`
- [x] `npx vitest run src/composables/charts`
- [ ] Open a multi-series bench chart and confirm Total / Σ no longer show `…000001` tails
- [ ] Confirm meaningful values (e.g. `10.126`) still display fully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart number formatting to remove distracting floating-point artifacts from calculated and near-integer decimal values.
  * Preserved meaningful decimal precision, including values such as `1.005` and `-1.005`.
  * Kept non-finite values unchanged for consistent display.
  * Updated chart label handling so numeric values and coordinate pairs display cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->