### PR TITLE
feat(ui): always show Sankey node names; labels toggle shows link values

### DIFF
--- a/docs/src/content/docs/charts/sankey.mdx
+++ b/docs/src/content/docs/charts/sankey.mdx
@@ -101,7 +101,7 @@ Sankey v1 supports sort, labels, and swap only — no log scale and no 3D contro
 | Setting | CLI flag | UI toggle | Notes |
 |---------|----------|-----------|-------|
 | Sort | `--sort asc\|desc` | Sort control | Orders nodes / flows |
-| Labels | `--show-labels` | Show labels | Shows values on links or nodes |
+| Labels | `--show-labels` | Show labels | Node names are always shown. `--show-labels` adds the same link values as the tooltip. |
 | Swap | `--swap yx` | Axis switcher | Swaps source and target (x ↔ y) |
 
 ```bash

--- a/ui/src/composables/charts/useSankeyChartOptions.test.ts
+++ b/ui/src/composables/charts/useSankeyChartOptions.test.ts
@@ -42,6 +42,10 @@ type SankeySeries = {
   data: { name: string }[]
   links: { source: string; target: string; value: number }[]
   label?: { show?: boolean }
+  edgeLabel?: {
+    show?: boolean
+    formatter?: (params: { data?: { value?: number }; value?: number }) => string
+  }
   emphasis?: { focus?: string }
   lineStyle?: { curveness?: number }
   left?: string
@@ -185,18 +189,24 @@ describe('useSankeyChartOptions', () => {
     expect(series.links).toEqual([])
   })
 
-  it('shows node labels when showLabels is on', () => {
-    const { options } = useSankeyChartOptions(
-      baseConfig({ chartData: withPoints(), showLabels: true })
-    )
-    expect(firstSeries(options.value).label?.show).toBe(true)
-  })
-
-  it('hides node labels when showLabels is off', () => {
+  it('always shows node names and hides link values by default', () => {
     const { options } = useSankeyChartOptions(
       baseConfig({ chartData: withPoints(), showLabels: false })
     )
-    expect(firstSeries(options.value).label?.show).toBe(false)
+    const series = firstSeries(options.value)
+    expect(series.label?.show).toBe(true)
+    expect(series.edgeLabel?.show).toBe(false)
+  })
+
+  it('shows link values when showLabels is on', () => {
+    const { options } = useSankeyChartOptions(
+      baseConfig({ chartData: withPoints(), showLabels: true })
+    )
+    const series = firstSeries(options.value)
+    expect(series.label?.show).toBe(true)
+    expect(series.edgeLabel?.show).toBe(true)
+    expect(series.edgeLabel?.formatter?.({ data: { value: 10 } })).toBe('10')
+    expect(series.edgeLabel?.formatter?.({ value: 5 })).toBe('5')
   })
 
   it('sorts nodes by total flow when sort is enabled (asc)', () => {
@@ -311,7 +321,7 @@ describe('useSankeyChartOptions', () => {
     expect(tooltip.backgroundColor).toBe('#1f2937')
     expect(tooltip.borderColor).toBe('#4b5563')
     const series = firstSeries(options.value)
-    expect(series.label?.show).toBe(false)
+    expect(series.label?.show).toBe(true)
   })
 
   it('edge tooltip shows color circles for both source and target', () => {

--- a/ui/src/composables/charts/useSankeyChartOptions.ts
+++ b/ui/src/composables/charts/useSankeyChartOptions.ts
@@ -4,6 +4,7 @@ import { type BaseChartConfig, getBaseOptions } from './baseChartOptions'
 import { hasXAxis, hasYAxis } from '@/lib/utils'
 import { getChartStyling, getTooltipTheme } from './shared'
 import { fontSize } from './shared/common'
+import { formatTooltipValue } from './shared/chartConfig'
 import { buildEdgeGraph, formatEdgeTooltip, sortEdgeGraphNodes } from './shared/edgeGraph'
 
 /** ECharts defaults right: '20%' for label room; we keep a tighter inset. */
@@ -75,7 +76,14 @@ export function useSankeyChartOptions(config: BaseChartConfig) {
           emphasis: { focus: 'adjacency' },
           lineStyle: { curveness: 0.5, color: 'gradient' },
           label: {
+            show: true,
+            color: styling.textColor,
+            fontSize,
+          },
+          edgeLabel: {
             show: showLabels.value,
+            formatter: (params: { data?: { value?: number }; value?: number }) =>
+              formatTooltipValue(params.data?.value ?? params.value),
             color: styling.textColor,
             fontSize,
           },


### PR DESCRIPTION
## Summary

Sankey charts are unreadable without node names, but `--show-labels` used to hide both names and values.

- Source/target **node names are always shown**.
- `--show-labels` / the UI **Show labels** toggle now only shows **link values** (same `formatTooltipValue` formatting as the tooltip).
- Hover tooltips are unchanged.
- Chord and other chart types are unchanged. No new CLI flag.

## Test plan

- [x] `pnpm exec vitest run src/composables/charts/useSankeyChartOptions.test.ts`
- [x] `task test:ui` (1198 tests)
- [ ] Open a Sankey HTML without `-l` and confirm node names are visible
- [ ] Toggle **Show labels** (or pass `--show-labels`) and confirm values appear on the ribbons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sankey charts now always display node names.
  * Link values can be shown with the `--show-labels` option.
  * Link values use consistent tooltip-style formatting.
  * Node labels now follow the chart theme’s text color and font size, including dark mode.

* **Documentation**
  * Updated Sankey settings documentation to clarify label behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->