### PR TITLE
feat(ui): upgrade Vue and ECharts

### DIFF
--- a/ui/embed-build/embed-build.test.ts
+++ b/ui/embed-build/embed-build.test.ts
@@ -242,7 +242,31 @@ describe('embedUiPlugin.closeBundle', () => {
     expect(decoded).toContain('export const s=1')
 
     expect(info).toHaveBeenCalled()
-    expect(String(info.mock.calls[0]?.[0])).toContain('[embed-ui] 3 chunks')
+    const report = String(info.mock.calls[0]?.[0])
+    expect(report).toContain('[embed-ui] 3 chunks')
+
+    const embeddedHtmlBytes = Buffer.byteLength(appendVizbDataScriptTag(outHtml), 'utf-8')
+    const chunkKeys = ['index-abc', 'ChartBar-xyz', 'shared-1']
+    const encodedChunks = chunkKeys.map((key) => {
+      const match = go.match(new RegExp(`"vizb:${key}": "([A-Za-z0-9+/=]+)"`))
+      expect(match, `missing encoded chunk ${key}`).toBeTruthy()
+      return match![1]!
+    })
+    const rawTotalBytes =
+      embeddedHtmlBytes +
+      encodedChunks.reduce(
+        (total, chunk) => total + zlib.gunzipSync(Buffer.from(chunk, 'base64')).length,
+        0
+      )
+    const encodedTotalBytes =
+      embeddedHtmlBytes + encodedChunks.reduce((total, chunk) => total + chunk.length, 0)
+
+    expect(report).toContain(
+      `HTML template (placeholder): ${(embeddedHtmlBytes / 1024).toFixed(2)} kB`
+    )
+    expect(report).toContain(
+      `Total embedded payload (all chunks + HTML): actual: ${(rawTotalBytes / 1024).toFixed(2)} kB │ encoded: ${(encodedTotalBytes / 1024).toFixed(2)} kB`
+    )
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('[embed-ui] gofmt skipped'))
   })
 

--- a/ui/embed-build/plugins/embed-ui.ts
+++ b/ui/embed-build/plugins/embed-ui.ts
@@ -131,6 +131,8 @@ export const embedUiPlugin = (rootDir: string): PluginOption => {
         entryKey: chunkKeyOf(entryFile),
       }
 
+      const htmlWithState = appendVizbDataScriptTag(out)
+
       const nameW = Math.max(...chunkSizes.map(({ file }) => file.length))
       const rawW = Math.max(...chunkSizes.map(({ raw }) => (raw / 1024).toFixed(2).length))
       const b64W = Math.max(...chunkSizes.map(({ b64 }) => (b64 / 1024).toFixed(2).length))
@@ -143,12 +145,19 @@ export const embedUiPlugin = (rootDir: string): PluginOption => {
           return `  ${name}  ${rawStr} kB │ encoded: ${b64Str} kB`
         })
         .join('\n')
-      const templateKB = (Buffer.byteLength(out, 'utf-8') / 1024).toFixed(2)
+      const htmlBytes = Buffer.byteLength(htmlWithState, 'utf-8')
+      const rawTotalBytes = htmlBytes + chunkSizes.reduce((total, chunk) => total + chunk.raw, 0)
+      // Chunk blobs are gzip+base64 in Go; the HTML template remains raw text.
+      const encodedTotalBytes =
+        htmlBytes + chunkSizes.reduce((total, chunk) => total + chunk.b64, 0)
+      const templateKB = (htmlBytes / 1024).toFixed(2)
+      const rawTotalKB = (rawTotalBytes / 1024).toFixed(2)
+      const encodedTotalKB = (encodedTotalBytes / 1024).toFixed(2)
       console.info(
-        `[embed-ui] ${chunkFiles.length} chunks\n${rows}\n\n  HTML template (placeholder): ${templateKB} kB\n`
+        `[embed-ui] ${chunkFiles.length} chunks\n${rows}\n\n` +
+          `  HTML template (placeholder): ${templateKB} kB\n` +
+          `  Total embedded payload (all chunks + HTML): actual: ${rawTotalKB} kB │ encoded: ${encodedTotalKB} kB\n`
       )
-
-      const htmlWithState = appendVizbDataScriptTag(out)
 
       // Escape backticks for Go raw string literal
       const goRawString = htmlWithState.split('`').join('` + "`" + `')

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,7 +29,7 @@
     "lucide-vue-next": "^0.461.0",
     "radix-vue": "^1.9.0",
     "tailwind-merge": "^2.5.5",
-    "vue": "^3.5.22",
+    "vue": "^3.5.41",
     "vue-echarts": "^8.1.0"
   },
   "devDependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,13 +24,13 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "echarts": "^5.5.0",
+    "echarts": "^6.1.0",
     "echarts-gl": "^2.1.0",
     "lucide-vue-next": "^0.461.0",
     "radix-vue": "^1.9.0",
     "tailwind-merge": "^2.5.5",
     "vue": "^3.5.22",
-    "vue-echarts": "^7.0.3"
+    "vue-echarts": "^8.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -19,19 +19,19 @@ importers:
         version: 2.1.0(echarts@6.1.0)
       lucide-vue-next:
         specifier: ^0.461.0
-        version: 0.461.0(vue@3.5.22(typescript@6.0.3))
+        version: 0.461.0(vue@3.5.41(typescript@6.0.3))
       radix-vue:
         specifier: ^1.9.0
-        version: 1.9.17(vue@3.5.22(typescript@6.0.3))
+        version: 1.9.17(vue@3.5.41(typescript@6.0.3))
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.6.0
       vue:
-        specifier: ^3.5.22
-        version: 3.5.22(typescript@6.0.3)
+        specifier: ^3.5.41
+        version: 3.5.41(typescript@6.0.3)
       vue-echarts:
         specifier: ^8.1.0
-        version: 8.1.0(echarts@6.1.0)(vue@3.5.22(typescript@6.0.3))
+        version: 8.1.0(echarts@6.1.0)(vue@3.5.41(typescript@6.0.3))
     devDependencies:
       '@biomejs/biome':
         specifier: 2.5.6
@@ -44,16 +44,16 @@ importers:
         version: 24.7.2
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
-        version: 6.0.7(vite@8.1.0(@types/node@24.7.2)(jiti@1.21.7)(terser@5.44.0))(vue@3.5.22(typescript@6.0.3))
+        version: 6.0.7(vite@8.1.0(@types/node@24.7.2)(jiti@1.21.7)(terser@5.44.0))(vue@3.5.41(typescript@6.0.3))
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
       '@vue/test-utils':
         specifier: ^2.4.11
-        version: 2.4.11(@vue/compiler-dom@3.5.22)(@vue/server-renderer@3.5.22(vue@3.5.22(typescript@6.0.3)))(vue@3.5.22(typescript@6.0.3))
+        version: 2.4.11(@vue/compiler-dom@3.5.41)(@vue/server-renderer@3.5.41)(vue@3.5.41(typescript@6.0.3))
       '@vue/tsconfig':
         specifier: ^0.8.1
-        version: 0.8.1(typescript@6.0.3)(vue@3.5.22(typescript@6.0.3))
+        version: 0.8.1(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.6)
@@ -123,12 +123,21 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -469,14 +478,20 @@ packages:
   '@vue/compiler-core@3.5.22':
     resolution: {integrity: sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ==}
 
+  '@vue/compiler-core@3.5.41':
+    resolution: {integrity: sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==}
+
   '@vue/compiler-dom@3.5.22':
     resolution: {integrity: sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA==}
 
-  '@vue/compiler-sfc@3.5.22':
-    resolution: {integrity: sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==}
+  '@vue/compiler-dom@3.5.41':
+    resolution: {integrity: sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==}
 
-  '@vue/compiler-ssr@3.5.22':
-    resolution: {integrity: sha512-GdgyLvg4R+7T8Nk2Mlighx7XGxq/fJf9jaVofc3IL0EPesTE86cP/8DD1lT3h1JeZr2ySBvyqKQJgbS54IX1Ww==}
+  '@vue/compiler-sfc@3.5.41':
+    resolution: {integrity: sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==}
+
+  '@vue/compiler-ssr@3.5.41':
+    resolution: {integrity: sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==}
 
   '@vue/language-core@3.1.1':
     resolution: {integrity: sha512-qjMY3Q+hUCjdH+jLrQapqgpsJ0rd/2mAY02lZoHG3VFJZZZKLjAlV+Oo9QmWIT4jh8+Rx8RUGUi++d7T9Wb6Mw==}
@@ -486,22 +501,23 @@ packages:
       typescript:
         optional: true
 
-  '@vue/reactivity@3.5.22':
-    resolution: {integrity: sha512-f2Wux4v/Z2pqc9+4SmgZC1p73Z53fyD90NFWXiX9AKVnVBEvLFOWCEgJD3GdGnlxPZt01PSlfmLqbLYzY/Fw4A==}
+  '@vue/reactivity@3.5.41':
+    resolution: {integrity: sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==}
 
-  '@vue/runtime-core@3.5.22':
-    resolution: {integrity: sha512-EHo4W/eiYeAzRTN5PCextDUZ0dMs9I8mQ2Fy+OkzvRPUYQEyK9yAjbasrMCXbLNhF7P0OUyivLjIy0yc6VrLJQ==}
+  '@vue/runtime-core@3.5.41':
+    resolution: {integrity: sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==}
 
-  '@vue/runtime-dom@3.5.22':
-    resolution: {integrity: sha512-Av60jsryAkI023PlN7LsqrfPvwfxOd2yAwtReCjeuugTJTkgrksYJJstg1e12qle0NarkfhfFu1ox2D+cQotww==}
+  '@vue/runtime-dom@3.5.41':
+    resolution: {integrity: sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==}
 
-  '@vue/server-renderer@3.5.22':
-    resolution: {integrity: sha512-gXjo+ao0oHYTSswF+a3KRHZ1WszxIqO7u6XwNHqcqb9JfyIL/pbWrrh/xLv7jeDqla9u+LK7yfZKHih1e1RKAQ==}
-    peerDependencies:
-      vue: 3.5.22
+  '@vue/server-renderer@3.5.41':
+    resolution: {integrity: sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==}
 
   '@vue/shared@3.5.22':
     resolution: {integrity: sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==}
+
+  '@vue/shared@3.5.41':
+    resolution: {integrity: sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==}
 
   '@vue/test-utils@2.4.11':
     resolution: {integrity: sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==}
@@ -715,8 +731,8 @@ packages:
   cssom@0.5.0:
     resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
 
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
@@ -1091,9 +1107,6 @@ packages:
     peerDependencies:
       vue: '>=3.0.1'
 
-  magic-string@0.30.19:
-    resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1137,6 +1150,11 @@ packages:
 
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1289,6 +1307,10 @@ packages:
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
@@ -1590,8 +1612,8 @@ packages:
     peerDependencies:
       typescript: '>=5.0.0'
 
-  vue@3.5.22:
-    resolution: {integrity: sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==}
+  vue@3.5.41:
+    resolution: {integrity: sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -1658,12 +1680,21 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
   '@babel/types@7.28.4':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
   '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@7.29.8':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
@@ -1732,11 +1763,11 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@floating-ui/vue@1.1.9(vue@3.5.22(typescript@6.0.3))':
+  '@floating-ui/vue@1.1.9(vue@3.5.41(typescript@6.0.3))':
     dependencies:
       '@floating-ui/dom': 1.7.4
       '@floating-ui/utils': 0.2.10
-      vue-demi: 0.14.10(vue@3.5.22(typescript@6.0.3))
+      vue-demi: 0.14.10(vue@3.5.41(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -1871,10 +1902,10 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.12': {}
 
-  '@tanstack/vue-virtual@3.13.12(vue@3.5.22(typescript@6.0.3))':
+  '@tanstack/vue-virtual@3.13.12(vue@3.5.41(typescript@6.0.3))':
     dependencies:
       '@tanstack/virtual-core': 3.13.12
-      vue: 3.5.22(typescript@6.0.3)
+      vue: 3.5.41(typescript@6.0.3)
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -1902,11 +1933,11 @@ snapshots:
     dependencies:
       '@types/node': 24.7.2
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.1.0(@types/node@24.7.2)(jiti@1.21.7)(terser@5.44.0))(vue@3.5.22(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@8.1.0(@types/node@24.7.2)(jiti@1.21.7)(terser@5.44.0))(vue@3.5.41(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.0(@types/node@24.7.2)(jiti@1.21.7)(terser@5.44.0)
-      vue: 3.5.22(typescript@6.0.3)
+      vue: 3.5.41(typescript@6.0.3)
 
   '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
     dependencies:
@@ -1983,27 +2014,40 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.5.41':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/shared': 3.5.41
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.22':
     dependencies:
       '@vue/compiler-core': 3.5.22
       '@vue/shared': 3.5.22
 
-  '@vue/compiler-sfc@3.5.22':
+  '@vue/compiler-dom@3.5.41':
     dependencies:
-      '@babel/parser': 7.28.4
-      '@vue/compiler-core': 3.5.22
-      '@vue/compiler-dom': 3.5.22
-      '@vue/compiler-ssr': 3.5.22
-      '@vue/shared': 3.5.22
+      '@vue/compiler-core': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/compiler-sfc@3.5.41':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/compiler-core': 3.5.41
+      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-ssr': 3.5.41
+      '@vue/shared': 3.5.41
       estree-walker: 2.0.2
-      magic-string: 0.30.19
-      postcss: 8.5.6
+      magic-string: 0.30.21
+      postcss: 8.5.26
       source-map-js: 1.2.1
 
-  '@vue/compiler-ssr@3.5.22':
+  '@vue/compiler-ssr@3.5.41':
     dependencies:
-      '@vue/compiler-dom': 3.5.22
-      '@vue/shared': 3.5.22
+      '@vue/compiler-dom': 3.5.41
+      '@vue/shared': 3.5.41
 
   '@vue/language-core@3.1.1(typescript@6.0.3)':
     dependencies:
@@ -2017,59 +2061,61 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@vue/reactivity@3.5.22':
+  '@vue/reactivity@3.5.41':
     dependencies:
-      '@vue/shared': 3.5.22
+      '@vue/shared': 3.5.41
 
-  '@vue/runtime-core@3.5.22':
+  '@vue/runtime-core@3.5.41':
     dependencies:
-      '@vue/reactivity': 3.5.22
-      '@vue/shared': 3.5.22
+      '@vue/reactivity': 3.5.41
+      '@vue/shared': 3.5.41
 
-  '@vue/runtime-dom@3.5.22':
+  '@vue/runtime-dom@3.5.41':
     dependencies:
-      '@vue/reactivity': 3.5.22
-      '@vue/runtime-core': 3.5.22
-      '@vue/shared': 3.5.22
-      csstype: 3.1.3
+      '@vue/reactivity': 3.5.41
+      '@vue/runtime-core': 3.5.41
+      '@vue/shared': 3.5.41
+      csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.22(vue@3.5.22(typescript@6.0.3))':
+  '@vue/server-renderer@3.5.41':
     dependencies:
-      '@vue/compiler-ssr': 3.5.22
-      '@vue/shared': 3.5.22
-      vue: 3.5.22(typescript@6.0.3)
+      '@vue/compiler-ssr': 3.5.41
+      '@vue/runtime-dom': 3.5.41
+      '@vue/shared': 3.5.41
 
   '@vue/shared@3.5.22': {}
 
-  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.22)(@vue/server-renderer@3.5.22(vue@3.5.22(typescript@6.0.3)))(vue@3.5.22(typescript@6.0.3))':
+  '@vue/shared@3.5.41': {}
+
+  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.41)(@vue/server-renderer@3.5.41)(vue@3.5.41(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-dom': 3.5.22
+      '@vue/compiler-dom': 3.5.41
       js-beautify: 1.15.4
-      vue: 3.5.22(typescript@6.0.3)
+      vue: 3.5.41(typescript@6.0.3)
       vue-component-type-helpers: 3.3.8
     optionalDependencies:
-      '@vue/server-renderer': 3.5.22(vue@3.5.22(typescript@6.0.3))
+      '@vue/server-renderer': 3.5.41
 
-  '@vue/tsconfig@0.8.1(typescript@6.0.3)(vue@3.5.22(typescript@6.0.3))':
+  '@vue/tsconfig@0.8.1(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3))':
     optionalDependencies:
       typescript: 6.0.3
-      vue: 3.5.22(typescript@6.0.3)
+      vue: 3.5.41(typescript@6.0.3)
 
-  '@vueuse/core@10.11.1(vue@3.5.22(typescript@6.0.3))':
+  '@vueuse/core@10.11.1(vue@3.5.41(typescript@6.0.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.5.22(typescript@6.0.3))
-      vue-demi: 0.14.10(vue@3.5.22(typescript@6.0.3))
+      '@vueuse/shared': 10.11.1(vue@3.5.41(typescript@6.0.3))
+      vue-demi: 0.14.10(vue@3.5.41(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
   '@vueuse/metadata@10.11.1': {}
 
-  '@vueuse/shared@10.11.1(vue@3.5.22(typescript@6.0.3))':
+  '@vueuse/shared@10.11.1(vue@3.5.41(typescript@6.0.3))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.22(typescript@6.0.3))
+      vue-demi: 0.14.10(vue@3.5.41(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -2239,7 +2285,7 @@ snapshots:
 
   cssom@0.5.0: {}
 
-  csstype@3.1.3: {}
+  csstype@3.2.3: {}
 
   defu@6.1.4: {}
 
@@ -2584,13 +2630,9 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lucide-vue-next@0.461.0(vue@3.5.22(typescript@6.0.3)):
+  lucide-vue-next@0.461.0(vue@3.5.41(typescript@6.0.3)):
     dependencies:
-      vue: 3.5.22(typescript@6.0.3)
-
-  magic-string@0.30.19:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
+      vue: 3.5.41(typescript@6.0.3)
 
   magic-string@0.30.21:
     dependencies:
@@ -2634,6 +2676,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanoid@3.3.15: {}
+
+  nanoid@3.3.18: {}
 
   nanoid@5.1.6: {}
 
@@ -2751,6 +2795,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -2761,20 +2811,20 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  radix-vue@1.9.17(vue@3.5.22(typescript@6.0.3)):
+  radix-vue@1.9.17(vue@3.5.41(typescript@6.0.3)):
     dependencies:
       '@floating-ui/dom': 1.7.4
-      '@floating-ui/vue': 1.1.9(vue@3.5.22(typescript@6.0.3))
+      '@floating-ui/vue': 1.1.9(vue@3.5.41(typescript@6.0.3))
       '@internationalized/date': 3.10.0
       '@internationalized/number': 3.6.5
-      '@tanstack/vue-virtual': 3.13.12(vue@3.5.22(typescript@6.0.3))
-      '@vueuse/core': 10.11.1(vue@3.5.22(typescript@6.0.3))
-      '@vueuse/shared': 10.11.1(vue@3.5.22(typescript@6.0.3))
+      '@tanstack/vue-virtual': 3.13.12(vue@3.5.41(typescript@6.0.3))
+      '@vueuse/core': 10.11.1(vue@3.5.41(typescript@6.0.3))
+      '@vueuse/shared': 10.11.1(vue@3.5.41(typescript@6.0.3))
       aria-hidden: 1.2.6
       defu: 6.1.4
       fast-deep-equal: 3.1.3
       nanoid: 5.1.6
-      vue: 3.5.22(typescript@6.0.3)
+      vue: 3.5.41(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
@@ -3026,14 +3076,14 @@ snapshots:
 
   vue-component-type-helpers@3.3.8: {}
 
-  vue-demi@0.14.10(vue@3.5.22(typescript@6.0.3)):
+  vue-demi@0.14.10(vue@3.5.41(typescript@6.0.3)):
     dependencies:
-      vue: 3.5.22(typescript@6.0.3)
+      vue: 3.5.41(typescript@6.0.3)
 
-  vue-echarts@8.1.0(echarts@6.1.0)(vue@3.5.22(typescript@6.0.3)):
+  vue-echarts@8.1.0(echarts@6.1.0)(vue@3.5.41(typescript@6.0.3)):
     dependencies:
       echarts: 6.1.0
-      vue: 3.5.22(typescript@6.0.3)
+      vue: 3.5.41(typescript@6.0.3)
 
   vue-tsc@3.1.1(typescript@6.0.3):
     dependencies:
@@ -3041,13 +3091,13 @@ snapshots:
       '@vue/language-core': 3.1.1(typescript@6.0.3)
       typescript: 6.0.3
 
-  vue@3.5.22(typescript@6.0.3):
+  vue@3.5.41(typescript@6.0.3):
     dependencies:
-      '@vue/compiler-dom': 3.5.22
-      '@vue/compiler-sfc': 3.5.22
-      '@vue/runtime-dom': 3.5.22
-      '@vue/server-renderer': 3.5.22(vue@3.5.22(typescript@6.0.3))
-      '@vue/shared': 3.5.22
+      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-sfc': 3.5.41
+      '@vue/runtime-dom': 3.5.41
+      '@vue/server-renderer': 3.5.41
+      '@vue/shared': 3.5.41
     optionalDependencies:
       typescript: 6.0.3
 

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       echarts:
-        specifier: ^5.5.0
-        version: 5.6.0
+        specifier: ^6.1.0
+        version: 6.1.0
       echarts-gl:
         specifier: ^2.1.0
-        version: 2.1.0(echarts@5.6.0)
+        version: 2.1.0(echarts@6.1.0)
       lucide-vue-next:
         specifier: ^0.461.0
         version: 0.461.0(vue@3.5.22(typescript@6.0.3))
@@ -30,8 +30,8 @@ importers:
         specifier: ^3.5.22
         version: 3.5.22(typescript@6.0.3)
       vue-echarts:
-        specifier: ^7.0.3
-        version: 7.0.3(@vue/runtime-core@3.5.22)(echarts@5.6.0)(vue@3.5.22(typescript@6.0.3))
+        specifier: ^8.1.0
+        version: 8.1.0(echarts@6.1.0)(vue@3.5.22(typescript@6.0.3))
     devDependencies:
       '@biomejs/biome':
         specifier: 2.5.6
@@ -773,8 +773,8 @@ packages:
     peerDependencies:
       echarts: ^5.1.2 || ^6.0.0
 
-  echarts@5.6.0:
-    resolution: {integrity: sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==}
+  echarts@6.1.0:
+    resolution: {integrity: sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==}
 
   editorconfig@1.0.7:
     resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
@@ -1567,17 +1567,6 @@ packages:
   vue-component-type-helpers@3.3.8:
     resolution: {integrity: sha512-troqCMmQodQDqUqn63NQaFi+CDSclSe7sc8VEBFqf5GFLqmGR2Ph3P2WEC7qwpRVyEWsTi/aAr4vyOe/B1hU3g==}
 
-  vue-demi@0.13.11:
-    resolution: {integrity: sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==}
-    engines: {node: '>=12'}
-    hasBin: true
-    peerDependencies:
-      '@vue/composition-api': ^1.0.0-rc.1
-      vue: ^3.0.0-0 || ^2.6.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
     engines: {node: '>=12'}
@@ -1589,15 +1578,11 @@ packages:
       '@vue/composition-api':
         optional: true
 
-  vue-echarts@7.0.3:
-    resolution: {integrity: sha512-/jSxNwOsw5+dYAUcwSfkLwKPuzTQ0Cepz1LxCOpj2QcHrrmUa/Ql0eQqMmc1rTPQVrh2JQ29n2dhq75ZcHvRDw==}
+  vue-echarts@8.1.0:
+    resolution: {integrity: sha512-/uJVwijy3M2vIZ0NcPDgdZVqgboc6zZtC/vERfESau0eFpkHOIujj0sIiMiLP4kztQrckMFnDYWrid+gLI+IOg==}
     peerDependencies:
-      '@vue/runtime-core': ^3.0.0
-      echarts: ^5.5.1
-      vue: ^2.7.0 || ^3.1.1
-    peerDependenciesMeta:
-      '@vue/runtime-core':
-        optional: true
+      echarts: ^6.0.0
+      vue: ^3.3.0
 
   vue-tsc@3.1.1:
     resolution: {integrity: sha512-fyixKxFniOVgn+L/4+g8zCG6dflLLt01Agz9jl3TO45Bgk87NZJRmJVPsiK+ouq3LB91jJCbOV+pDkzYTxbI7A==}
@@ -1649,6 +1634,9 @@ packages:
 
   zrender@5.6.1:
     resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
+
+  zrender@6.1.0:
+    resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
 
 snapshots:
 
@@ -2306,16 +2294,16 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  echarts-gl@2.1.0(echarts@5.6.0):
+  echarts-gl@2.1.0(echarts@6.1.0):
     dependencies:
       claygl: 1.3.0
-      echarts: 5.6.0
+      echarts: 6.1.0
       zrender: 5.6.1
 
-  echarts@5.6.0:
+  echarts@6.1.0:
     dependencies:
       tslib: 2.3.0
-      zrender: 5.6.1
+      zrender: 6.1.0
 
   editorconfig@1.0.7:
     dependencies:
@@ -3038,23 +3026,14 @@ snapshots:
 
   vue-component-type-helpers@3.3.8: {}
 
-  vue-demi@0.13.11(vue@3.5.22(typescript@6.0.3)):
-    dependencies:
-      vue: 3.5.22(typescript@6.0.3)
-
   vue-demi@0.14.10(vue@3.5.22(typescript@6.0.3)):
     dependencies:
       vue: 3.5.22(typescript@6.0.3)
 
-  vue-echarts@7.0.3(@vue/runtime-core@3.5.22)(echarts@5.6.0)(vue@3.5.22(typescript@6.0.3)):
+  vue-echarts@8.1.0(echarts@6.1.0)(vue@3.5.22(typescript@6.0.3)):
     dependencies:
-      echarts: 5.6.0
+      echarts: 6.1.0
       vue: 3.5.22(typescript@6.0.3)
-      vue-demi: 0.13.11(vue@3.5.22(typescript@6.0.3))
-    optionalDependencies:
-      '@vue/runtime-core': 3.5.22
-    transitivePeerDependencies:
-      - '@vue/composition-api'
 
   vue-tsc@3.1.1(typescript@6.0.3):
     dependencies:
@@ -3098,5 +3077,9 @@ snapshots:
   ws@8.21.1: {}
 
   zrender@5.6.1:
+    dependencies:
+      tslib: 2.3.0
+
+  zrender@6.1.0:
     dependencies:
       tslib: 2.3.0

--- a/ui/src/components/Chart3D.vue
+++ b/ui/src/components/Chart3D.vue
@@ -13,6 +13,10 @@ import {
 import { Bar3DChart, Line3DChart, Scatter3DChart } from 'echarts-gl/charts'
 import { Grid3DComponent } from 'echarts-gl/components'
 import VChart from 'vue-echarts'
+import {
+  createLegendSelectChangedForwarder,
+  type LegendSelectChangedEvent,
+} from './charts/legendEvents'
 
 // This component owns every echarts-gl import. Because it is only ever reached
 // through a dynamic import() (see ChartCard.vue), the gl engine lands in its own
@@ -37,20 +41,22 @@ defineProps<{
   initOptions: Record<string, unknown>
 }>()
 
-defineEmits<{
-  legendselectchanged: [e: { selected: Record<string, boolean> }]
+const emit = defineEmits<{
+  legendselectchanged: [e: LegendSelectChangedEvent]
 }>()
+
+const onLegendSelectChanged = createLegendSelectChangedForwarder((event) =>
+  emit('legendselectchanged', event)
+)
 </script>
 
 <template>
   <!--
-    `:update-options="{ notMerge: false }"` is the toggle that fixes the
-    autoRotate lag. vue-echarts defaults to
-    `setOption(option, { notMerge: option !== oldOption, ... })`, so every
-    time our options computed produces a new reference (theme, sort, scale,
-    autoRotate, anything), ECharts receives `notMerge: true` and the
-    3D scene is torn down + rebuilt (re-uploads bar/line geometry, re-binds
-    lights, restarts the view-control animation state). That's the lag.
+    `:update-options="{ notMerge: false }"` fixes the autoRotate lag and makes
+    the 3D update contract explicit. vue-echarts 8 normally plans option
+    updates automatically, but a replacement update tears down + rebuilds the
+    3D scene (re-uploads bar/line geometry, re-binds lights, and restarts the
+    view-control animation state).
 
     Overriding to `notMerge: false` makes ECharts MERGE the new option into
     the existing one. Incremental changes — a single field like
@@ -68,6 +74,6 @@ defineEmits<{
     :init-options="initOptions"
     :update-options="{ notMerge: false, replaceMerge: ['series', 'visualMap'] }"
     :autoresize="true"
-    @legendselectchanged="$emit('legendselectchanged', $event)"
+    @legendselectchanged="onLegendSelectChanged"
   />
 </template>

--- a/ui/src/components/ChartBar.vue
+++ b/ui/src/components/ChartBar.vue
@@ -5,6 +5,10 @@ import { GridComponent } from 'echarts/components'
 import { BarChart } from 'echarts/charts'
 import VChart from 'vue-echarts'
 import { BASE_2D } from './charts/base'
+import {
+  createLegendSelectChangedForwarder,
+  type LegendSelectChangedEvent,
+} from './charts/legendEvents'
 
 // Reached only through a dynamic import() (see ChartCard.vue), so the BarChart
 // module lands in its own chunk and is parsed only when a bar chart renders.
@@ -15,9 +19,13 @@ defineProps<{
   initOptions: Record<string, unknown>
 }>()
 
-defineEmits<{
-  legendselectchanged: [e: { selected: Record<string, boolean> }]
+const emit = defineEmits<{
+  legendselectchanged: [e: LegendSelectChangedEvent]
 }>()
+
+const onLegendSelectChanged = createLegendSelectChangedForwarder((event) =>
+  emit('legendselectchanged', event)
+)
 </script>
 
 <template>
@@ -25,6 +33,6 @@ defineEmits<{
     :option="option"
     :init-options="initOptions"
     :autoresize="true"
-    @legendselectchanged="$emit('legendselectchanged', $event)"
+    @legendselectchanged="onLegendSelectChanged"
   />
 </template>

--- a/ui/src/components/ChartHeatmap.vue
+++ b/ui/src/components/ChartHeatmap.vue
@@ -5,6 +5,10 @@ import { GridComponent, VisualMapComponent } from 'echarts/components'
 import { HeatmapChart, ScatterChart } from 'echarts/charts'
 import VChart from 'vue-echarts'
 import { BASE_2D } from './charts/base'
+import {
+  createLegendSelectChangedForwarder,
+  type LegendSelectChangedEvent,
+} from './charts/legendEvents'
 
 use([...BASE_2D, GridComponent, VisualMapComponent, HeatmapChart, ScatterChart])
 
@@ -13,9 +17,13 @@ defineProps<{
   initOptions: Record<string, unknown>
 }>()
 
-defineEmits<{
-  legendselectchanged: [e: { selected: Record<string, boolean> }]
+const emit = defineEmits<{
+  legendselectchanged: [e: LegendSelectChangedEvent]
 }>()
+
+const onLegendSelectChanged = createLegendSelectChangedForwarder((event) =>
+  emit('legendselectchanged', event)
+)
 </script>
 
 <template>
@@ -23,6 +31,6 @@ defineEmits<{
     :option="option"
     :init-options="initOptions"
     :autoresize="true"
-    @legendselectchanged="$emit('legendselectchanged', $event)"
+    @legendselectchanged="onLegendSelectChanged"
   />
 </template>

--- a/ui/src/components/ChartLine.vue
+++ b/ui/src/components/ChartLine.vue
@@ -5,6 +5,10 @@ import { GridComponent } from 'echarts/components'
 import { LineChart } from 'echarts/charts'
 import VChart from 'vue-echarts'
 import { BASE_2D } from './charts/base'
+import {
+  createLegendSelectChangedForwarder,
+  type LegendSelectChangedEvent,
+} from './charts/legendEvents'
 
 // Reached only through a dynamic import() (see ChartCard.vue), so the LineChart
 // module lands in its own chunk and is parsed only when a line chart renders.
@@ -15,9 +19,13 @@ defineProps<{
   initOptions: Record<string, unknown>
 }>()
 
-defineEmits<{
-  legendselectchanged: [e: { selected: Record<string, boolean> }]
+const emit = defineEmits<{
+  legendselectchanged: [e: LegendSelectChangedEvent]
 }>()
+
+const onLegendSelectChanged = createLegendSelectChangedForwarder((event) =>
+  emit('legendselectchanged', event)
+)
 </script>
 
 <template>
@@ -25,6 +33,6 @@ defineEmits<{
     :option="option"
     :init-options="initOptions"
     :autoresize="true"
-    @legendselectchanged="$emit('legendselectchanged', $event)"
+    @legendselectchanged="onLegendSelectChanged"
   />
 </template>

--- a/ui/src/components/ChartPie.vue
+++ b/ui/src/components/ChartPie.vue
@@ -4,6 +4,10 @@ import { use } from 'echarts/core'
 import { PieChart } from 'echarts/charts'
 import VChart from 'vue-echarts'
 import { BASE_2D } from './charts/base'
+import {
+  createLegendSelectChangedForwarder,
+  type LegendSelectChangedEvent,
+} from './charts/legendEvents'
 
 // Reached only through a dynamic import() (see ChartCard.vue). Pie needs no grid
 // or cartesian coord system, so this chunk stays the lightest of the three.
@@ -14,9 +18,13 @@ defineProps<{
   initOptions: Record<string, unknown>
 }>()
 
-defineEmits<{
-  legendselectchanged: [e: { selected: Record<string, boolean> }]
+const emit = defineEmits<{
+  legendselectchanged: [e: LegendSelectChangedEvent]
 }>()
+
+const onLegendSelectChanged = createLegendSelectChangedForwarder((event) =>
+  emit('legendselectchanged', event)
+)
 </script>
 
 <template>
@@ -24,6 +32,6 @@ defineEmits<{
     :option="option"
     :init-options="initOptions"
     :autoresize="true"
-    @legendselectchanged="$emit('legendselectchanged', $event)"
+    @legendselectchanged="onLegendSelectChanged"
   />
 </template>

--- a/ui/src/components/ChartRadar.vue
+++ b/ui/src/components/ChartRadar.vue
@@ -5,6 +5,10 @@ import { RadarChart } from 'echarts/charts'
 import { RadarComponent } from 'echarts/components'
 import VChart from 'vue-echarts'
 import { BASE_2D } from './charts/base'
+import {
+  createLegendSelectChangedForwarder,
+  type LegendSelectChangedEvent,
+} from './charts/legendEvents'
 
 use([...BASE_2D, RadarComponent, RadarChart])
 
@@ -13,9 +17,13 @@ defineProps<{
   initOptions: Record<string, unknown>
 }>()
 
-defineEmits<{
-  legendselectchanged: [e: { selected: Record<string, boolean> }]
+const emit = defineEmits<{
+  legendselectchanged: [e: LegendSelectChangedEvent]
 }>()
+
+const onLegendSelectChanged = createLegendSelectChangedForwarder((event) =>
+  emit('legendselectchanged', event)
+)
 </script>
 
 <template>
@@ -23,6 +31,6 @@ defineEmits<{
     :option="option"
     :init-options="initOptions"
     :autoresize="true"
-    @legendselectchanged="$emit('legendselectchanged', $event)"
+    @legendselectchanged="onLegendSelectChanged"
   />
 </template>

--- a/ui/src/components/ChartSankey.vue
+++ b/ui/src/components/ChartSankey.vue
@@ -4,6 +4,10 @@ import { use } from 'echarts/core'
 import { SankeyChart } from 'echarts/charts'
 import VChart from 'vue-echarts'
 import { BASE_2D } from './charts/base'
+import {
+  createLegendSelectChangedForwarder,
+  type LegendSelectChangedEvent,
+} from './charts/legendEvents'
 
 // Reached only through a dynamic import() (see ChartCard.vue). Sankey is a
 // graph layout (no cartesian grid); chunk stays light like pie/radar.
@@ -14,9 +18,13 @@ defineProps<{
   initOptions: Record<string, unknown>
 }>()
 
-defineEmits<{
-  legendselectchanged: [e: { selected: Record<string, boolean> }]
+const emit = defineEmits<{
+  legendselectchanged: [e: LegendSelectChangedEvent]
 }>()
+
+const onLegendSelectChanged = createLegendSelectChangedForwarder((event) =>
+  emit('legendselectchanged', event)
+)
 </script>
 
 <template>
@@ -24,6 +32,6 @@ defineEmits<{
     :option="option"
     :init-options="initOptions"
     :autoresize="true"
-    @legendselectchanged="$emit('legendselectchanged', $event)"
+    @legendselectchanged="onLegendSelectChanged"
   />
 </template>

--- a/ui/src/components/ChartScatter.vue
+++ b/ui/src/components/ChartScatter.vue
@@ -5,6 +5,10 @@ import { GridComponent, VisualMapComponent } from 'echarts/components'
 import { ScatterChart } from 'echarts/charts'
 import VChart from 'vue-echarts'
 import { BASE_2D } from './charts/base'
+import {
+  createLegendSelectChangedForwarder,
+  type LegendSelectChangedEvent,
+} from './charts/legendEvents'
 
 // Reached only through a dynamic import() (see ChartCard.vue), so the ScatterChart
 // module lands in its own chunk and is parsed only when a scatter chart renders.
@@ -15,9 +19,13 @@ defineProps<{
   initOptions: Record<string, unknown>
 }>()
 
-defineEmits<{
-  legendselectchanged: [e: { selected: Record<string, boolean> }]
+const emit = defineEmits<{
+  legendselectchanged: [e: LegendSelectChangedEvent]
 }>()
+
+const onLegendSelectChanged = createLegendSelectChangedForwarder((event) =>
+  emit('legendselectchanged', event)
+)
 </script>
 
 <template>
@@ -26,6 +34,6 @@ defineEmits<{
     :init-options="initOptions"
     :autoresize="true"
     :update-options="{ notMerge: false, replaceMerge: ['series', 'visualMap'] }"
-    @legendselectchanged="$emit('legendselectchanged', $event)"
+    @legendselectchanged="onLegendSelectChanged"
   />
 </template>

--- a/ui/src/components/charts.integration.test.ts
+++ b/ui/src/components/charts.integration.test.ts
@@ -41,6 +41,7 @@ vi.mock('vue-echarts', () => ({
           'data-testid': 'vchart',
           'data-not-merge': props.updateOptions?.notMerge === false ? '0' : '1',
           onClick: () => emit('legendselectchanged', { selected: { A: true } }),
+          onDblclick: () => emit('legendselectchanged', { selected: { A: 'yes' } }),
         })
     },
   }),
@@ -81,6 +82,8 @@ describe('chart shells', () => {
     expect(w.find('[data-testid="vchart"]').exists()).toBe(true)
     await w.get('[data-testid="vchart"]').trigger('click')
     expect(onLegendselectchanged).toHaveBeenCalledWith({ selected: { A: true } })
+    await w.get('[data-testid="vchart"]').trigger('dblclick')
+    expect(onLegendselectchanged).toHaveBeenCalledTimes(1)
     expect(useMock).toHaveBeenCalled()
     expect(name).toBeTruthy()
   })

--- a/ui/src/components/charts/legendEvents.ts
+++ b/ui/src/components/charts/legendEvents.ts
@@ -1,0 +1,22 @@
+export interface LegendSelectChangedEvent {
+  selected: Record<string, boolean>
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isBooleanRecord = (value: unknown): value is Record<string, boolean> =>
+  isRecord(value) && Object.values(value).every((entry) => typeof entry === 'boolean')
+
+export const isLegendSelectChangedEvent = (event: unknown): event is LegendSelectChangedEvent =>
+  isRecord(event) && isBooleanRecord(event.selected)
+
+export const createLegendSelectChangedForwarder = (
+  forward: (event: LegendSelectChangedEvent) => void
+) => {
+  return (event: unknown) => {
+    if (isLegendSelectChangedEvent(event)) {
+      forward(event)
+    }
+  }
+}

--- a/ui/src/composables/charts/baseChartOptions.test.ts
+++ b/ui/src/composables/charts/baseChartOptions.test.ts
@@ -50,6 +50,7 @@ describe('BaseChartConfig (relaxed scale/threeDRotate)', () => {
     expect(opts.tooltip).toBeDefined()
     expect(opts.toolbox).toBeDefined()
     expect(opts.legend).toBeDefined()
+    expect(opts.legend).toMatchObject({ left: 'center', top: 0 })
     expect(opts.emphasis).toEqual({ focus: 'series' })
   })
 

--- a/ui/src/composables/charts/baseChartOptions.ts
+++ b/ui/src/composables/charts/baseChartOptions.ts
@@ -59,6 +59,9 @@ export const getBaseOptions = (config: BaseChartConfig): Partial<EChartsOption> 
     legend: {
       show: true,
       left: 'center',
+      // ECharts 6 moved the default legend to the bottom. Keep Vizb's existing
+      // top legend band explicit instead of inheriting the library theme.
+      top: 0,
       itemWidth: 10,
       itemHeight: 10,
       textStyle: { fontSize, color: textColor },

--- a/ui/src/composables/charts/shared/chartConfig.test.ts
+++ b/ui/src/composables/charts/shared/chartConfig.test.ts
@@ -9,6 +9,8 @@ import {
   createValueModeGridConfig,
   VALUE_MODE_GRID_TOP,
   createHeatmapLayoutConfig,
+  createHorizontalAxisConfig,
+  createLegendConfig,
   DATAZOOM_INITIAL_END_PERCENT,
   getChartStyling,
   heatmapDataZoomXBottom,
@@ -30,6 +32,12 @@ const indicators = ['A', 'B', 'C']
 const styling = getChartStyling(true)
 
 describe('createAxisConfig (y-axis range)', () => {
+  it('keeps ECharts 5 axis-name positioning explicit', () => {
+    const { xAxis, yAxis } = createAxisConfig(styling, ['a', 'b'], 'linear', 'x')
+    expect(xAxis.nameMoveOverlap).toBe(false)
+    expect(yAxis.nameMoveOverlap).toBe(false)
+  })
+
   it('includes zero on linear scale by default (bar-style baseline)', () => {
     const { yAxis } = createAxisConfig(styling, ['a', 'b'], 'linear')
     expect(yAxis.scale).toBeUndefined()
@@ -50,6 +58,12 @@ describe('createAxisConfig (y-axis range)', () => {
 })
 
 describe('createValueAxisConfig (y-axis range)', () => {
+  it('keeps ECharts 5 axis-name positioning explicit', () => {
+    const { xAxis, yAxis } = createValueAxisConfig(styling, 'x', 'y')
+    expect(xAxis.nameMoveOverlap).toBe(false)
+    expect(yAxis.nameMoveOverlap).toBe(false)
+  })
+
   it('fits y-axis to data for value-mode line/scatter', () => {
     const { yAxis } = createValueAxisConfig(styling, 'x', 'y', 'linear', true)
     expect(yAxis.scale).toBe(true)
@@ -93,6 +107,11 @@ describe('createDataZoomConfig', () => {
 })
 
 describe('createGridConfig', () => {
+  it('disables the ECharts 6 automatic outer-bounds adjustment', () => {
+    expect(createGridConfig(1, true).outerBoundsMode).toBe('none')
+    expect(createGridConfig(1, false).outerBoundsMode).toBe('none')
+  })
+
   it('reserves fixed px bottom only when dataZoom is present', () => {
     expect(createGridConfig(1, true).bottom).toBe(100)
     expect(createGridConfig(1, true).containLabel).toBe(false)
@@ -109,6 +128,11 @@ describe('createGridConfig', () => {
 })
 
 describe('createHeatmapLayoutConfig', () => {
+  it('disables the ECharts 6 automatic outer-bounds adjustment', () => {
+    expect(createHeatmapLayoutConfig().grid.outerBoundsMode).toBe('none')
+    expect(createHeatmapLayoutConfig({ hasXDataZoom: true }).grid.outerBoundsMode).toBe('none')
+  })
+
   it('reserves visualMap + tick band only when dataZoom is absent', () => {
     const layout = createHeatmapLayoutConfig({ compact: true })
     expect(layout.visualMapBottom).toBe(HEATMAP_VISUAL_MAP_BOTTOM)
@@ -418,10 +442,30 @@ describe('createTooltipConfig item + empty branches', () => {
   })
 })
 
-describe('createLegendConfig single series', () => {
+describe('createLegendConfig', () => {
   it('hides legend when only one series', async () => {
-    const { createLegendConfig } = await import('./chartConfig')
     expect(createLegendConfig([{ xAxis: 'a' }], styling, false)).toEqual({ show: false })
+  })
+
+  it('pins the default legend to the ECharts 5 top position', () => {
+    expect(createLegendConfig([{ xAxis: 'a' }], styling, true)).toMatchObject({
+      left: 'center',
+      top: 0,
+    })
+  })
+
+  it('does not combine a custom bottom position with the default top position', () => {
+    const legend = createLegendConfig([{ xAxis: 'a' }], styling, true, { bottom: 0 })
+    expect(legend.bottom).toBe(0)
+    expect(legend.top).toBeUndefined()
+  })
+})
+
+describe('createHorizontalAxisConfig', () => {
+  it('keeps ECharts 5 axis-name positioning explicit', () => {
+    const { xAxis, yAxis } = createHorizontalAxisConfig(styling, ['a'], 'linear', 'category')
+    expect(xAxis.nameMoveOverlap).toBe(false)
+    expect(yAxis.nameMoveOverlap).toBe(false)
   })
 })
 

--- a/ui/src/composables/charts/shared/chartConfig.ts
+++ b/ui/src/composables/charts/shared/chartConfig.ts
@@ -1,4 +1,4 @@
-import type { EChartsOption } from 'echarts/types/dist/shared'
+import type { EChartsOption } from 'echarts'
 import type { ScaleType } from '@/types'
 import { fontSize } from './common'
 import { describe } from '@/lib/stats'
@@ -63,6 +63,9 @@ export function createHeatmapLayoutConfig(options: HeatmapLayoutOptions = {}) {
       bottom: gridBottom,
       top: options.top ?? (hasLegend ? `${legendSpace}%` : 8),
       containLabel: !hasXDataZoom,
+      // ECharts 6 otherwise shrinks fixed grids to keep axes inside the
+      // canvas. Vizb already reserves each axis/chrome band explicitly.
+      outerBoundsMode: 'none' as const,
     },
   }
 }
@@ -238,6 +241,9 @@ export function createValueAxisConfig(
 
   const yAxisConfig: any = {
     type: yScale === 'log' ? 'log' : 'value',
+    // ECharts 6 moves axis names to avoid label overlap by default. Vizb's
+    // nameGap values already reserve their position using the v5 behavior.
+    nameMoveOverlap: false,
     ...(yAxisName
       ? { name: yAxisName, nameLocation: 'middle', nameGap: 45, nameTextStyle: nameStyle }
       : {}),
@@ -255,6 +261,7 @@ export function createValueAxisConfig(
   return {
     xAxis: {
       type: 'value',
+      nameMoveOverlap: false,
       ...(xAxisName
         ? { name: xAxisName, nameLocation: 'middle', nameGap: 30, nameTextStyle: nameStyle }
         : {}),
@@ -333,6 +340,7 @@ export function createAxisConfig(
 ): { xAxis: any; yAxis: any } {
   const yAxisConfig: any = {
     type: scale === 'log' ? 'log' : 'value',
+    nameMoveOverlap: false,
     splitLine: {
       lineStyle: {
         opacity: styling.opacity,
@@ -356,6 +364,7 @@ export function createAxisConfig(
   return {
     xAxis: {
       type: 'category',
+      nameMoveOverlap: false,
       data: xAxisData,
       // Axis title (group name) under the category axis — not the series ticks.
       ...(xAxisName
@@ -409,6 +418,7 @@ export function createHorizontalAxisConfig(
 
   const xAxisConfig: any = {
     type: scale === 'log' ? 'log' : 'value',
+    nameMoveOverlap: false,
     splitLine: {
       lineStyle: { opacity: styling.opacity },
     },
@@ -426,6 +436,7 @@ export function createHorizontalAxisConfig(
     xAxis: xAxisConfig,
     yAxis: {
       type: 'category',
+      nameMoveOverlap: false,
       inverse: true,
       data: yAxisData,
       ...(categoryAxisName
@@ -752,9 +763,17 @@ export function createLegendConfig(
     return { show: false }
   }
 
+  const hasCustomVerticalPosition =
+    customConfig &&
+    (Object.prototype.hasOwnProperty.call(customConfig, 'top') ||
+      Object.prototype.hasOwnProperty.call(customConfig, 'bottom'))
+
   return {
     show: true,
     left: 'center',
+    // Match the ECharts 5 theme unless a chart intentionally supplies its own
+    // top or bottom placement (for example horizontal bars).
+    ...(!hasCustomVerticalPosition ? { top: 0 } : {}),
     itemWidth: 10,
     itemHeight: 10,
     textStyle: { fontSize, color: styling.textColor },
@@ -806,6 +825,7 @@ export function createGridConfig(seriesLength = 1, hasDataZoom = false): any {
       bottom: 100,
       top: `${legendSpace}%`,
       containLabel: false,
+      outerBoundsMode: 'none',
     }
   }
 
@@ -817,6 +837,7 @@ export function createGridConfig(seriesLength = 1, hasDataZoom = false): any {
     bottom: SERIES_TICK_BAND,
     top: `${legendSpace}%`,
     containLabel: true,
+    outerBoundsMode: 'none',
   }
 }
 

--- a/ui/src/composables/charts/useHeatmapChartOptions.test.ts
+++ b/ui/src/composables/charts/useHeatmapChartOptions.test.ts
@@ -185,7 +185,7 @@ describe('useHeatmapChartOptions — grouped 3D', () => {
     expect(series[0]!.type).toBe('heatmap')
     expect(series.slice(1).map((s) => s.name)).toEqual(['zA', 'zB'])
     expect(series.slice(1).every((s) => s.type === 'scatter')).toBe(true)
-    expect((options.value.legend as { show?: boolean }).show).toBe(true)
+    expect(options.value.legend).toMatchObject({ show: true, left: 'center', top: 0 })
   })
 
   it('hides legend when only one z value', () => {

--- a/ui/src/composables/charts/useHeatmapChartOptions.ts
+++ b/ui/src/composables/charts/useHeatmapChartOptions.ts
@@ -323,6 +323,9 @@ function build3DHeatmap(config: BaseChartConfig): EChartsOption {
     legend: {
       show: zValues.length > 1,
       left: 'center',
+      // The heatmap grid reserves its legend band above the plot. ECharts 6
+      // changed the implicit legend position to bottom, so pin the old layout.
+      top: 0,
       itemWidth: 10,
       itemHeight: 10,
       textStyle: { color: styling.textColor },

--- a/ui/src/composables/charts/usePieChartOptions.ts
+++ b/ui/src/composables/charts/usePieChartOptions.ts
@@ -1,6 +1,6 @@
 import { computed } from 'vue'
 import type { EChartsOption } from 'echarts'
-import type { TitleOption } from 'echarts/types/dist/shared'
+import type { TitleComponentOption } from 'echarts/components'
 import { type BaseChartConfig, getBaseOptions } from './baseChartOptions'
 import { getNextColorFor, hasXAxis, hasYAxis, hasZAxis } from '@/lib/utils'
 import {
@@ -37,7 +37,7 @@ const makePieTitle = (
   text: string,
   left: string,
   styling: ReturnType<typeof getChartStyling>
-): TitleOption => ({
+): TitleComponentOption => ({
   text,
   left,
   top: '5%',


### PR DESCRIPTION
## Summary

- upgrade Vue to 3.5.41, ECharts to 6.1, and Vue-ECharts to 8.1
- preserve existing legend, axis, and grid behavior while safely forwarding legend selection events
- report total raw and encoded payload size for the embedded UI, including the HTML template

## Verification

- `task test:ui`
- `task lint:ui`
- `task format:check:ui`
- `task build:ui`
- `task build:cli --force`
- Chromium 3D rendering, update, and export smokes