### PR TITLE
fix(ui): apply log scale for fractional values

### DIFF
--- a/ui/src/composables/charts/shared/3d.test.ts
+++ b/ui/src/composables/charts/shared/3d.test.ts
@@ -634,7 +634,8 @@ describe('remaining 3d branch coverage', () => {
     const { createContinuous3DAxes } = await import('./3d')
     const axes = createContinuous3DAxes(styling, 'x', 'y', 'z', 'log')
     expect(axes.xAxis3D.type).toBe('log')
-    expect(axes.xAxis3D.logBase).toBe(10)
+    expect(axes.yAxis3D.type).toBe('log')
+    expect(axes.zAxis3D.type).toBe('log')
   })
 
   it('createContinuous3DTooltipFormatter default labels', async () => {

--- a/ui/src/composables/charts/shared/3d.test.ts
+++ b/ui/src/composables/charts/shared/3d.test.ts
@@ -15,6 +15,7 @@ import {
   createValue3DTooltipFormatter,
   createZLegendConfig,
   resolve3DVisualMap,
+  resolve3DZAxisType,
   symbolSizeFor3DGrid,
   symbolSizeForContinuous3D,
 } from './3d'
@@ -626,6 +627,25 @@ describe('maxFrom3DData / seriesHasMetricDimension edges', () => {
     expect(maxFrom3DData([])).toBe(1)
     expect(maxFrom3DData([{ data: [{ value: [0, 0] }] }], 2)).toBe(1)
     expect(resolve3DVisualMap(true, [{ data: [] }], styling)).toMatchObject({ max: 1 })
+  })
+})
+
+describe('resolve3DZAxisType', () => {
+  it('keeps log when metric heights are positive', () => {
+    expect(
+      resolve3DZAxisType('log', [
+        { name: 'a', data: [{ value: [0, 0, 0.2] }, { value: [1, 0, 3] }] },
+      ])
+    ).toBe('log')
+  })
+
+  it('falls back to value for empty or non-positive metrics', () => {
+    expect(resolve3DZAxisType('log', [])).toBe('value')
+    expect(
+      resolve3DZAxisType('log', [
+        { name: 'a', data: [{ value: [0, 0, 0] }, { value: [1, 0, -1] }] },
+      ])
+    ).toBe('value')
   })
 })
 

--- a/ui/src/composables/charts/shared/3d.test.ts
+++ b/ui/src/composables/charts/shared/3d.test.ts
@@ -647,6 +647,10 @@ describe('resolve3DZAxisType', () => {
       ])
     ).toBe('value')
   })
+
+  it('treats missing metric height (no value[2]) as non-positive', () => {
+    expect(resolve3DZAxisType('log', [{ name: 'a', data: [{ value: [0, 0] }] }])).toBe('value')
+  })
 })
 
 describe('remaining 3d branch coverage', () => {

--- a/ui/src/composables/charts/shared/3d.ts
+++ b/ui/src/composables/charts/shared/3d.ts
@@ -11,6 +11,7 @@ import {
   getTooltipTheme,
   type ChartStyling,
 } from './chartConfig'
+import { resolveLogScale } from './common'
 
 /** Blue-to-red gradient for value-mode 3D visualMap (metric height). */
 export const VALUE_3D_COLOR_RANGE = [
@@ -41,6 +42,20 @@ export function maxFrom3DData(series: { data: { value: number[] }[] }[], dimensi
     }
   }
   return max || 1
+}
+
+/** Metric height on grouped/value 3D points is value[2] (not zValues category labels). */
+export function* series3DMetricValues(series: Series3DData[]): Generator<number | null> {
+  for (const s of series) {
+    for (const item of s.data) {
+      yield item.value[2] ?? null
+    }
+  }
+}
+
+/** Log z-axis only when metric heights have a positive domain. */
+export function resolve3DZAxisType(scale: ScaleType, series: Series3DData[]): 'log' | 'value' {
+  return resolveLogScale(scale, series3DMetricValues(series)) === 'log' ? 'log' : 'value'
 }
 
 export function create3DVisualMap(max: number, styling: ChartStyling, dimension: 1 | 2 | 3 = 2) {

--- a/ui/src/composables/charts/shared/3d.ts
+++ b/ui/src/composables/charts/shared/3d.ts
@@ -285,24 +285,20 @@ export function createContinuous3DAxes(
   scale: ScaleType = 'linear'
 ) {
   const valueType = scale === 'log' ? ('log' as const) : ('value' as const)
-  const log = scale === 'log' ? { logBase: 10 } : {}
   const axisCommon = makeAxis3DCommon(styling)
   return {
     xAxis3D: {
       type: valueType,
-      ...log,
       ...axisCommon,
       ...axis3DName(xLabel, styling),
     },
     yAxis3D: {
       type: valueType,
-      ...log,
       ...axisCommon,
       ...axis3DName(yLabel, styling),
     },
     zAxis3D: {
       type: valueType,
-      ...log,
       ...axisCommon,
       ...axis3DName(zLabel, styling),
     },

--- a/ui/src/composables/charts/shared/chartConfig.test.ts
+++ b/ui/src/composables/charts/shared/chartConfig.test.ts
@@ -36,33 +36,27 @@ describe('createAxisConfig (y-axis range)', () => {
   })
 
   it('fits y-axis to data range for line/scatter (scale: true)', () => {
-    const { yAxis } = createAxisConfig(
-      styling,
-      ['a', 'b'],
-      'linear',
-      undefined,
-      undefined,
-      false,
-      true
-    )
+    const { yAxis } = createAxisConfig(styling, ['a', 'b'], 'linear', undefined, false, true)
     expect(yAxis.scale).toBe(true)
   })
 
-  it('sets log min from data instead of scale when log scale is active', () => {
-    const { yAxis } = createAxisConfig(styling, ['a', 'b'], 'log', 2500, undefined, false, true)
+  it('uses dataMin/dataMax for log scale', () => {
+    const { yAxis } = createAxisConfig(styling, ['a', 'b'], 'log', undefined, false, true)
     expect(yAxis.scale).toBeUndefined()
-    expect(yAxis.min).toBe(1000)
+    expect(yAxis.type).toBe('log')
+    expect(yAxis.min).toBe('dataMin')
+    expect(yAxis.max).toBe('dataMax')
   })
 })
 
 describe('createValueAxisConfig (y-axis range)', () => {
   it('fits y-axis to data for value-mode line/scatter', () => {
-    const { yAxis } = createValueAxisConfig(styling, 'x', 'y', 'linear', undefined, true)
+    const { yAxis } = createValueAxisConfig(styling, 'x', 'y', 'linear', true)
     expect(yAxis.scale).toBe(true)
   })
 
   it('keeps zero baseline for value-mode bar charts', () => {
-    const { yAxis } = createValueAxisConfig(styling, 'x', 'y', 'linear', undefined, false)
+    const { yAxis } = createValueAxisConfig(styling, 'x', 'y', 'linear', false)
     expect(yAxis.scale).toBeUndefined()
   })
 })
@@ -344,9 +338,11 @@ describe('createHorizontalDataZoomConfig', () => {
 })
 
 describe('createValueAxisConfig log min', () => {
-  it('sets log minimum from minValue', () => {
-    const axes = createValueAxisConfig(styling, 'x', 'y', 'log', 25)
-    expect(axes.yAxis.min).toBe(10)
+  it('uses dataMin/dataMax for log scale', () => {
+    const axes = createValueAxisConfig(styling, 'x', 'y', 'log')
+    expect(axes.yAxis.type).toBe('log')
+    expect(axes.yAxis.min).toBe('dataMin')
+    expect(axes.yAxis.max).toBe('dataMax')
   })
 })
 
@@ -364,11 +360,12 @@ describe('createValueModeTooltip', () => {
 })
 
 describe('createHorizontalAxisConfig log + large', () => {
-  it('sets log min and auto interval for large categories', async () => {
+  it('uses dataMin/dataMax for log and auto interval for large categories', async () => {
     const { createHorizontalAxisConfig } = await import('./chartConfig')
     const many = Array.from({ length: 60 }, (_, i) => `c${i}`)
-    const axes = createHorizontalAxisConfig(styling, many, 'log', 50, 'cat', true)
-    expect(axes.xAxis.min).toBe(10)
+    const axes = createHorizontalAxisConfig(styling, many, 'log', 'cat', true)
+    expect(axes.xAxis.min).toBe('dataMin')
+    expect(axes.xAxis.max).toBe('dataMax')
     expect(axes.yAxis.axisLabel.interval).toBe('auto')
     expect(axes.yAxis.nameGap).toBe(88)
   })

--- a/ui/src/composables/charts/shared/chartConfig.ts
+++ b/ui/src/composables/charts/shared/chartConfig.ts
@@ -9,6 +9,7 @@ export const LARGE_X_THRESHOLD = 50
 export const DATAZOOM_INITIAL_END_PERCENT = 20
 
 const axisTitleFontSize = 16
+const LOG_AXIS_RANGE = { min: 'dataMin' as const, max: 'dataMax' as const }
 
 // Bottom chrome for heatmap / correlation — visualMap always, dataZoom when len > 50.
 export const HEATMAP_VISUAL_MAP_BOTTOM = 8
@@ -227,7 +228,6 @@ export function createValueAxisConfig(
   xAxisName?: string,
   yAxisName?: string,
   yScale: ScaleType = 'linear',
-  minValue?: number,
   fitYAxisToData = false
 ): { xAxis: any; yAxis: any } {
   const nameStyle = {
@@ -238,7 +238,6 @@ export function createValueAxisConfig(
 
   const yAxisConfig: any = {
     type: yScale === 'log' ? 'log' : 'value',
-    logBase: 10,
     ...(yAxisName
       ? { name: yAxisName, nameLocation: 'middle', nameGap: 45, nameTextStyle: nameStyle }
       : {}),
@@ -247,10 +246,9 @@ export function createValueAxisConfig(
     axisLine: { lineStyle: { color: styling.axisColor } },
   }
 
-  if (yScale === 'log' && minValue !== undefined) {
-    const minLog = Math.pow(10, Math.floor(Math.log10(minValue)))
-    yAxisConfig.min = Math.max(1, minLog)
-  } else if (fitYAxisToData && yScale === 'linear') {
+  if (yScale === 'log') {
+    Object.assign(yAxisConfig, LOG_AXIS_RANGE)
+  } else if (fitYAxisToData) {
     yAxisConfig.scale = true
   }
 
@@ -329,14 +327,12 @@ export function createAxisConfig(
   styling: ChartStyling,
   xAxisData: string[],
   scale: ScaleType = 'linear',
-  minValue?: number,
   xAxisName?: string,
   hasDataZoom = false,
   fitYAxisToData = false
 ): { xAxis: any; yAxis: any } {
   const yAxisConfig: any = {
     type: scale === 'log' ? 'log' : 'value',
-    logBase: 10,
     splitLine: {
       lineStyle: {
         opacity: styling.opacity,
@@ -350,12 +346,9 @@ export function createAxisConfig(
     },
   }
 
-  // For log scale, set a clean minimum to avoid showing 0.1
-  if (scale === 'log' && minValue !== undefined) {
-    // Round down to nearest power of 10, but minimum is 1
-    const minLog = Math.pow(10, Math.floor(Math.log10(minValue)))
-    yAxisConfig.min = Math.max(1, minLog)
-  } else if (fitYAxisToData && scale === 'linear') {
+  if (scale === 'log') {
+    Object.assign(yAxisConfig, LOG_AXIS_RANGE)
+  } else if (fitYAxisToData) {
     // ECharts default includes zero; scale the axis to the series min/max instead.
     yAxisConfig.scale = true
   }
@@ -405,7 +398,6 @@ export function createHorizontalAxisConfig(
   styling: ChartStyling,
   yAxisData: string[],
   scale: ScaleType = 'linear',
-  minValue?: number,
   categoryAxisName?: string,
   hasDataZoom = false
 ): { xAxis: any; yAxis: any } {
@@ -417,7 +409,6 @@ export function createHorizontalAxisConfig(
 
   const xAxisConfig: any = {
     type: scale === 'log' ? 'log' : 'value',
-    logBase: 10,
     splitLine: {
       lineStyle: { opacity: styling.opacity },
     },
@@ -429,10 +420,7 @@ export function createHorizontalAxisConfig(
     },
   }
 
-  if (scale === 'log' && minValue !== undefined) {
-    const minLog = Math.pow(10, Math.floor(Math.log10(minValue)))
-    xAxisConfig.min = Math.max(1, minLog)
-  }
+  if (scale === 'log') Object.assign(xAxisConfig, LOG_AXIS_RANGE)
 
   return {
     xAxis: xAxisConfig,

--- a/ui/src/composables/charts/shared/common.test.ts
+++ b/ui/src/composables/charts/shared/common.test.ts
@@ -8,7 +8,7 @@ import {
   sortByValue,
   adjustForLogScaleLine,
   useSortedSeriesData,
-  getEffectiveScale,
+  resolveLogScale,
   computeSeriesTotals,
   sortByAxisTotal,
 } from './common'
@@ -80,47 +80,22 @@ describe('useSortedSeriesData', () => {
   })
 })
 
-describe('getEffectiveScale', () => {
-  it('downgrades log to linear when empty (max defaults to 0)', () => {
-    expect(getEffectiveScale([], 'log')).toEqual({
-      minValue: undefined,
-      effectiveScale: 'linear',
-    })
+describe('resolveLogScale', () => {
+  it('falls back to linear when empty', () => {
+    expect(resolveLogScale('log', [])).toBe('linear')
   })
 
-  it('skips nulls and tracks min positive + max', () => {
-    const series = [
-      { xAxis: 'a', values: [null, 5, 2], benchmarkId: '' },
-      { xAxis: 'b', values: [null, 8, 0.5], benchmarkId: '' },
-    ]
-    expect(getEffectiveScale(series, 'linear')).toEqual({
-      minValue: 0.5,
-      effectiveScale: 'linear',
-    })
+  it('keeps log when any value is positive', () => {
+    expect(resolveLogScale('log', [0.2, 0.5])).toBe('log')
+    expect(resolveLogScale('log', [-5, 0, 3])).toBe('log')
   })
 
-  it('downgrades log to linear when max < 1', () => {
-    const series = [{ xAxis: 'a', values: [0.2, 0.5], benchmarkId: '' }]
-    expect(getEffectiveScale(series, 'log')).toEqual({
-      minValue: 0.2,
-      effectiveScale: 'linear',
-    })
+  it('falls back when only non-positive values exist', () => {
+    expect(resolveLogScale('log', [-5, 0, null])).toBe('linear')
   })
 
-  it('keeps log when max >= 1', () => {
-    const series = [{ xAxis: 'a', values: [0.2, 2], benchmarkId: '' }]
-    expect(getEffectiveScale(series, 'log')).toEqual({
-      minValue: 0.2,
-      effectiveScale: 'log',
-    })
-  })
-
-  it('ignores non-positive for minValue but uses them for max', () => {
-    const series = [{ xAxis: 'a', values: [-5, 0, 3], benchmarkId: '' }]
-    expect(getEffectiveScale(series, 'linear')).toEqual({
-      minValue: 3,
-      effectiveScale: 'linear',
-    })
+  it('passes linear through unchanged', () => {
+    expect(resolveLogScale('linear', [1, 2])).toBe('linear')
   })
 })
 

--- a/ui/src/composables/charts/shared/common.ts
+++ b/ui/src/composables/charts/shared/common.ts
@@ -1,6 +1,6 @@
 import { computed } from 'vue'
 import type { Ref } from 'vue'
-import type { SortOrder, ScaleType, ChartData, SeriesData, Sort } from '@/types'
+import type { SortOrder, ScaleType, ChartData, Sort } from '@/types'
 import type { Point3D } from '@/types'
 import { hasYAxis } from '@/lib/utils'
 
@@ -41,29 +41,13 @@ export function useSortedSeriesData(chartData: Ref<ChartData>, _sort: Ref<Sort>)
   }))
 }
 
-// Compute effective scale and min value — log is downgraded to linear when max < 1.
-// Single pass (no `Math.min(...arr)` spread — that both allocates an intermediate
-// array and throws RangeError once the arg count is large, e.g. 100k points).
-export function getEffectiveScale(
-  series: SeriesData[],
-  scale: ScaleType
-): { minValue: number | undefined; effectiveScale: ScaleType } {
-  let minValue: number | undefined
-  let maxValue = 0
-  let any = false
-  for (const s of series) {
-    for (const v of s.values) {
-      if (v === null) continue
-      if (!any) {
-        maxValue = v
-        any = true
-      } else if (v > maxValue) {
-        maxValue = v
-      }
-      if (v > 0 && (minValue === undefined || v < minValue)) minValue = v
-    }
+/** Log needs a positive domain; fall back to linear when none exists. */
+export function resolveLogScale(scale: ScaleType, values: Iterable<number | null>): ScaleType {
+  if (scale !== 'log') return scale
+  for (const v of values) {
+    if (v !== null && v > 0) return 'log'
   }
-  return { minValue, effectiveScale: scale === 'log' && maxValue < 1 ? 'linear' : scale }
+  return 'linear'
 }
 
 // Sum each named series' data values — used for tooltip axis-sum display. Data

--- a/ui/src/composables/charts/shared/mixedMode.test.ts
+++ b/ui/src/composables/charts/shared/mixedMode.test.ts
@@ -337,8 +337,8 @@ describe('buildMixedAxes3DOptions', () => {
       }),
       'scatter3D'
     )
-    expect(option.yAxis3D).toMatchObject({ type: 'log', logBase: 10 })
-    expect(option.zAxis3D).toMatchObject({ type: 'log', logBase: 10 })
+    expect(option.yAxis3D).toMatchObject({ type: 'log' })
+    expect(option.zAxis3D).toMatchObject({ type: 'log' })
     expect(seriesList(option)).toEqual([])
     expect(option.visualMap).toBeTruthy()
   })

--- a/ui/src/composables/charts/shared/mixedMode.ts
+++ b/ui/src/composables/charts/shared/mixedMode.ts
@@ -25,7 +25,7 @@ import {
   symbolSizeForContinuous3D,
   resolve3DVisualMap,
 } from './3d'
-import { adjustForLogScaleLine, getEffectiveScale } from './common'
+import { adjustForLogScaleLine, resolveLogScale } from './common'
 import { resolve3DSymbolProps, resolveSeriesSymbol } from './seriesConfig'
 import { resolve2DScatterVisualMap } from './visualMap'
 import type { Series3DData } from '@/types'
@@ -110,10 +110,9 @@ export function buildMixedAxes2DOptions(
   const yLabel = chartData.value.axisLabels?.y
   const baseOptions = getBaseOptions(config)
   const styling = getChartStyling(isDark.value)
-  const effectiveScale = scale?.value ?? 'linear'
-  const { minValue, effectiveScale: yScale } = getEffectiveScale(
-    [{ xAxis: chartData.value.title, values: tuples.map(([, y]) => y), benchmarkId: '' }],
-    effectiveScale
+  const yScale = resolveLogScale(
+    scale?.value ?? 'linear',
+    tuples.map(([, y]) => y)
   )
 
   const data = scaleMixedTuples(tuples, yScale)
@@ -174,7 +173,6 @@ export function buildMixedAxes2DOptions(
     styling,
     xCategories,
     yScale,
-    minValue,
     xLabel,
     largeX,
     chartType === 'scatter'
@@ -219,7 +217,6 @@ export function buildMixedAxes3DOptions(
   const { yCount } = continuous3DGridCounts(pointCount)
   const yScale = scale?.value ?? 'linear'
   const valueType = yScale === 'log' ? ('log' as const) : ('value' as const)
-  const logOpts = yScale === 'log' ? { logBase: 10 } : {}
   const grid3D = create3DGridConfig({
     styling,
     autoRotate: threeDRotate?.value ?? false,
@@ -290,13 +287,11 @@ export function buildMixedAxes3DOptions(
     },
     yAxis3D: {
       type: valueType,
-      ...logOpts,
       ...axisCommon,
       ...axis3DName(axisLabels?.y, styling),
     },
     zAxis3D: {
       type: valueType,
-      ...logOpts,
       ...axisCommon,
       ...axis3DName(axisLabels?.z, styling),
     },

--- a/ui/src/composables/charts/shared/valueMode.ts
+++ b/ui/src/composables/charts/shared/valueMode.ts
@@ -12,7 +12,7 @@ import {
   LARGE_DATA_THRESHOLD,
   scatterSeriesLargeOpts,
 } from './chartConfig'
-import { adjustForLogScaleLine, getEffectiveScale } from './common'
+import { adjustForLogScaleLine, resolveLogScale } from './common'
 import { resolveSeriesSymbol } from './seriesConfig'
 import { resolve2DScatterVisualMap } from './visualMap'
 
@@ -71,10 +71,9 @@ export function buildValueAxes2DOptions(
   const yLabel = chartData.value.axisLabels?.y
   const baseOptions = getBaseOptions(config)
   const styling = getChartStyling(isDark.value)
-  const effectiveScale = scale?.value ?? 'linear'
-  const { minValue, effectiveScale: yScale } = getEffectiveScale(
-    [{ xAxis: chartData.value.title, values: tuples.map((t) => t[1]), benchmarkId: '' }],
-    effectiveScale
+  const yScale = resolveLogScale(
+    scale?.value ?? 'linear',
+    tuples.map((t) => t[1])
   )
 
   const sorted = sortValueTuples(tuples, sort.value.enabled, sort.value.order)
@@ -126,7 +125,6 @@ export function buildValueAxes2DOptions(
       xLabel,
       yLabel,
       yScale,
-      minValue,
       chartType === 'line' || chartType === 'scatter'
     ),
     dataZoom: [

--- a/ui/src/composables/charts/useBar3DChartOptions.test.ts
+++ b/ui/src/composables/charts/useBar3DChartOptions.test.ts
@@ -116,6 +116,25 @@ describe('useBar3DChartOptions — remaining branches', () => {
     expect(options.value.visualMap).toMatchObject({ show: true })
   })
 
+  it('falls back z-axis to value when log has no positive metric domain', () => {
+    const { options } = useBar3DChartOptions(
+      baseConfig({
+        chartData: emptyChartData({
+          title: 'sales',
+          statType: 'sum',
+          render3D: {
+            ...valueModeRender,
+            barSeries: [{ name: 'sales', data: [{ value: [0, 0, 0] }, { value: [1, 0, -2] }] }],
+            cellTotals: { '0,0': 0, '1,0': -2 },
+          },
+        }),
+        threeD: true,
+        scale: 'log',
+      })
+    )
+    expect((options.value.zAxis3D as { type?: string }).type).toBe('value')
+  })
+
   it('emits mixed-mode bar3D', () => {
     const { options } = useBar3DChartOptions(
       baseConfig({

--- a/ui/src/composables/charts/useBar3DChartOptions.ts
+++ b/ui/src/composables/charts/useBar3DChartOptions.ts
@@ -18,6 +18,7 @@ import {
   buildContinuous3DOptions,
   makeContinuous3DParams,
   valuePoints3DToSeries,
+  resolve3DZAxisType,
   type Continuous3DContext,
 } from './shared'
 import { buildMixedAxes3DOptions } from './shared/mixedMode'
@@ -35,7 +36,7 @@ export function useBar3DChartOptions(config: BaseChartConfig) {
     const defaultColor = getDefaultThemeColor()
     const axisCommon = makeAxis3DCommon(styling)
     const zAxis3DBase = {
-      ...(scale?.value === 'log' ? { type: 'log' as const } : { type: 'value' as const }),
+      type: resolve3DZAxisType(scale?.value ?? 'linear', render.barSeries),
       ...axisCommon,
     }
     if (render.mode === 'mixed') {

--- a/ui/src/composables/charts/useBar3DChartOptions.ts
+++ b/ui/src/composables/charts/useBar3DChartOptions.ts
@@ -35,9 +35,7 @@ export function useBar3DChartOptions(config: BaseChartConfig) {
     const defaultColor = getDefaultThemeColor()
     const axisCommon = makeAxis3DCommon(styling)
     const zAxis3DBase = {
-      ...(scale?.value === 'log'
-        ? { type: 'log' as const, logBase: 10 }
-        : { type: 'value' as const }),
+      ...(scale?.value === 'log' ? { type: 'log' as const } : { type: 'value' as const }),
       ...axisCommon,
     }
     if (render.mode === 'mixed') {

--- a/ui/src/composables/charts/useBarChartOptions.ts
+++ b/ui/src/composables/charts/useBarChartOptions.ts
@@ -17,7 +17,7 @@ import {
   makeLegendTitle,
   LARGE_DATA_THRESHOLD,
 } from './shared'
-import { useSortedSeriesData, getEffectiveScale, computeSeriesTotals } from './shared/common'
+import { useSortedSeriesData, resolveLogScale, computeSeriesTotals } from './shared/common'
 import { buildValueAxes2DOptions } from './shared/valueMode'
 import { buildMixedAxes2DOptions } from './shared/mixedMode'
 
@@ -45,10 +45,13 @@ export function useBarChartOptions(config: BaseChartConfig) {
     // `scale` is optional on BaseChartConfig (relaxed in Task 7) — pie/heatmap/
     // radar pass a config without it. The bar composable is the only consumer,
     // so we default at the call site.
-    const { minValue, effectiveScale } = getEffectiveScale(series, scale?.value ?? 'linear')
+    const yScale = resolveLogScale(
+      scale?.value ?? 'linear',
+      series.flatMap((s) => s.values)
+    )
     const largeX = isLargeXAxis(xAxisData)
     const xLabel = chartData.value.axisLabels?.x
-    const useStack = stack?.value === true && effectiveScale !== 'log'
+    const useStack = stack?.value === true && yScale !== 'log'
 
     if (!hasYAxis && isHorizontal) {
       return {
@@ -62,13 +65,13 @@ export function useBarChartOptions(config: BaseChartConfig) {
         },
         tooltip: createTooltipConfig(false, isDark.value),
         legend: { show: false },
-        ...createHorizontalAxisConfig(styling, xAxisData, effectiveScale, minValue, xLabel, largeX),
+        ...createHorizontalAxisConfig(styling, xAxisData, yScale, xLabel, largeX),
         ...(largeX ? { dataZoom: createHorizontalDataZoomConfig(styling) } : {}),
         series: [
           {
             name: chartData.value.title,
             type: 'bar' as const,
-            data: series.map((s) => barNullable(s.values[0] ?? null, effectiveScale)),
+            data: series.map((s) => barNullable(s.values[0] ?? null, yScale)),
             label: createLabelConfig(showLabels.value, styling, 'horizontal'),
             large: true,
             largeThreshold: LARGE_DATA_THRESHOLD,
@@ -84,7 +87,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
         grid: createGridConfig(1, largeX),
         tooltip: createTooltipConfig(false, isDark.value),
         legend: { show: false },
-        ...createAxisConfig(styling, xAxisData, effectiveScale, minValue, xLabel, largeX),
+        ...createAxisConfig(styling, xAxisData, yScale, xLabel, largeX),
         ...(largeX ? { dataZoom: createDataZoomConfig(xAxisData, styling) } : {}),
         series: [
           {
@@ -94,7 +97,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
             // object — a 100k-bar chart would otherwise allocate 100k label configs
             // on every recompute. `large` keeps the draw on one frame past the
             // threshold.
-            data: series.map((s) => barNullable(s.values[0] ?? null, effectiveScale)),
+            data: series.map((s) => barNullable(s.values[0] ?? null, yScale)),
             label: createLabelConfig(showLabels.value, styling),
             large: true,
             largeThreshold: LARGE_DATA_THRESHOLD,
@@ -109,7 +112,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
     const transposedSeries = yAxisLabels.map((yAxisLabel, yIndex) => ({
       name: yAxisLabel,
       type: 'bar' as const,
-      data: series.map((s) => barNullable(s.values[yIndex] ?? null, effectiveScale)),
+      data: series.map((s) => barNullable(s.values[yIndex] ?? null, yScale)),
       label: createLabelConfig(
         showLabels.value,
         styling,
@@ -156,7 +159,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
           hasMultipleSeries,
           { bottom: 0 }
         ),
-        ...createHorizontalAxisConfig(styling, xAxisData, effectiveScale, minValue, xLabel, largeX),
+        ...createHorizontalAxisConfig(styling, xAxisData, yScale, xLabel, largeX),
         ...(largeX ? { dataZoom: createHorizontalDataZoomConfig(styling) } : {}),
         series: transposedSeries,
       } as EChartsOption
@@ -173,7 +176,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
         hasMultipleSeries,
         showLegendTitle ? { top: 24 } : undefined
       ),
-      ...createAxisConfig(styling, xAxisData, effectiveScale, minValue, xLabel, largeX),
+      ...createAxisConfig(styling, xAxisData, yScale, xLabel, largeX),
       ...(largeX ? { dataZoom: createDataZoomConfig(xAxisData, styling) } : {}),
       series: transposedSeries,
     } as EChartsOption

--- a/ui/src/composables/charts/useCategorySeriesChartOptions.ts
+++ b/ui/src/composables/charts/useCategorySeriesChartOptions.ts
@@ -19,7 +19,7 @@ import {
 import {
   adjustForLogScaleLine,
   useSortedSeriesData,
-  getEffectiveScale,
+  resolveLogScale,
   computeSeriesTotals,
 } from './shared/common'
 import { resolveSeriesSymbol } from './shared/seriesConfig'
@@ -65,7 +65,10 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
     const { series, xAxisData, hasYAxis } = sortedData.value
     const baseOptions = getBaseOptions(config)
     const styling = getChartStyling(isDark.value)
-    const { minValue, effectiveScale } = getEffectiveScale(series, scale?.value ?? 'linear')
+    const yScale = resolveLogScale(
+      scale?.value ?? 'linear',
+      series.flatMap((s) => s.values)
+    )
     const largeX = isLargeXAxis(xAxisData)
     const xLabel = chartData.value.axisLabels?.x
     const seriesExtras = resolveSeriesSymbol(
@@ -75,13 +78,13 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
     )
     const useVisualMap = kind === 'scatter' && visualMap?.value === true
     const smoothLines = kind === 'line' && config.smooth?.value === true
-    const useStack = kind === 'line' && stack?.value === true && effectiveScale !== 'log'
+    const useStack = kind === 'line' && stack?.value === true && yScale !== 'log'
 
     if (!hasYAxis) {
       const singleSeries = {
         name: chartData.value.title,
         type: kind,
-        data: series.map((s) => adjustForLogScaleLine(s.values[0] ?? null, effectiveScale)),
+        data: series.map((s) => adjustForLogScaleLine(s.values[0] ?? null, yScale)),
         label: createLabelConfig(showLabels.value, styling),
         ...(kind === 'scatter'
           ? scatterSeriesLargeOpts(useVisualMap)
@@ -95,7 +98,7 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
         ...baseOptions,
         grid: createGridConfig(1, largeX),
         tooltip: createPinnedAxisTooltip(isDark.value),
-        ...createAxisConfig(styling, xAxisData, effectiveScale, minValue, xLabel, largeX, true),
+        ...createAxisConfig(styling, xAxisData, yScale, xLabel, largeX, true),
         ...(largeX ? { dataZoom: createDataZoomConfig(xAxisData, styling) } : {}),
         legend: { show: false },
         visualMap: resolve2DScatterVisualMap(
@@ -112,7 +115,7 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
     const transposedSeries = yAxisLabels.map((yAxisLabel, yIndex) => ({
       name: yAxisLabel,
       type: kind,
-      data: series.map((s) => adjustForLogScaleLine(s.values[yIndex] ?? null, effectiveScale)),
+      data: series.map((s) => adjustForLogScaleLine(s.values[yIndex] ?? null, yScale)),
       label: createLabelConfig(showLabels.value, styling),
       ...(kind === 'scatter'
         ? scatterSeriesLargeOpts(useVisualMap)
@@ -139,7 +142,7 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
         1
       ),
       tooltip: createTooltipConfig(showXBreakdown, isDark.value, seriesTotals),
-      ...createAxisConfig(styling, xAxisData, effectiveScale, minValue, xLabel, largeX, true),
+      ...createAxisConfig(styling, xAxisData, yScale, xLabel, largeX, true),
       ...(largeX ? { dataZoom: createDataZoomConfig(xAxisData, styling) } : {}),
       legend: createLegendConfig(
         transposedSeries.map((s) => ({ xAxis: s.name })),

--- a/ui/src/composables/charts/useLine3DChartOptions.ts
+++ b/ui/src/composables/charts/useLine3DChartOptions.ts
@@ -18,6 +18,7 @@ import {
   buildContinuous3DOptions,
   makeContinuous3DParams,
   valuePoints3DToSeries,
+  resolve3DZAxisType,
   type Continuous3DContext,
 } from './shared'
 import { resolve3DSymbolProps } from './shared/seriesConfig'
@@ -46,7 +47,7 @@ export function useLine3DChartOptions(config: BaseChartConfig) {
     const defaultColor = getDefaultThemeColor()
     const axisCommon = makeAxis3DCommon(styling)
     const zAxis3DBase = {
-      ...(scale?.value === 'log' ? { type: 'log' as const } : { type: 'value' as const }),
+      type: resolve3DZAxisType(scale?.value ?? 'linear', render.lineSeries),
       ...axisCommon,
     }
     if (render.mode === 'mixed') {

--- a/ui/src/composables/charts/useLine3DChartOptions.ts
+++ b/ui/src/composables/charts/useLine3DChartOptions.ts
@@ -46,9 +46,7 @@ export function useLine3DChartOptions(config: BaseChartConfig) {
     const defaultColor = getDefaultThemeColor()
     const axisCommon = makeAxis3DCommon(styling)
     const zAxis3DBase = {
-      ...(scale?.value === 'log'
-        ? { type: 'log' as const, logBase: 10 }
-        : { type: 'value' as const }),
+      ...(scale?.value === 'log' ? { type: 'log' as const } : { type: 'value' as const }),
       ...axisCommon,
     }
     if (render.mode === 'mixed') {

--- a/ui/src/composables/charts/useScatter3DChartOptions.ts
+++ b/ui/src/composables/charts/useScatter3DChartOptions.ts
@@ -48,9 +48,7 @@ export function useScatter3DChartOptions(config: BaseChartConfig) {
     const defaultColor = getDefaultThemeColor()
     const axisCommon = makeAxis3DCommon(styling)
     const zAxis3DBase = {
-      ...(scale?.value === 'log'
-        ? { type: 'log' as const, logBase: 10 }
-        : { type: 'value' as const }),
+      ...(scale?.value === 'log' ? { type: 'log' as const } : { type: 'value' as const }),
       ...axisCommon,
     }
     const isValueMode = render.mode === 'value'

--- a/ui/src/composables/charts/useScatter3DChartOptions.ts
+++ b/ui/src/composables/charts/useScatter3DChartOptions.ts
@@ -19,6 +19,7 @@ import {
   getTooltipTheme,
   makeContinuous3DParams,
   valuePoints3DToSeries,
+  resolve3DZAxisType,
   type Continuous3DContext,
 } from './shared'
 import { resolve3DSymbolProps } from './shared/seriesConfig'
@@ -48,7 +49,7 @@ export function useScatter3DChartOptions(config: BaseChartConfig) {
     const defaultColor = getDefaultThemeColor()
     const axisCommon = makeAxis3DCommon(styling)
     const zAxis3DBase = {
-      ...(scale?.value === 'log' ? { type: 'log' as const } : { type: 'value' as const }),
+      type: resolve3DZAxisType(scale?.value ?? 'linear', render.lineSeries),
       ...axisCommon,
     }
     const isValueMode = render.mode === 'value'


### PR DESCRIPTION
## Summary

- Fixes logarithmic scale silently doing nothing when all y-values are in (0, 1) (e.g. training loss 0.12–0.30).
- Log axes use ECharts `min: 'dataMin'` / `max: 'dataMax'` instead of a power-of-10 floor clamped at ≥1.
- Drops explicit `logBase: 10` (ECharts default) and renames `getEffectiveScale` → `resolveLogScale` (keep log only when a positive domain exists).

Closes #345.

## Test plan

- [x] `npx vitest run src/composables/charts` (UI chart unit tests)
- [x] `npx vue-tsc -b` (UI typecheck)
- [x] Rebuild UI embed / open chart:
  ```bash
  vizb line test.csv -n loss -g step -p x --col-axis y \
    --select "train_loss{Train},eval_loss{Eval}" --smooth --scale log -o narrow.html
  ```
  Confirm Settings → Logarithmic keeps a log y-axis and range hugs the data (no empty band up to 1).
- [x] Spot-check a wide-range series (max ≥ 1) still looks correct on log.
- [x] Zero/negative values still create gaps on log (not plotted as ≤0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logarithmic chart axes to use the full available data range.
  * Logarithmic scaling now automatically falls back to linear when no positive values are available.
  * Updated 2D and 3D charts for more consistent axis behavior.
  * Preserved linear-axis fitting and disabled stacking where logarithmic scales are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->