### PR TITLE
fix(ui): sync stack setting to URL

### DIFF
--- a/ui/src/composables/useUrlRouter.test.ts
+++ b/ui/src/composables/useUrlRouter.test.ts
@@ -357,6 +357,17 @@ describe('useUrlRouter', () => {
     expect(scatter.stack).toBeUndefined()
   })
 
+  it('uses a linear scale when enabling line stacking', async () => {
+    holder.datasets = ref([ds([{ type: 'line', stack: false, scale: 'log' }])])
+    mockWindow('?line.st=true')
+    const { useUrlRouter } = await import('./useUrlRouter')
+    await useUrlRouter().initFromUrl()
+
+    const line = holder.datasets.value[0]!.settings[0] as LineConfig
+    expect(line.stack).toBe(true)
+    expect(line.scale).toBe('linear')
+  })
+
   it('syncs enabled and disabled bar and line stacks to the URL', async () => {
     holder.datasets = ref([
       ds([

--- a/ui/src/composables/useUrlRouter.test.ts
+++ b/ui/src/composables/useUrlRouter.test.ts
@@ -335,6 +335,42 @@ describe('useUrlRouter', () => {
     expect(replaceState).toHaveBeenCalledWith(null, '', '/?bar.h=true')
   })
 
+  it('applies stack parameters to bar and line configs', async () => {
+    holder.datasets = ref([
+      ds([
+        { type: 'bar', stack: false, scale: 'log' },
+        { type: 'line', stack: true, scale: 'log' },
+        { type: 'scatter', scale: 'linear' },
+      ]),
+    ])
+    mockWindow('?bar.st=true&line.st=false&scatter.st=true')
+    const { useUrlRouter } = await import('./useUrlRouter')
+    await useUrlRouter().initFromUrl()
+
+    const bar = holder.datasets.value[0]!.settings[0] as BarConfig
+    const line = holder.datasets.value[0]!.settings[1] as LineConfig
+    const scatter = holder.datasets.value[0]!.settings[2] as { stack?: boolean }
+    expect(bar.stack).toBe(true)
+    expect(bar.scale).toBe('linear')
+    expect(line.stack).toBe(false)
+    expect(line.scale).toBe('log')
+    expect(scatter.stack).toBeUndefined()
+  })
+
+  it('syncs enabled and disabled bar and line stacks to the URL', async () => {
+    holder.datasets = ref([
+      ds([
+        { type: 'bar', stack: true },
+        { type: 'line', stack: false },
+      ]),
+    ])
+    const replaceState = mockWindow('')
+    const { useUrlRouter } = await import('./useUrlRouter')
+    useUrlRouter().syncUrlToState()
+
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/?bar.st=true&line.st=false')
+  })
+
   it('applies legacy global s/l/sc and per-chart sort/labels/scale/vm params', async () => {
     mockWindow(
       '?s=desc&l=true&sc=log&bar.so=asc&bar.l=false&line.l=true&line.sc=log&scatter.vm=true&scatter.so=desc'

--- a/ui/src/composables/useUrlRouter.ts
+++ b/ui/src/composables/useUrlRouter.ts
@@ -62,6 +62,7 @@ type ConfigUpdate = {
   threeDVisualMap?: boolean
   visualMap?: boolean
   horizontal?: boolean
+  stack?: boolean
 }
 
 // Find the first config of the given chart type and apply a partial update in
@@ -87,6 +88,11 @@ const applyConfigUpdate = (type: ChartType, update: ConfigUpdate): boolean => {
     }
     if (cfg.type === 'bar' && update.horizontal !== undefined) {
       ;(cfg as BarConfig).horizontal = update.horizontal
+    }
+    if ((cfg.type === 'bar' || cfg.type === 'line') && update.stack !== undefined) {
+      const stackable = cfg as BarConfig | LineConfig
+      stackable.stack = update.stack
+      if (update.stack) stackable.scale = 'linear'
     }
   }
   return true
@@ -191,6 +197,7 @@ export function useUrlRouter() {
       const d3vm = params[`${ct}.3d-vm`]
       const vm = params[`${ct}.vm`]
       const sw = params[`${ct}.sw`]
+      const st = params[`${ct}.st`]
 
       const update: ConfigUpdate = {}
       if (so && SORT_ORDERS.includes(so.toLowerCase() as SortOrder)) {
@@ -212,6 +219,10 @@ export function useUrlRouter() {
       const h = params[`${ct}.h`]
       if (h === 'true') update.horizontal = true
       else if (h === 'false') update.horizontal = false
+      if (ct === 'bar' || ct === 'line') {
+        if (st === 'true') update.stack = true
+        else if (st === 'false') update.stack = false
+      }
 
       if (Object.keys(update).length > 0) {
         applyConfigUpdate(ct, update)
@@ -277,6 +288,9 @@ export function useUrlRouter() {
         if (cfg.type === 'bar') {
           const barCfg = cfg as BarConfig
           if (barCfg.horizontal === true) params[`${ct}.h`] = 'true'
+        }
+        if ((cfg.type === 'bar' || cfg.type === 'line') && cfg.stack !== undefined) {
+          params[`${ct}.st`] = cfg.stack ? 'true' : 'false'
         }
       }
 


### PR DESCRIPTION
Closes #370

## Summary
- parse bar.st and line.st URL parameters into chart settings
- serialize both enabled and explicitly disabled stack settings for stable refresh/share behavior
- keep stacked charts on the required linear scale

## Validation
- pnpm test -- useUrlRouter.test.ts (71 files, 1200 tests passed)
- pnpm test:coverage (1200 tests passed, 100% coverage)
- pnpm typecheck
- pnpm format:check
- node --test action/*.test.mjs (17 tests passed)
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added URL support for configuring stacked bar and line charts.
  * Chart stacking settings can now be read from and saved to the URL.
  * Enabling line-chart stacking automatically uses a compatible linear scale.
  * Existing scale settings remain unchanged when stacking is disabled or unsupported chart types are used.

* **Tests**
  * Added coverage for initializing and synchronizing chart stacking settings through URL parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->