### PR TITLE
feat(action): add optional cmd retries

### DIFF
--- a/.github/workflows/github-legends.yml
+++ b/.github/workflows/github-legends.yml
@@ -72,7 +72,6 @@ jobs:
         with:
           cmd: curl -sfL "https://github-contributions-api.jogruber.de/v4/${{ matrix.id }}"
           cmd-retries: 3
-          cmd-retry-strategy: exponential
           id: ${{ matrix.id }}
           name: ${{ matrix.id }}
           description: ${{ matrix.description }}

--- a/.github/workflows/github-legends.yml
+++ b/.github/workflows/github-legends.yml
@@ -71,6 +71,8 @@ jobs:
         uses: ./
         with:
           cmd: curl -sfL "https://github-contributions-api.jogruber.de/v4/${{ matrix.id }}"
+          cmd-retries: 3
+          cmd-retry-strategy: exponential
           id: ${{ matrix.id }}
           name: ${{ matrix.id }}
           description: ${{ matrix.description }}

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,15 @@ inputs:
   bench-file:
     description: "DEPRECATED: use 'file'. Existing input file; honored only when 'file' is empty." # remove on v1
     default: ""
+  cmd-retries:
+    description: "Total attempts for cmd. 1 = no retry (default). Integer >= 1."
+    default: "1"
+  cmd-retry-delay:
+    description: "Seconds to wait between cmd attempts. Linear: every wait. Exponential: initial wait. Number >= 0."
+    default: "2"
+  cmd-retry-strategy:
+    description: "Backoff between cmd attempts: linear or exponential."
+    default: "linear"
   name:
     description: "Dataset/benchmark name (-n flag)"
     default: "Comparisons"
@@ -221,6 +230,9 @@ runs:
         INPUT_file: ${{ inputs.file }}
         INPUT_bench-cmd: ${{ inputs.bench-cmd }}
         INPUT_bench-file: ${{ inputs.bench-file }}
+        INPUT_cmd-retries: ${{ inputs.cmd-retries }}
+        INPUT_cmd-retry-delay: ${{ inputs.cmd-retry-delay }}
+        INPUT_cmd-retry-strategy: ${{ inputs.cmd-retry-strategy }}
         INPUT_name: ${{ inputs.name }}
         INPUT_title: ${{ inputs.title }}
         INPUT_description: ${{ inputs.description }}

--- a/action.yml
+++ b/action.yml
@@ -19,14 +19,8 @@ inputs:
     description: "DEPRECATED: use 'file'. Existing input file; honored only when 'file' is empty." # remove on v1
     default: ""
   cmd-retries:
-    description: "Total attempts for cmd. 1 = no retry (default). Integer >= 1."
+    description: "Total attempts for cmd. 1 = no retry (default). Integer >= 1. Failed attempts wait 2s, then double."
     default: "1"
-  cmd-retry-delay:
-    description: "Seconds to wait between cmd attempts. Linear: every wait. Exponential: initial wait. Number >= 0."
-    default: "2"
-  cmd-retry-strategy:
-    description: "Backoff between cmd attempts: linear or exponential."
-    default: "linear"
   name:
     description: "Dataset/benchmark name (-n flag)"
     default: "Comparisons"
@@ -231,8 +225,6 @@ runs:
         INPUT_bench-cmd: ${{ inputs.bench-cmd }}
         INPUT_bench-file: ${{ inputs.bench-file }}
         INPUT_cmd-retries: ${{ inputs.cmd-retries }}
-        INPUT_cmd-retry-delay: ${{ inputs.cmd-retry-delay }}
-        INPUT_cmd-retry-strategy: ${{ inputs.cmd-retry-strategy }}
         INPUT_name: ${{ inputs.name }}
         INPUT_title: ${{ inputs.title }}
         INPUT_description: ${{ inputs.description }}

--- a/action/lib.mjs
+++ b/action/lib.mjs
@@ -28,6 +28,9 @@ export function resolveInputs(env = process.env) {
   return {
     file,
     cmd,
+    cmdRetries: parseCmdRetries(input('cmd-retries', env)),
+    cmdRetryDelay: parseCmdRetryDelay(input('cmd-retry-delay', env)),
+    cmdRetryStrategy: parseCmdRetryStrategy(input('cmd-retry-strategy', env)),
     hasInput: Boolean(file || cmd),
     jsonFile: outputJson || 'bench.json',
     name: input('name', env),
@@ -59,6 +62,83 @@ export function resolveInputs(env = process.env) {
     outputHtml: input('output-html', env),
     dataUrl,
   }
+}
+
+/** @param {string} value */
+function parseCmdRetries(value) {
+  if (!value) return 1
+  const n = Number(value)
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error('cmd-retries must be an integer >= 1')
+  }
+  return n
+}
+
+/** @param {string} value */
+function parseCmdRetryDelay(value) {
+  if (!value) return 2
+  const n = Number(value)
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error('cmd-retry-delay must be a number >= 0')
+  }
+  return n
+}
+
+/** @param {string} value */
+function parseCmdRetryStrategy(value) {
+  if (!value) return 'linear'
+  if (value !== 'linear' && value !== 'exponential') {
+    throw new Error('cmd-retry-strategy must be "linear" or "exponential"')
+  }
+  return value
+}
+
+/** @param {number} seconds */
+function sleepSync(seconds) {
+  if (!(seconds > 0)) return
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, seconds * 1000)
+}
+
+/**
+ * @param {() => void} fn
+ * @param {{
+ *   retries: number,
+ *   delaySec: number,
+ *   strategy: 'linear' | 'exponential',
+ *   sleep?: (sec: number) => void,
+ *   log?: (msg: string) => void,
+ * }} opts
+ */
+export function runWithRetries(fn, opts) {
+  const sleep = opts.sleep ?? sleepSync
+  const log = opts.log ?? ((msg) => console.error(msg))
+  let lastError
+
+  for (let attempt = 1; attempt <= opts.retries; attempt++) {
+    try {
+      fn()
+      return
+    } catch (err) {
+      lastError = err
+      if (attempt === opts.retries) throw err
+      const waitSec =
+        opts.strategy === 'exponential'
+          ? opts.delaySec * 2 ** (attempt - 1)
+          : opts.delaySec
+      const detail =
+        err && typeof err === 'object' && 'exitCode' in err
+          ? `exit ${/** @type {{ exitCode: unknown }} */ (err).exitCode}`
+          : err instanceof Error
+            ? err.message
+            : String(err)
+      log(
+        `::warning::cmd failed (attempt ${attempt}/${opts.retries}, ${detail}). Retrying in ${waitSec}s (${opts.strategy}).`,
+      )
+      sleep(waitSec)
+    }
+  }
+
+  throw lastError
 }
 
 /** @param {string} value */
@@ -166,7 +246,13 @@ export function runShellCapture(command, stdoutPath) {
 
 /**
  * @param {ReturnType<typeof resolveInputs>} inputs
- * @param {{ run?: typeof run, runShellCapture?: typeof runShellCapture, vizbBin?: string }} [deps]
+ * @param {{
+ *   run?: typeof run,
+ *   runShellCapture?: typeof runShellCapture,
+ *   vizbBin?: string,
+ *   sleep?: (sec: number) => void,
+ *   log?: (msg: string) => void,
+ * }} [deps]
  */
 export function runPipeline(inputs, deps = {}) {
   const execRun = deps.run ?? run
@@ -177,7 +263,13 @@ export function runPipeline(inputs, deps = {}) {
     let inputPath = inputs.file
     if (!inputPath) {
       inputPath = join(tmpdir(), `vizb-data-input-${process.pid}.txt`)
-      execShell(inputs.cmd, inputPath)
+      runWithRetries(() => execShell(inputs.cmd, inputPath), {
+        retries: inputs.cmdRetries,
+        delaySec: inputs.cmdRetryDelay,
+        strategy: inputs.cmdRetryStrategy,
+        sleep: deps.sleep,
+        log: deps.log,
+      })
     }
     execRun(vizb, [inputPath, '-o', inputs.jsonFile, ...buildConvertArgs(inputs)])
   }

--- a/action/lib.mjs
+++ b/action/lib.mjs
@@ -29,8 +29,6 @@ export function resolveInputs(env = process.env) {
     file,
     cmd,
     cmdRetries: parseCmdRetries(input('cmd-retries', env)),
-    cmdRetryDelay: parseCmdRetryDelay(input('cmd-retry-delay', env)),
-    cmdRetryStrategy: parseCmdRetryStrategy(input('cmd-retry-strategy', env)),
     hasInput: Boolean(file || cmd),
     jsonFile: outputJson || 'bench.json',
     name: input('name', env),
@@ -74,24 +72,7 @@ function parseCmdRetries(value) {
   return n
 }
 
-/** @param {string} value */
-function parseCmdRetryDelay(value) {
-  if (!value) return 2
-  const n = Number(value)
-  if (!Number.isFinite(n) || n < 0) {
-    throw new Error('cmd-retry-delay must be a number >= 0')
-  }
-  return n
-}
-
-/** @param {string} value */
-function parseCmdRetryStrategy(value) {
-  if (!value) return 'linear'
-  if (value !== 'linear' && value !== 'exponential') {
-    throw new Error('cmd-retry-strategy must be "linear" or "exponential"')
-  }
-  return value
-}
+const CMD_RETRY_DELAY_SEC = 2
 
 /** @param {number} seconds */
 function sleepSync(seconds) {
@@ -103,8 +84,6 @@ function sleepSync(seconds) {
  * @param {() => void} fn
  * @param {{
  *   retries: number,
- *   delaySec: number,
- *   strategy: 'linear' | 'exponential',
  *   sleep?: (sec: number) => void,
  *   log?: (msg: string) => void,
  * }} opts
@@ -112,33 +91,20 @@ function sleepSync(seconds) {
 export function runWithRetries(fn, opts) {
   const sleep = opts.sleep ?? sleepSync
   const log = opts.log ?? ((msg) => console.error(msg))
-  let lastError
 
   for (let attempt = 1; attempt <= opts.retries; attempt++) {
     try {
       fn()
       return
     } catch (err) {
-      lastError = err
       if (attempt === opts.retries) throw err
-      const waitSec =
-        opts.strategy === 'exponential'
-          ? opts.delaySec * 2 ** (attempt - 1)
-          : opts.delaySec
-      const detail =
-        err && typeof err === 'object' && 'exitCode' in err
-          ? `exit ${/** @type {{ exitCode: unknown }} */ (err).exitCode}`
-          : err instanceof Error
-            ? err.message
-            : String(err)
+      const waitSec = CMD_RETRY_DELAY_SEC * 2 ** (attempt - 1)
       log(
-        `::warning::cmd failed (attempt ${attempt}/${opts.retries}, ${detail}). Retrying in ${waitSec}s (${opts.strategy}).`,
+        `::warning::cmd failed (attempt ${attempt}/${opts.retries}, ${err.message ?? err}). Retrying in ${waitSec}s.`,
       )
       sleep(waitSec)
     }
   }
-
-  throw lastError
 }
 
 /** @param {string} value */
@@ -265,8 +231,6 @@ export function runPipeline(inputs, deps = {}) {
       inputPath = join(tmpdir(), `vizb-data-input-${process.pid}.txt`)
       runWithRetries(() => execShell(inputs.cmd, inputPath), {
         retries: inputs.cmdRetries,
-        delaySec: inputs.cmdRetryDelay,
-        strategy: inputs.cmdRetryStrategy,
         sleep: deps.sleep,
         log: deps.log,
       })

--- a/action/lib.test.mjs
+++ b/action/lib.test.mjs
@@ -173,28 +173,17 @@ describe('resolveInputs', () => {
     assert.equal(r.tagAxis, 'x')
   })
 
-  it('defaults cmd retry to off (1 attempt), 2s, linear', () => {
+  it('defaults cmd retry to off (1 attempt)', () => {
     const r = resolveInputs(envFrom({ file: 'a.txt' }))
     assert.equal(r.cmdRetries, 1)
-    assert.equal(r.cmdRetryDelay, 2)
-    assert.equal(r.cmdRetryStrategy, 'linear')
   })
 
-  it('parses cmd retry inputs', () => {
-    const r = resolveInputs(
-      envFrom({
-        cmd: 'echo hi',
-        'cmd-retries': '3',
-        'cmd-retry-delay': '0.5',
-        'cmd-retry-strategy': 'exponential',
-      }),
-    )
+  it('parses cmd-retries', () => {
+    const r = resolveInputs(envFrom({ cmd: 'echo hi', 'cmd-retries': '3' }))
     assert.equal(r.cmdRetries, 3)
-    assert.equal(r.cmdRetryDelay, 0.5)
-    assert.equal(r.cmdRetryStrategy, 'exponential')
   })
 
-  it('rejects invalid cmd retry inputs', () => {
+  it('rejects invalid cmd-retries', () => {
     assert.throws(
       () => resolveInputs(envFrom({ file: 'a.txt', 'cmd-retries': '0' })),
       /cmd-retries must be an integer >= 1/,
@@ -202,18 +191,6 @@ describe('resolveInputs', () => {
     assert.throws(
       () => resolveInputs(envFrom({ file: 'a.txt', 'cmd-retries': 'abc' })),
       /cmd-retries must be an integer >= 1/,
-    )
-    assert.throws(
-      () => resolveInputs(envFrom({ file: 'a.txt', 'cmd-retry-delay': '-1' })),
-      /cmd-retry-delay must be a number >= 0/,
-    )
-    assert.throws(
-      () => resolveInputs(envFrom({ file: 'a.txt', 'cmd-retry-delay': 'abc' })),
-      /cmd-retry-delay must be a number >= 0/,
-    )
-    assert.throws(
-      () => resolveInputs(envFrom({ file: 'a.txt', 'cmd-retry-strategy': 'expo' })),
-      /cmd-retry-strategy must be "linear" or "exponential"/,
     )
   })
 })
@@ -280,8 +257,6 @@ describe('runWithRetries', () => {
       },
       {
         retries: 3,
-        delaySec: 2,
-        strategy: 'linear',
         sleep: (sec) => sleeps.push(sec),
         log: (msg) => logs.push(msg),
       },
@@ -302,16 +277,16 @@ describe('runWithRetries', () => {
       },
       {
         retries: 3,
-        delaySec: 2,
-        strategy: 'linear',
         sleep: (sec) => sleeps.push(sec),
         log: (msg) => logs.push(msg),
       },
     )
     assert.equal(attempts, 2)
     assert.deepEqual(sleeps, [2])
-    assert.equal(logs.length, 1)
-    assert.match(logs[0], /::warning::cmd failed \(attempt 1\/3, exit 1\)\. Retrying in 2s \(linear\)\./)
+    assert.equal(
+      logs[0],
+      '::warning::cmd failed (attempt 1/3, exited with code 1). Retrying in 2s.',
+    )
   })
 
   it('rethrows the last error after attempts are exhausted', () => {
@@ -326,8 +301,6 @@ describe('runWithRetries', () => {
           },
           {
             retries: 3,
-            delaySec: 2,
-            strategy: 'linear',
             sleep: (sec) => sleeps.push(sec),
             log: () => {},
           },
@@ -335,25 +308,6 @@ describe('runWithRetries', () => {
       (err) => err instanceof Error && err.exitCode === 7,
     )
     assert.equal(attempts, 3)
-    assert.deepEqual(sleeps, [2, 2])
-  })
-
-  it('uses exponential waits', () => {
-    const sleeps = []
-    assert.throws(
-      () =>
-        runWithRetries(
-          () => failWith(1),
-          {
-            retries: 3,
-            delaySec: 2,
-            strategy: 'exponential',
-            sleep: (sec) => sleeps.push(sec),
-            log: () => {},
-          },
-        ),
-      /exited with code 1/,
-    )
     assert.deepEqual(sleeps, [2, 4])
   })
 
@@ -366,8 +320,6 @@ describe('runWithRetries', () => {
           () => failWith(1),
           {
             retries: 1,
-            delaySec: 2,
-            strategy: 'linear',
             sleep: (sec) => sleeps.push(sec),
             log: (msg) => logs.push(msg),
           },
@@ -386,13 +338,14 @@ describe('runWithRetries', () => {
       },
       {
         retries: 2,
-        delaySec: 0,
-        strategy: 'linear',
         sleep: () => {},
         log: (msg) => logs.push(msg),
       },
     )
-    assert.equal(logs[0], '::warning::cmd failed (attempt 1/2, spawn ENOENT). Retrying in 0s (linear).')
+    assert.equal(
+      logs[0],
+      '::warning::cmd failed (attempt 1/2, spawn ENOENT). Retrying in 2s.',
+    )
   })
 })
 
@@ -432,8 +385,6 @@ describe('runPipeline', () => {
       outputHtml: 'index.html',
       dataUrl: '',
       cmdRetries: 1,
-      cmdRetryDelay: 2,
-      cmdRetryStrategy: 'linear',
       ...over,
     }
   }
@@ -486,8 +437,6 @@ describe('runPipeline', () => {
         hasInput: true,
         outputHtml: '',
         cmdRetries: 3,
-        cmdRetryDelay: 2,
-        cmdRetryStrategy: 'linear',
       }),
       {
         vizbBin: 'vizb',
@@ -505,7 +454,7 @@ describe('runPipeline', () => {
       },
     )
     assert.equal(shells, 3)
-    assert.deepEqual(sleeps, [2, 2])
+    assert.deepEqual(sleeps, [2, 4])
   })
 
   it('does not retry when file is set', () => {

--- a/action/lib.test.mjs
+++ b/action/lib.test.mjs
@@ -7,6 +7,7 @@ import {
   resolveInputs,
   resolveVizbBin,
   runPipeline,
+  runWithRetries,
   splitMergeFiles,
 } from './lib.mjs'
 
@@ -171,6 +172,50 @@ describe('resolveInputs', () => {
     assert.equal(r.enable3d, true)
     assert.equal(r.tagAxis, 'x')
   })
+
+  it('defaults cmd retry to off (1 attempt), 2s, linear', () => {
+    const r = resolveInputs(envFrom({ file: 'a.txt' }))
+    assert.equal(r.cmdRetries, 1)
+    assert.equal(r.cmdRetryDelay, 2)
+    assert.equal(r.cmdRetryStrategy, 'linear')
+  })
+
+  it('parses cmd retry inputs', () => {
+    const r = resolveInputs(
+      envFrom({
+        cmd: 'echo hi',
+        'cmd-retries': '3',
+        'cmd-retry-delay': '0.5',
+        'cmd-retry-strategy': 'exponential',
+      }),
+    )
+    assert.equal(r.cmdRetries, 3)
+    assert.equal(r.cmdRetryDelay, 0.5)
+    assert.equal(r.cmdRetryStrategy, 'exponential')
+  })
+
+  it('rejects invalid cmd retry inputs', () => {
+    assert.throws(
+      () => resolveInputs(envFrom({ file: 'a.txt', 'cmd-retries': '0' })),
+      /cmd-retries must be an integer >= 1/,
+    )
+    assert.throws(
+      () => resolveInputs(envFrom({ file: 'a.txt', 'cmd-retries': 'abc' })),
+      /cmd-retries must be an integer >= 1/,
+    )
+    assert.throws(
+      () => resolveInputs(envFrom({ file: 'a.txt', 'cmd-retry-delay': '-1' })),
+      /cmd-retry-delay must be a number >= 0/,
+    )
+    assert.throws(
+      () => resolveInputs(envFrom({ file: 'a.txt', 'cmd-retry-delay': 'abc' })),
+      /cmd-retry-delay must be a number >= 0/,
+    )
+    assert.throws(
+      () => resolveInputs(envFrom({ file: 'a.txt', 'cmd-retry-strategy': 'expo' })),
+      /cmd-retry-strategy must be "linear" or "exponential"/,
+    )
+  })
 })
 
 describe('splitMergeFiles', () => {
@@ -218,6 +263,139 @@ describe('resolveVizbBin', () => {
   })
 })
 
+describe('runWithRetries', () => {
+  function failWith(code, message = `exited with code ${code}`) {
+    const err = new Error(message)
+    err.exitCode = code
+    throw err
+  }
+
+  it('returns on first success without sleeping', () => {
+    const sleeps = []
+    const logs = []
+    let attempts = 0
+    runWithRetries(
+      () => {
+        attempts += 1
+      },
+      {
+        retries: 3,
+        delaySec: 2,
+        strategy: 'linear',
+        sleep: (sec) => sleeps.push(sec),
+        log: (msg) => logs.push(msg),
+      },
+    )
+    assert.equal(attempts, 1)
+    assert.deepEqual(sleeps, [])
+    assert.deepEqual(logs, [])
+  })
+
+  it('retries after failure then succeeds', () => {
+    const sleeps = []
+    const logs = []
+    let attempts = 0
+    runWithRetries(
+      () => {
+        attempts += 1
+        if (attempts < 2) failWith(1)
+      },
+      {
+        retries: 3,
+        delaySec: 2,
+        strategy: 'linear',
+        sleep: (sec) => sleeps.push(sec),
+        log: (msg) => logs.push(msg),
+      },
+    )
+    assert.equal(attempts, 2)
+    assert.deepEqual(sleeps, [2])
+    assert.equal(logs.length, 1)
+    assert.match(logs[0], /::warning::cmd failed \(attempt 1\/3, exit 1\)\. Retrying in 2s \(linear\)\./)
+  })
+
+  it('rethrows the last error after attempts are exhausted', () => {
+    const sleeps = []
+    let attempts = 0
+    assert.throws(
+      () =>
+        runWithRetries(
+          () => {
+            attempts += 1
+            failWith(attempts === 3 ? 7 : 1)
+          },
+          {
+            retries: 3,
+            delaySec: 2,
+            strategy: 'linear',
+            sleep: (sec) => sleeps.push(sec),
+            log: () => {},
+          },
+        ),
+      (err) => err instanceof Error && err.exitCode === 7,
+    )
+    assert.equal(attempts, 3)
+    assert.deepEqual(sleeps, [2, 2])
+  })
+
+  it('uses exponential waits', () => {
+    const sleeps = []
+    assert.throws(
+      () =>
+        runWithRetries(
+          () => failWith(1),
+          {
+            retries: 3,
+            delaySec: 2,
+            strategy: 'exponential',
+            sleep: (sec) => sleeps.push(sec),
+            log: () => {},
+          },
+        ),
+      /exited with code 1/,
+    )
+    assert.deepEqual(sleeps, [2, 4])
+  })
+
+  it('does not sleep when retries is 1', () => {
+    const sleeps = []
+    const logs = []
+    assert.throws(
+      () =>
+        runWithRetries(
+          () => failWith(1),
+          {
+            retries: 1,
+            delaySec: 2,
+            strategy: 'linear',
+            sleep: (sec) => sleeps.push(sec),
+            log: (msg) => logs.push(msg),
+          },
+        ),
+      /exited with code 1/,
+    )
+    assert.deepEqual(sleeps, [])
+    assert.deepEqual(logs, [])
+  })
+
+  it('logs spawn errors by message', () => {
+    const logs = []
+    runWithRetries(
+      () => {
+        if (logs.length === 0) throw new Error('spawn ENOENT')
+      },
+      {
+        retries: 2,
+        delaySec: 0,
+        strategy: 'linear',
+        sleep: () => {},
+        log: (msg) => logs.push(msg),
+      },
+    )
+    assert.equal(logs[0], '::warning::cmd failed (attempt 1/2, spawn ENOENT). Retrying in 0s (linear).')
+  })
+})
+
 describe('runPipeline', () => {
   function baseInputs(over = {}) {
     return {
@@ -253,6 +431,9 @@ describe('runPipeline', () => {
       tagAxis: 'n',
       outputHtml: 'index.html',
       dataUrl: '',
+      cmdRetries: 1,
+      cmdRetryDelay: 2,
+      cmdRetryStrategy: 'linear',
       ...over,
     }
   }
@@ -292,6 +473,51 @@ describe('runPipeline', () => {
     assert.equal(shells[0], 'echo hello')
     assert.ok(shells[1].includes('vizb-data-input-'))
     assert.equal(calls.length, 1)
+  })
+
+  it('retries cmd capture until it succeeds', () => {
+    /** @type {number[]} */
+    const sleeps = []
+    let shells = 0
+    runPipeline(
+      baseInputs({
+        file: '',
+        cmd: 'flaky',
+        hasInput: true,
+        outputHtml: '',
+        cmdRetries: 3,
+        cmdRetryDelay: 2,
+        cmdRetryStrategy: 'linear',
+      }),
+      {
+        vizbBin: 'vizb',
+        run: () => {},
+        runShellCapture: () => {
+          shells += 1
+          if (shells < 3) {
+            const err = new Error('flaky exited with code 1')
+            err.exitCode = 1
+            throw err
+          }
+        },
+        sleep: (sec) => sleeps.push(sec),
+        log: () => {},
+      },
+    )
+    assert.equal(shells, 3)
+    assert.deepEqual(sleeps, [2, 2])
+  })
+
+  it('does not retry when file is set', () => {
+    let shells = 0
+    runPipeline(baseInputs({ cmd: 'should-not-run', cmdRetries: 3 }), {
+      vizbBin: 'vizb',
+      run: () => {},
+      runShellCapture: () => {
+        shells += 1
+      },
+    })
+    assert.equal(shells, 0)
   })
 
   it('merges when merge-dir set and json exists', () => {

--- a/docs/src/content/docs/ci-cd/github-action.mdx
+++ b/docs/src/content/docs/ci-cd/github-action.mdx
@@ -49,9 +49,7 @@ The action:
 | `file` | `""` | Path to an existing input file to visualize — benchmark output, CSV, or JSON (takes priority over `cmd`). |
 | `bench-cmd` | `""` | **Deprecated:** use `cmd`. Honored only when `cmd` is empty. |
 | `bench-file` | `""` | **Deprecated:** use `file`. Honored only when `file` is empty. |
-| `cmd-retries` | `"1"` | Total attempts for `cmd`. `1` = no retry (default). Integer ≥ 1. |
-| `cmd-retry-delay` | `"2"` | Seconds to wait between `cmd` attempts. Linear: every wait. Exponential: initial wait. Number ≥ 0. |
-| `cmd-retry-strategy` | `"linear"` | Backoff between `cmd` attempts: `linear` or `exponential`. |
+| `cmd-retries` | `"1"` | Total attempts for `cmd`. `1` = no retry (default). Integer ≥ 1. Failed attempts wait 2s, then double. |
 | `name` | `"Comparisons"` | Dataset/benchmark name (`-n` flag). |
 | `title` | `""` | Override the chart title when `col-axis` produces one chart; independent of `name` (`--title` flag). |
 | `description` | `""` | Dataset/benchmark description (`-d` flag). |
@@ -102,7 +100,7 @@ The action resolves input in this priority order:
   At least one of `cmd`, `file`, `merge-files`, `merge-dir`, or `data-url` must be provided.
 </Aside>
 
-Retry inputs apply only when `cmd` actually runs (`file` is empty). Default is one attempt. Set `cmd-retries` to 3 (or more) to retry a flaky command; failed attempts log a warning and wait `cmd-retry-delay` seconds (`linear` every time, or `exponential` doubling from that delay). Convert, merge, and `ui` are not retried.
+Retry applies only when `cmd` actually runs (`file` is empty). Default is one attempt. Set `cmd-retries` to 3 (or more) to retry a flaky command; failed attempts log a warning and wait 2s, then 4s, then 8s, and so on. Convert, merge, and `ui` are not retried.
 
 ## Minimal Examples
 
@@ -122,8 +120,6 @@ Retry inputs apply only when `cmd` actually runs (`file` is empty). Default is o
   with:
     cmd: "go test -bench=."
     cmd-retries: 3
-    cmd-retry-delay: 2
-    cmd-retry-strategy: linear
     output-html: pages/index.html
 ```
 

--- a/docs/src/content/docs/ci-cd/github-action.mdx
+++ b/docs/src/content/docs/ci-cd/github-action.mdx
@@ -49,6 +49,9 @@ The action:
 | `file` | `""` | Path to an existing input file to visualize — benchmark output, CSV, or JSON (takes priority over `cmd`). |
 | `bench-cmd` | `""` | **Deprecated:** use `cmd`. Honored only when `cmd` is empty. |
 | `bench-file` | `""` | **Deprecated:** use `file`. Honored only when `file` is empty. |
+| `cmd-retries` | `"1"` | Total attempts for `cmd`. `1` = no retry (default). Integer ≥ 1. |
+| `cmd-retry-delay` | `"2"` | Seconds to wait between `cmd` attempts. Linear: every wait. Exponential: initial wait. Number ≥ 0. |
+| `cmd-retry-strategy` | `"linear"` | Backoff between `cmd` attempts: `linear` or `exponential`. |
 | `name` | `"Comparisons"` | Dataset/benchmark name (`-n` flag). |
 | `title` | `""` | Override the chart title when `col-axis` produces one chart; independent of `name` (`--title` flag). |
 | `description` | `""` | Dataset/benchmark description (`-d` flag). |
@@ -99,6 +102,8 @@ The action resolves input in this priority order:
   At least one of `cmd`, `file`, `merge-files`, `merge-dir`, or `data-url` must be provided.
 </Aside>
 
+Retry inputs apply only when `cmd` actually runs (`file` is empty). Default is one attempt. Set `cmd-retries` to 3 (or more) to retry a flaky command; failed attempts log a warning and wait `cmd-retry-delay` seconds (`linear` every time, or `exponential` doubling from that delay). Convert, merge, and `ui` are not retried.
+
 ## Minimal Examples
 
 ### Run benchmarks and generate HTML
@@ -107,6 +112,18 @@ The action resolves input in this priority order:
 - uses: goptics/vizb@v0
   with:
     cmd: "go test -bench=."
+    output-html: pages/index.html
+```
+
+### Retry a flaky command
+
+```yaml
+- uses: goptics/vizb@v0
+  with:
+    cmd: "go test -bench=."
+    cmd-retries: 3
+    cmd-retry-delay: 2
+    cmd-retry-strategy: linear
     output-html: pages/index.html
 ```
 


### PR DESCRIPTION
Closes #377

## Summary

The composite action ran `cmd` once and failed the step on the first non-zero exit. Retry is now optional and **off by default**.

- `cmd-retries` (default `1`) — total attempts; `1` keeps fail-fast
- `cmd-retry-delay` (default `2`) — seconds between attempts
- `cmd-retry-strategy` (default `linear`) — `linear` or `exponential`

Only the user `cmd` / `bench-cmd` capture is retried. `file`, convert, merge, and `ui` are unchanged. Failed attempts log a `::warning::` before sleeping. Invalid retry inputs fail before `cmd` starts.

CHANGELOG is left to git-cliff.

## Test plan

- [x] `node --test action/*.test.mjs` (28 tests)
- [ ] Action CI: `.github/workflows/action-ci.yml` unit job
- [ ] Optional: invoke the action with a flaky `cmd` and `cmd-retries: 3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable command retries, with a default of one total attempt.
  * Added exponential retry delays starting at two seconds, with progress warnings and final error reporting.
  * Retries apply to executed command operations only; conversion, merging, and UI operations are not retried.
  * Updated the GitHub Legends workflow to use three command attempts.

* **Documentation**
  * Added command-retry input details and a workflow example to the GitHub Action documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->