### PR TITLE
fix(action): skip download when the resolved tag is cached

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Collapse large opaque embed diffs in GitHub review UI.
 pkg/template/vizb-ui.gen.go linguist-generated=true
+
+# Git Bash on windows-latest cannot run CRLF shell scripts.
+action/*.sh text eol=lf

--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -67,30 +67,6 @@ jobs:
           JSON_FILE: ${{ steps.vizb.outputs.output-file-json }}
         run: node scripts/verify-action-output.mjs
 
-      - name: Run action (cyclic chord)
-        if: matrix.os == 'ubuntu-latest'
-        id: chord
-        uses: ./
-        with:
-          file: examples/csv/chord-relations.csv
-          parser: csv
-          select: source,target,value
-          charts: chord
-          chart: chord:labels
-          output-html: chord.html
-          output-json: results/chord.json
-          vizb-binary: ${{ inputs.binary == 'build' && './bin/vizb' || '' }}
-
-      - name: Verify Chord outputs
-        if: matrix.os == 'ubuntu-latest'
-        env:
-          EXPECTED_JSON_KIND: object
-          EXPECTED_NAMES: '["Comparisons"]'
-          EXPECTED_CHART_TYPE: chord
-          HTML_FILE: ${{ steps.chord.outputs.output-file-html }}
-          JSON_FILE: ${{ steps.chord.outputs.output-file-json }}
-        run: node scripts/verify-action-output.mjs
-
   stateful:
     needs: [unit]
     strategy:

--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -1,7 +1,18 @@
 name: action
 on:
   workflow_call:
+    inputs:
+      binary:
+        description: "build = local go build + vizb-binary; released = download latest v0"
+        type: string
+        default: build
   workflow_dispatch:
+    inputs:
+      binary:
+        description: "build = local go build + vizb-binary; released = download latest v0"
+        type: choice
+        options: [build, released]
+        default: build
 
 jobs:
   # Fast gate: Node unit tests before multi-OS action runs.
@@ -23,7 +34,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Go
-        if: env.ACT != 'true'
+        if: env.ACT != 'true' && inputs.binary == 'build'
         uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
@@ -32,11 +43,11 @@ jobs:
       # PRs and manual dispatch: rebuild so action tests see current ui/.
       # workflow_call from main/release: tracked gen is enough.
       - name: Rebuild embed for PR or dispatch
-        if: env.ACT != 'true' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+        if: env.ACT != 'true' && inputs.binary == 'build' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
         uses: ./.github/actions/setup-embed-ui
 
       - name: Build vizb
-        if: env.ACT != 'true'
+        if: env.ACT != 'true' && inputs.binary == 'build'
         run: go build -o ./bin/vizb .
 
       - name: Run action (stateless)
@@ -46,7 +57,7 @@ jobs:
           file: examples/go/hash.txt
           output-html: index.html
           output-json: results/stateless.json
-          vizb-binary: ./bin/vizb
+          vizb-binary: ${{ inputs.binary == 'build' && './bin/vizb' || '' }}
 
       - name: Verify action outputs
         env:
@@ -68,7 +79,7 @@ jobs:
           chart: chord:labels
           output-html: chord.html
           output-json: results/chord.json
-          vizb-binary: ./bin/vizb
+          vizb-binary: ${{ inputs.binary == 'build' && './bin/vizb' || '' }}
 
       - name: Verify Chord outputs
         if: matrix.os == 'ubuntu-latest'
@@ -90,18 +101,18 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Go
-        if: env.ACT != 'true'
+        if: env.ACT != 'true' && inputs.binary == 'build'
         uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Rebuild embed for PR or dispatch
-        if: env.ACT != 'true' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+        if: env.ACT != 'true' && inputs.binary == 'build' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
         uses: ./.github/actions/setup-embed-ui
 
       - name: Build vizb
-        if: env.ACT != 'true'
+        if: env.ACT != 'true' && inputs.binary == 'build'
         run: go build -o ./bin/vizb .
 
       - name: Generate previous JSON
@@ -110,7 +121,7 @@ jobs:
           name: Hash
           file: examples/go/hash.txt
           output-json: results/prev/hash.json
-          vizb-binary: ./bin/vizb
+          vizb-binary: ${{ inputs.binary == 'build' && './bin/vizb' || '' }}
 
       - name: Run action (stateful)
         id: vizb
@@ -123,7 +134,7 @@ jobs:
           merge-dir: results/prev
           output-html: index.html
           output-json: results/bench.json
-          vizb-binary: ./bin/vizb
+          vizb-binary: ${{ inputs.binary == 'build' && './bin/vizb' || '' }}
 
       - name: Verify action outputs
         env:

--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Fast gate: Node unit tests before multi-OS composite runs.
+  # Fast gate: Node unit tests before multi-OS action runs.
   unit:
     runs-on: ubuntu-slim
     steps:

--- a/.github/workflows/action-released.yml
+++ b/.github/workflows/action-released.yml
@@ -1,0 +1,29 @@
+name: action (released)
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - action.yml
+      - action/resolve.sh
+      - action/install.sh
+      - .github/workflows/action-ci.yml
+      - .github/workflows/action-released.yml
+  push:
+    branches: [main]
+    paths:
+      - action.yml
+      - action/resolve.sh
+      - action/install.sh
+      - .github/workflows/action-ci.yml
+      - .github/workflows/action-released.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  action:
+    uses: ./.github/workflows/action-ci.yml
+    with:
+      binary: released

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@ Notable changes to Vizb documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [Unreleased]
-
-### Changed
-
-- **action** — Resolve and install are bash scripts (`action/resolve.sh`, `action/install.sh`); only the pipeline runs in Node. Pass inputs with `toJSON(inputs)` (no per-flag `INPUT_*` map). Cache the resolved release tag (including `@v0`) so a hit skips the archive download.
-
 # [v0.19.0] - 2026-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Notable changes to Vizb documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased]
+
+### Changed
+
+- **action** — Resolve and install are bash scripts (`action/resolve.sh`, `action/install.sh`); only the pipeline runs in Node. Pass inputs with `toJSON(inputs)` (no per-flag `INPUT_*` map). Cache the resolved release tag (including `@v0`) so a hit skips the archive download.
+
 # [v0.19.0] - 2026-08-13
 
 ### Added

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
   cmd:
     description: "Command whose stdout is visualized — any command emitting CSV/JSON tabular data or benchmark output (e.g., go test -bench=., cargo bench, cat data.csv)."
     default: ""
+  cmd-retries:
+    description: "Total attempts for cmd. 1 = no retry (default). Integer >= 1. Failed attempts wait 2s, then double."
+    default: "1"
   file:
     description: "Path to an existing input file to visualize — benchmark output, CSV, or JSON (takes priority over cmd)"
     default: ""
@@ -18,9 +21,6 @@ inputs:
   bench-file:
     description: "DEPRECATED: use 'file'. Existing input file; honored only when 'file' is empty." # remove on v1
     default: ""
-  cmd-retries:
-    description: "Total attempts for cmd. 1 = no retry (default). Integer >= 1. Failed attempts wait 2s, then double."
-    default: "1"
   name:
     description: "Dataset/benchmark name (-n flag)"
     default: "Comparisons"

--- a/action.yml
+++ b/action.yml
@@ -109,7 +109,7 @@ inputs:
     description: "URL to fetch vizb JSON from at runtime (-U flag). Accepts full dataset payloads or a lazy [{id,name}] catalog with details at /dataset/<encoded-id>."
     default: ""
   vizb-binary:
-    description: "Path to a pre-built vizb binary on the runner. When set, skips release download/cache and installs this binary instead — useful for testing local builds or unreleased changes."
+    description: "Path to a pre-built vizb binary on the runner. When set, skips version resolution, cache, and release download and installs this binary instead — useful for testing local builds or unreleased changes."
     default: ""
 outputs:
   output-file-html:
@@ -123,96 +123,29 @@ runs:
   using: composite
   steps:
     - name: Resolve vizb version
+      if: inputs.vizb-binary == ''
       id: version
       shell: bash
-      run: |
-        if [ -n "${{ inputs.vizb-binary }}" ]; then
-          echo "tag=local" >> "$GITHUB_OUTPUT"
-          echo "is-major=false" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        REF="${{ github.action_ref }}"
-        if [ -z "$REF" ]; then
-          REF="v0"
-        fi
-
-        if echo "$REF" | grep -qE '^v[0-9]+$'; then
-          PREFIX="${REF#v}"
-          TAG=$(git ls-remote --tags --refs --sort='-version:refname' \
-            https://github.com/goptics/vizb "refs/tags/v${PREFIX}.*" | \
-            head -1 | sed 's|.*/||')
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "is-major=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "tag=$REF" >> "$GITHUB_OUTPUT"
-          echo "is-major=false" >> "$GITHUB_OUTPUT"
-        fi
+      run: bash "$GITHUB_ACTION_PATH/action/resolve.sh"
 
     - name: Cache vizb binary
-      if: steps.version.outputs.is-major != 'true' && inputs.vizb-binary == ''
+      if: inputs.vizb-binary == ''
       id: cache-vizb
       uses: actions/cache@v6
       with:
-        # Windows installs as vizb.exe (required for Node spawnSync / PATHEXT).
         path: |
           ~/.local/bin/vizb
           ~/.local/bin/vizb.exe
         key: vizb-${{ steps.version.outputs.tag }}-${{ runner.os }}-${{ runner.arch }}
 
     - name: Install vizb
-      if: steps.cache-vizb.outputs.cache-hit != 'true'
+      if: inputs.vizb-binary != '' || steps.cache-vizb.outputs.cache-hit != 'true'
       shell: bash
-      run: |
-        mkdir -p ~/.local/bin
+      env:
+        VIZB_BINARY: ${{ inputs.vizb-binary }}
+        VIZB_TAG: ${{ steps.version.outputs.tag }}
+      run: bash "$GITHUB_ACTION_PATH/action/install.sh"
 
-        # Node spawnSync on Windows only finds PATHEXT names (vizb.exe).
-        if [ "${{ runner.os }}" = "Windows" ]; then
-          VIZB_DEST="$HOME/.local/bin/vizb.exe"
-        else
-          VIZB_DEST="$HOME/.local/bin/vizb"
-        fi
-
-        VIZB_BINARY="${{ inputs.vizb-binary }}"
-        if [ -n "$VIZB_BINARY" ]; then
-          # go build -o ./bin/vizb on Windows yields ./bin/vizb.exe
-          if [ ! -f "$VIZB_BINARY" ] && [ -f "${VIZB_BINARY}.exe" ]; then
-            VIZB_BINARY="${VIZB_BINARY}.exe"
-          fi
-          echo "::notice::Installing local vizb binary from $VIZB_BINARY"
-          cp "$VIZB_BINARY" "$VIZB_DEST"
-          chmod +x "$VIZB_DEST"
-          exit 0
-        fi
-
-        OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
-        [ "$OS" = "macos" ] && OS="darwin"
-        ARCH=$(echo "${{ runner.arch }}" | tr '[:upper:]' '[:lower:]')
-        [ "$ARCH" = "x64" ] && ARCH="amd64"
-
-        TAG="${{ steps.version.outputs.tag }}"
-        VERSION="${TAG#v}"
-        EXT=".tar.gz"
-        [ "$OS" = "windows" ] && EXT=".zip"
-
-        URL="https://github.com/goptics/vizb/releases/download/${TAG}/vizb@${VERSION}-${OS}-${ARCH}${EXT}"
-
-        curl -sfL "$URL" -o vizb-archive || {
-          echo "::error::Failed to download vizb from $URL. Check that release ${TAG} exists."
-          exit 1
-        }
-
-        if [ "$OS" = "windows" ]; then
-          unzip -o vizb-archive -d ~/.local/bin
-          if [ ! -f "$HOME/.local/bin/vizb.exe" ] && [ -f "$HOME/.local/bin/vizb" ]; then
-            mv "$HOME/.local/bin/vizb" "$HOME/.local/bin/vizb.exe"
-          fi
-        else
-          tar xzf vizb-archive -C ~/.local/bin
-          chmod +x ~/.local/bin/vizb
-        fi
-
-    # Always on PATH (covers cache hits when Install is skipped).
     - name: Add vizb to PATH
       shell: bash
       run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
@@ -220,38 +153,5 @@ runs:
     - name: Run vizb pipeline
       shell: bash
       env:
-        INPUT_cmd: ${{ inputs.cmd }}
-        INPUT_file: ${{ inputs.file }}
-        INPUT_bench-cmd: ${{ inputs.bench-cmd }}
-        INPUT_bench-file: ${{ inputs.bench-file }}
-        INPUT_cmd-retries: ${{ inputs.cmd-retries }}
-        INPUT_name: ${{ inputs.name }}
-        INPUT_title: ${{ inputs.title }}
-        INPUT_description: ${{ inputs.description }}
-        INPUT_tag: ${{ inputs.tag }}
-        INPUT_id: ${{ inputs.id }}
-        INPUT_group: ${{ inputs.group }}
-        INPUT_group-pattern: ${{ inputs.group-pattern }}
-        INPUT_group-regex: ${{ inputs.group-regex }}
-        INPUT_sort: ${{ inputs.sort }}
-        INPUT_filter: ${{ inputs.filter }}
-        INPUT_mem-unit: ${{ inputs.mem-unit }}
-        INPUT_time-unit: ${{ inputs.time-unit }}
-        INPUT_number-unit: ${{ inputs.number-unit }}
-        INPUT_round: ${{ inputs.round }}
-        INPUT_select: ${{ inputs.select }}
-        INPUT_col-axis: ${{ inputs.col-axis }}
-        INPUT_json-path: ${{ inputs.json-path }}
-        INPUT_stat: ${{ inputs.stat }}
-        INPUT_chart: ${{ inputs.chart }}
-        INPUT_charts: ${{ inputs.charts }}
-        INPUT_parser: ${{ inputs.parser }}
-        INPUT_show-labels: ${{ inputs.show-labels }}
-        INPUT_enable-3d: ${{ inputs.enable-3d }}
-        INPUT_merge-files: ${{ inputs.merge-files }}
-        INPUT_merge-dir: ${{ inputs.merge-dir }}
-        INPUT_tag-axis: ${{ inputs.tag-axis }}
-        INPUT_output-json: ${{ inputs.output-json }}
-        INPUT_output-html: ${{ inputs.output-html }}
-        INPUT_data-url: ${{ inputs.data-url }}
+        VIZB_ACTION_INPUTS: ${{ toJSON(inputs) }}
       run: node "$GITHUB_ACTION_PATH/action/run.mjs"

--- a/action/install.sh
+++ b/action/install.sh
@@ -38,23 +38,20 @@ EXT=".tar.gz"
 
 URL="https://github.com/goptics/vizb/releases/download/${TAG}/vizb@${VERSION}-${OS}-${ARCH}${EXT}"
 
-if [ "${VIZB_DRY_RUN:-}" = "1" ]; then
-  echo "dest=${DEST}"
-  echo "url=${URL}"
-  exit 0
-fi
+ARCHIVE=$(mktemp "${TMPDIR:-/tmp}/vizb-archive.XXXXXX")
+trap 'rm -f "$ARCHIVE"' EXIT
 
-curl -sfL "$URL" -o vizb-archive || {
+curl -sfL "$URL" -o "$ARCHIVE" || {
   echo "::error::Failed to download vizb from $URL. Check that release ${TAG} exists."
   exit 1
 }
 
 if [ "$OS" = "windows" ]; then
-  unzip -o vizb-archive -d "$BIN_DIR"
+  unzip -o "$ARCHIVE" -d "$BIN_DIR"
   if [ ! -f "${BIN_DIR}/vizb.exe" ] && [ -f "${BIN_DIR}/vizb" ]; then
     mv "${BIN_DIR}/vizb" "$DEST"
   fi
 else
-  tar xzf vizb-archive -C "$BIN_DIR"
+  tar xzf "$ARCHIVE" -C "$BIN_DIR"
   chmod +x "${BIN_DIR}/vizb"
 fi

--- a/action/install.sh
+++ b/action/install.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BIN_DIR="${HOME}/.local/bin"
+mkdir -p "$BIN_DIR"
+
+if [ "${RUNNER_OS:-}" = "Windows" ]; then
+  DEST="${BIN_DIR}/vizb.exe"
+else
+  DEST="${BIN_DIR}/vizb"
+fi
+
+VIZB_BINARY="${VIZB_BINARY:-}"
+if [ -n "$VIZB_BINARY" ]; then
+  if [ ! -f "$VIZB_BINARY" ] && [ -f "${VIZB_BINARY}.exe" ]; then
+    VIZB_BINARY="${VIZB_BINARY}.exe"
+  fi
+  echo "::notice::Installing local vizb binary from $VIZB_BINARY"
+  cp "$VIZB_BINARY" "$DEST"
+  chmod +x "$DEST"
+  exit 0
+fi
+
+OS=$(echo "${RUNNER_OS:-}" | tr '[:upper:]' '[:lower:]')
+[ "$OS" = "macos" ] && OS="darwin"
+ARCH=$(echo "${RUNNER_ARCH:-}" | tr '[:upper:]' '[:lower:]')
+[ "$ARCH" = "x64" ] && ARCH="amd64"
+
+TAG="${VIZB_TAG:-}"
+if [ -z "$TAG" ]; then
+  echo "::error::VIZB_TAG is required when VIZB_BINARY is not set"
+  exit 1
+fi
+
+VERSION="${TAG#v}"
+EXT=".tar.gz"
+[ "$OS" = "windows" ] && EXT=".zip"
+
+URL="https://github.com/goptics/vizb/releases/download/${TAG}/vizb@${VERSION}-${OS}-${ARCH}${EXT}"
+
+if [ "${VIZB_DRY_RUN:-}" = "1" ]; then
+  echo "dest=${DEST}"
+  echo "url=${URL}"
+  exit 0
+fi
+
+curl -sfL "$URL" -o vizb-archive || {
+  echo "::error::Failed to download vizb from $URL. Check that release ${TAG} exists."
+  exit 1
+}
+
+if [ "$OS" = "windows" ]; then
+  unzip -o vizb-archive -d "$BIN_DIR"
+  if [ ! -f "${BIN_DIR}/vizb.exe" ] && [ -f "${BIN_DIR}/vizb" ]; then
+    mv "${BIN_DIR}/vizb" "$DEST"
+  fi
+else
+  tar xzf vizb-archive -C "$BIN_DIR"
+  chmod +x "${BIN_DIR}/vizb"
+fi

--- a/action/lib.mjs
+++ b/action/lib.mjs
@@ -3,9 +3,27 @@ import { closeSync, existsSync, openSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+/** @param {NodeJS.ProcessEnv} env */
+function parsedActionInputs(env) {
+  const raw = env.VIZB_ACTION_INPUTS
+  if (!raw) return null
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new Error('VIZB_ACTION_INPUTS is not valid JSON')
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('VIZB_ACTION_INPUTS is not valid JSON')
+  }
+  return parsed
+}
+
 /** @param {string} key @param {NodeJS.ProcessEnv} [env] */
 function input(key, env = process.env) {
-  return env[`INPUT_${key}`] ?? ''
+  const blob = parsedActionInputs(env)
+  if (blob && Object.hasOwn(blob, key)) return String(blob[key] ?? '')
+  return env[`INPUT_${key.toUpperCase()}`] ?? ''
 }
 
 /**

--- a/action/lib.mjs
+++ b/action/lib.mjs
@@ -2,40 +2,32 @@ import { spawnSync } from 'node:child_process'
 import { closeSync, existsSync, openSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { setTimeout } from 'node:timers/promises'
 
 /** @param {NodeJS.ProcessEnv} env */
-function parsedActionInputs(env) {
+function parseActionInputs(env) {
   const raw = env.VIZB_ACTION_INPUTS
-  if (!raw) return null
-  let parsed
+  if (!raw) return {}
   try {
-    parsed = JSON.parse(raw)
+    return JSON.parse(raw)
   } catch {
     throw new Error('VIZB_ACTION_INPUTS is not valid JSON')
   }
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error('VIZB_ACTION_INPUTS is not valid JSON')
-  }
-  return parsed
-}
-
-/** @param {string} key @param {NodeJS.ProcessEnv} [env] */
-function input(key, env = process.env) {
-  const blob = parsedActionInputs(env)
-  if (blob && Object.hasOwn(blob, key)) return String(blob[key] ?? '')
-  return env[`INPUT_${key.toUpperCase()}`] ?? ''
 }
 
 /**
  * @param {NodeJS.ProcessEnv} [env]
  */
 export function resolveInputs(env = process.env) {
-  const file = input('file', env) || input('bench-file', env)
-  const cmd = input('cmd', env) || input('bench-cmd', env)
-  const mergeFiles = input('merge-files', env)
-  const mergeDir = input('merge-dir', env)
-  const dataUrl = input('data-url', env)
-  const outputJson = input('output-json', env)
+  const blob = parseActionInputs(env)
+  const input = (key) => String(blob[key] ?? '')
+
+  const file = input('file') || input('bench-file')
+  const cmd = input('cmd') || input('bench-cmd')
+  const mergeFiles = input('merge-files')
+  const mergeDir = input('merge-dir')
+  const dataUrl = input('data-url')
+  const outputJson = input('output-json')
 
   if (!file && !cmd && !mergeFiles && !mergeDir && !dataUrl) {
     throw new Error(
@@ -46,36 +38,36 @@ export function resolveInputs(env = process.env) {
   return {
     file,
     cmd,
-    cmdRetries: parseCmdRetries(input('cmd-retries', env)),
+    cmdRetries: parseCmdRetries(input('cmd-retries')),
     hasInput: Boolean(file || cmd),
     jsonFile: outputJson || 'bench.json',
-    name: input('name', env),
-    title: input('title', env),
-    description: input('description', env),
-    tag: input('tag', env),
-    id: input('id', env),
-    group: input('group', env),
-    groupPattern: input('group-pattern', env),
-    groupRegex: input('group-regex', env),
-    sort: input('sort', env),
-    filter: input('filter', env),
-    memUnit: input('mem-unit', env),
-    timeUnit: input('time-unit', env),
-    numberUnit: input('number-unit', env),
-    round: input('round', env) === 'true',
-    select: input('select', env),
-    colAxis: input('col-axis', env),
-    jsonPath: input('json-path', env),
-    stat: input('stat', env),
-    chart: input('chart', env),
-    charts: input('charts', env),
-    parser: input('parser', env),
-    showLabels: input('show-labels', env) === 'true',
-    enable3d: input('enable-3d', env) === 'true',
+    name: input('name'),
+    title: input('title'),
+    description: input('description'),
+    tag: input('tag'),
+    id: input('id'),
+    group: input('group'),
+    groupPattern: input('group-pattern'),
+    groupRegex: input('group-regex'),
+    sort: input('sort'),
+    filter: input('filter'),
+    memUnit: input('mem-unit'),
+    timeUnit: input('time-unit'),
+    numberUnit: input('number-unit'),
+    round: input('round') === 'true',
+    select: input('select'),
+    colAxis: input('col-axis'),
+    jsonPath: input('json-path'),
+    stat: input('stat'),
+    chart: input('chart'),
+    charts: input('charts'),
+    parser: input('parser'),
+    showLabels: input('show-labels') === 'true',
+    enable3d: input('enable-3d') === 'true',
     mergeFiles,
     mergeDir,
-    tagAxis: input('tag-axis', env) || 'n',
-    outputHtml: input('output-html', env),
+    tagAxis: input('tag-axis') || 'n',
+    outputHtml: input('output-html'),
     dataUrl,
   }
 }
@@ -92,22 +84,16 @@ function parseCmdRetries(value) {
 
 const CMD_RETRY_DELAY_SEC = 2
 
-/** @param {number} seconds */
-function sleepSync(seconds) {
-  if (!(seconds > 0)) return
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, seconds * 1000)
-}
-
 /**
  * @param {() => void} fn
  * @param {{
  *   retries: number,
- *   sleep?: (sec: number) => void,
+ *   sleep?: (sec: number) => void | Promise<void>,
  *   log?: (msg: string) => void,
  * }} opts
  */
-export function runWithRetries(fn, opts) {
-  const sleep = opts.sleep ?? sleepSync
+export async function runWithRetries(fn, opts) {
+  const wait = opts.sleep ?? ((sec) => setTimeout(sec * 1000))
   const log = opts.log ?? ((msg) => console.error(msg))
 
   for (let attempt = 1; attempt <= opts.retries; attempt++) {
@@ -120,7 +106,7 @@ export function runWithRetries(fn, opts) {
       log(
         `::warning::cmd failed (attempt ${attempt}/${opts.retries}, ${err.message ?? err}). Retrying in ${waitSec}s.`,
       )
-      sleep(waitSec)
+      await wait(waitSec)
     }
   }
 }
@@ -234,11 +220,11 @@ export function runShellCapture(command, stdoutPath) {
  *   run?: typeof run,
  *   runShellCapture?: typeof runShellCapture,
  *   vizbBin?: string,
- *   sleep?: (sec: number) => void,
+ *   sleep?: (sec: number) => void | Promise<void>,
  *   log?: (msg: string) => void,
  * }} [deps]
  */
-export function runPipeline(inputs, deps = {}) {
+export async function runPipeline(inputs, deps = {}) {
   const execRun = deps.run ?? run
   const execShell = deps.runShellCapture ?? runShellCapture
   const vizb = deps.vizbBin ?? resolveVizbBin()
@@ -247,7 +233,7 @@ export function runPipeline(inputs, deps = {}) {
     let inputPath = inputs.file
     if (!inputPath) {
       inputPath = join(tmpdir(), `vizb-data-input-${process.pid}.txt`)
-      runWithRetries(() => execShell(inputs.cmd, inputPath), {
+      await runWithRetries(() => execShell(inputs.cmd, inputPath), {
         retries: inputs.cmdRetries,
         sleep: deps.sleep,
         log: deps.log,

--- a/action/lib.test.mjs
+++ b/action/lib.test.mjs
@@ -110,9 +110,36 @@ describe('resolveInputs', () => {
   function envFrom(map) {
     /** @type {NodeJS.ProcessEnv} */
     const env = {}
-    for (const [k, v] of Object.entries(map)) env[`INPUT_${k}`] = v
+    for (const [k, v] of Object.entries(map)) env[`INPUT_${k.toUpperCase()}`] = v
     return env
   }
+
+  it('reads GitHub-injected uppercase INPUT_ names', () => {
+    const r = resolveInputs({
+      INPUT_FILE: 'data.csv',
+      'INPUT_CMD-RETRIES': '2',
+    })
+    assert.equal(r.file, 'data.csv')
+    assert.equal(r.cmdRetries, 2)
+  })
+
+  it('prefers VIZB_ACTION_INPUTS JSON over INPUT_*', () => {
+    const r = resolveInputs({
+      VIZB_ACTION_INPUTS: JSON.stringify({
+        file: 'from-json.csv',
+        'cmd-retries': '4',
+        chart: 'bar:scale=log\npie:labels',
+      }),
+      INPUT_FILE: 'from-env.csv',
+    })
+    assert.equal(r.file, 'from-json.csv')
+    assert.equal(r.cmdRetries, 4)
+    assert.equal(r.chart, 'bar:scale=log\npie:labels')
+  })
+
+  it('rejects invalid VIZB_ACTION_INPUTS', () => {
+    assert.throws(() => resolveInputs({ VIZB_ACTION_INPUTS: '{' }), /not valid JSON/)
+  })
 
   it('prefers file/cmd over deprecated bench-* aliases', () => {
     const r = resolveInputs(

--- a/action/lib.test.mjs
+++ b/action/lib.test.mjs
@@ -108,30 +108,17 @@ describe('buildConvertArgs', () => {
 describe('resolveInputs', () => {
   /** @param {Record<string, string>} map */
   function envFrom(map) {
-    /** @type {NodeJS.ProcessEnv} */
-    const env = {}
-    for (const [k, v] of Object.entries(map)) env[`INPUT_${k.toUpperCase()}`] = v
-    return env
+    return { VIZB_ACTION_INPUTS: JSON.stringify(map) }
   }
 
-  it('reads GitHub-injected uppercase INPUT_ names', () => {
-    const r = resolveInputs({
-      INPUT_FILE: 'data.csv',
-      'INPUT_CMD-RETRIES': '2',
-    })
-    assert.equal(r.file, 'data.csv')
-    assert.equal(r.cmdRetries, 2)
-  })
-
-  it('prefers VIZB_ACTION_INPUTS JSON over INPUT_*', () => {
-    const r = resolveInputs({
-      VIZB_ACTION_INPUTS: JSON.stringify({
+  it('reads VIZB_ACTION_INPUTS JSON', () => {
+    const r = resolveInputs(
+      envFrom({
         file: 'from-json.csv',
         'cmd-retries': '4',
         chart: 'bar:scale=log\npie:labels',
       }),
-      INPUT_FILE: 'from-env.csv',
-    })
+    )
     assert.equal(r.file, 'from-json.csv')
     assert.equal(r.cmdRetries, 4)
     assert.equal(r.chart, 'bar:scale=log\npie:labels')
@@ -274,11 +261,11 @@ describe('runWithRetries', () => {
     throw err
   }
 
-  it('returns on first success without sleeping', () => {
+  it('returns on first success without sleeping', async () => {
     const sleeps = []
     const logs = []
     let attempts = 0
-    runWithRetries(
+    await runWithRetries(
       () => {
         attempts += 1
       },
@@ -293,11 +280,11 @@ describe('runWithRetries', () => {
     assert.deepEqual(logs, [])
   })
 
-  it('retries after failure then succeeds', () => {
+  it('retries after failure then succeeds', async () => {
     const sleeps = []
     const logs = []
     let attempts = 0
-    runWithRetries(
+    await runWithRetries(
       () => {
         attempts += 1
         if (attempts < 2) failWith(1)
@@ -316,10 +303,10 @@ describe('runWithRetries', () => {
     )
   })
 
-  it('rethrows the last error after attempts are exhausted', () => {
+  it('rethrows the last error after attempts are exhausted', async () => {
     const sleeps = []
     let attempts = 0
-    assert.throws(
+    await assert.rejects(
       () =>
         runWithRetries(
           () => {
@@ -338,10 +325,10 @@ describe('runWithRetries', () => {
     assert.deepEqual(sleeps, [2, 4])
   })
 
-  it('does not sleep when retries is 1', () => {
+  it('does not sleep when retries is 1', async () => {
     const sleeps = []
     const logs = []
-    assert.throws(
+    await assert.rejects(
       () =>
         runWithRetries(
           () => failWith(1),
@@ -357,9 +344,9 @@ describe('runWithRetries', () => {
     assert.deepEqual(logs, [])
   })
 
-  it('logs spawn errors by message', () => {
+  it('logs spawn errors by message', async () => {
     const logs = []
-    runWithRetries(
+    await runWithRetries(
       () => {
         if (logs.length === 0) throw new Error('spawn ENOENT')
       },
@@ -416,10 +403,10 @@ describe('runPipeline', () => {
     }
   }
 
-  it('runs convert then ui for file + html', () => {
+  it('runs convert then ui for file + html', async () => {
     /** @type {string[][]} */
     const calls = []
-    runPipeline(baseInputs(), {
+    await runPipeline(baseInputs(), {
       vizbBin: 'vizb',
       run: (cmd, args) => {
         calls.push([cmd, ...args])
@@ -431,12 +418,12 @@ describe('runPipeline', () => {
     assert.deepEqual(calls[1].slice(0, 4), ['vizb', 'ui', 'results/out.json', '-o'])
   })
 
-  it('captures cmd stdout then converts', () => {
+  it('captures cmd stdout then converts', async () => {
     /** @type {string[][]} */
     const calls = []
     /** @type {string[]} */
     const shells = []
-    runPipeline(
+    await runPipeline(
       baseInputs({ file: '', cmd: 'echo hello', hasInput: true, outputHtml: '' }),
       {
         vizbBin: 'vizb',
@@ -453,11 +440,11 @@ describe('runPipeline', () => {
     assert.equal(calls.length, 1)
   })
 
-  it('retries cmd capture until it succeeds', () => {
+  it('retries cmd capture until it succeeds', async () => {
     /** @type {number[]} */
     const sleeps = []
     let shells = 0
-    runPipeline(
+    await runPipeline(
       baseInputs({
         file: '',
         cmd: 'flaky',
@@ -484,9 +471,9 @@ describe('runPipeline', () => {
     assert.deepEqual(sleeps, [2, 4])
   })
 
-  it('does not retry when file is set', () => {
+  it('does not retry when file is set', async () => {
     let shells = 0
-    runPipeline(baseInputs({ cmd: 'should-not-run', cmdRetries: 3 }), {
+    await runPipeline(baseInputs({ cmd: 'should-not-run', cmdRetries: 3 }), {
       vizbBin: 'vizb',
       run: () => {},
       runShellCapture: () => {
@@ -496,12 +483,12 @@ describe('runPipeline', () => {
     assert.equal(shells, 0)
   })
 
-  it('merges when merge-dir set and json exists', () => {
+  it('merges when merge-dir set and json exists', async () => {
     /** @type {string[][]} */
     const calls = []
     // Pre-create path check via real existsSync is fine if we only convert+merge
     // without relying on file presence — inject by writing nothing and only merge-files.
-    runPipeline(
+    await runPipeline(
       baseInputs({
         hasInput: false,
         file: '',
@@ -524,10 +511,10 @@ describe('runPipeline', () => {
     assert.ok(calls[0].includes('results/prev'))
   })
 
-  it('uses data-url for ui without convert', () => {
+  it('uses data-url for ui without convert', async () => {
     /** @type {string[][]} */
     const calls = []
-    runPipeline(
+    await runPipeline(
       baseInputs({
         file: '',
         hasInput: false,

--- a/action/resolve.sh
+++ b/action/resolve.sh
@@ -2,9 +2,6 @@
 set -euo pipefail
 
 REF="${GITHUB_ACTION_REF:-v0}"
-if [ -z "$REF" ]; then
-  REF="v0"
-fi
 
 if echo "$REF" | grep -qE '^v[0-9]+$'; then
   PREFIX="${REF#v}"

--- a/action/resolve.sh
+++ b/action/resolve.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REF="${GITHUB_ACTION_REF:-v0}"
+if [ -z "$REF" ]; then
+  REF="v0"
+fi
+
+if echo "$REF" | grep -qE '^v[0-9]+$'; then
+  PREFIX="${REF#v}"
+  TAG=$(git ls-remote --tags --refs --sort='-version:refname' \
+    https://github.com/goptics/vizb "refs/tags/v${PREFIX}.*" |
+    head -1 | sed 's|.*/||')
+  if [ -z "$TAG" ]; then
+    echo "::error::No release tags found for $REF"
+    exit 1
+  fi
+else
+  TAG="$REF"
+fi
+
+echo "tag=$TAG" >> "$GITHUB_OUTPUT"

--- a/action/run.mjs
+++ b/action/run.mjs
@@ -2,7 +2,7 @@
 import { resolveInputs, runPipeline } from './lib.mjs'
 
 try {
-  runPipeline(resolveInputs())
+  await runPipeline(resolveInputs())
 } catch (err) {
   const message = err instanceof Error ? err.message : String(err)
   console.error(`::error::${message}`)

--- a/action/scripts.test.mjs
+++ b/action/scripts.test.mjs
@@ -30,6 +30,53 @@ function writeGitStub(binDir, body) {
   return git
 }
 
+function writeExec(path, body) {
+  writeFileSync(path, `#!/usr/bin/env bash\n${body}`)
+  chmodSync(path, 0o755)
+}
+
+function runInstallRelease({ runnerOs, runnerArch, tag }) {
+  const dir = tempDir('vizb-install-')
+  const home = join(dir, 'home')
+  const cwd = join(dir, 'cwd')
+  const bin = join(dir, 'bin')
+  mkdirSync(home, { recursive: true })
+  mkdirSync(cwd, { recursive: true })
+  mkdirSync(bin, { recursive: true })
+
+  const destName = runnerOs === 'Windows' ? 'vizb.exe' : 'vizb'
+  const dest = join(home, '.local', 'bin', destName)
+  const urlLog = join(dir, 'curl.url')
+  const archiveLog = join(dir, 'curl.dest')
+
+  writeExec(
+    join(bin, 'curl'),
+    `printf '%s' "$2" > '${urlLog}'\nprintf '%s' "$4" > '${archiveLog}'\nprintf archive > "$4"\n`,
+  )
+  writeExec(join(bin, 'tar'), `printf extracted > '${dest}'\n`)
+  writeExec(join(bin, 'unzip'), `printf extracted > '${dest}'\n`)
+
+  const result = runBash(
+    installSh,
+    {
+      HOME: home,
+      RUNNER_OS: runnerOs,
+      RUNNER_ARCH: runnerArch,
+      VIZB_TAG: tag,
+      PATH: `${bin}:${process.env.PATH}`,
+    },
+    { cwd },
+  )
+
+  return {
+    result,
+    cwd,
+    dest,
+    url: existsSync(urlLog) ? readFileSync(urlLog, 'utf8') : '',
+    archive: existsSync(archiveLog) ? readFileSync(archiveLog, 'utf8') : '',
+  }
+}
+
 describe('resolve.sh', () => {
   it('uses a pinned ref as the tag without calling git', () => {
     const dir = tempDir('vizb-resolve-')
@@ -124,38 +171,30 @@ describe('install.sh', () => {
   })
 
   it('maps macos/x64 to a darwin/amd64 tar.gz url', () => {
-    const dir = tempDir('vizb-install-')
-    const result = runBash(installSh, {
-      HOME: dir,
-      RUNNER_OS: 'macOS',
-      RUNNER_ARCH: 'X64',
-      VIZB_TAG: 'v0.18.2',
-      VIZB_DRY_RUN: '1',
-    })
-
-    assert.equal(result.status, 0, result.stderr)
-    assert.match(result.stdout, /dest=.*\/\.local\/bin\/vizb$/m)
-    assert.match(
-      result.stdout,
-      /url=https:\/\/github.com\/goptics\/vizb\/releases\/download\/v0\.18\.2\/vizb@0\.18\.2-darwin-amd64\.tar\.gz/,
+    const r = runInstallRelease({ runnerOs: 'macOS', runnerArch: 'X64', tag: 'v0.18.2' })
+    assert.equal(r.result.status, 0, r.result.stderr)
+    assert.ok(r.dest.endsWith(`${join('.local', 'bin', 'vizb')}`))
+    assert.equal(
+      r.url,
+      'https://github.com/goptics/vizb/releases/download/v0.18.2/vizb@0.18.2-darwin-amd64.tar.gz',
     )
   })
 
-  it('maps windows/x64 to a zip url and vizb.exe dest', () => {
-    const dir = tempDir('vizb-install-')
-    const result = runBash(installSh, {
-      HOME: dir,
-      RUNNER_OS: 'Windows',
-      RUNNER_ARCH: 'X64',
-      VIZB_TAG: 'v0.18.2',
-      VIZB_DRY_RUN: '1',
-    })
+  it('downloads to a unique temp archive and removes it', () => {
+    const r = runInstallRelease({ runnerOs: 'Linux', runnerArch: 'X64', tag: 'v0.18.2' })
+    assert.equal(r.result.status, 0, r.result.stderr)
+    assert.equal(existsSync(join(r.cwd, 'vizb-archive')), false)
+    assert.ok(r.archive.includes('vizb-archive.'))
+    assert.equal(existsSync(r.archive), false)
+  })
 
-    assert.equal(result.status, 0, result.stderr)
-    assert.match(result.stdout, /dest=.*\/\.local\/bin\/vizb\.exe$/m)
-    assert.match(
-      result.stdout,
-      /url=https:\/\/github.com\/goptics\/vizb\/releases\/download\/v0\.18\.2\/vizb@0\.18\.2-windows-amd64\.zip/,
+  it('maps windows/x64 to a zip url and vizb.exe dest', () => {
+    const r = runInstallRelease({ runnerOs: 'Windows', runnerArch: 'X64', tag: 'v0.18.2' })
+    assert.equal(r.result.status, 0, r.result.stderr)
+    assert.ok(r.dest.endsWith(`${join('.local', 'bin', 'vizb.exe')}`))
+    assert.equal(
+      r.url,
+      'https://github.com/goptics/vizb/releases/download/v0.18.2/vizb@0.18.2-windows-amd64.zip',
     )
   })
 })

--- a/action/scripts.test.mjs
+++ b/action/scripts.test.mjs
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const actionDir = dirname(fileURLToPath(import.meta.url))
+const resolveSh = join(actionDir, 'resolve.sh')
+const installSh = join(actionDir, 'install.sh')
+
+function runBash(script, env, extra = {}) {
+  return spawnSync('bash', [script], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+    ...extra,
+  })
+}
+
+function tempDir(prefix) {
+  return mkdtempSync(join(tmpdir(), prefix))
+}
+
+function writeGitStub(binDir, body) {
+  mkdirSync(binDir, { recursive: true })
+  const git = join(binDir, 'git')
+  writeFileSync(git, `#!/usr/bin/env bash\n${body}`)
+  chmodSync(git, 0o755)
+  return git
+}
+
+describe('resolve.sh', () => {
+  it('uses a pinned ref as the tag without calling git', () => {
+    const dir = tempDir('vizb-resolve-')
+    const out = join(dir, 'out')
+    writeFileSync(out, '')
+    const gitLog = join(dir, 'git.log')
+    writeGitStub(
+      join(dir, 'bin'),
+      `echo called >> '${gitLog}'\nexit 1\n`,
+    )
+
+    const result = runBash(resolveSh, {
+      GITHUB_ACTION_REF: 'v0.18.2',
+      GITHUB_OUTPUT: out,
+      PATH: `${join(dir, 'bin')}:${process.env.PATH}`,
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(readFileSync(out, 'utf8'), 'tag=v0.18.2\n')
+    assert.equal(existsSync(gitLog), false)
+  })
+
+  it('resolves a major ref from stubbed git ls-remote', () => {
+    const dir = tempDir('vizb-resolve-')
+    const out = join(dir, 'out')
+    writeFileSync(out, '')
+    writeGitStub(
+      join(dir, 'bin'),
+      'printf "abc\\trefs/tags/v0.19.0\\n"\n',
+    )
+
+    const result = runBash(resolveSh, {
+      GITHUB_ACTION_REF: 'v0',
+      GITHUB_OUTPUT: out,
+      PATH: `${join(dir, 'bin')}:${process.env.PATH}`,
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(readFileSync(out, 'utf8'), 'tag=v0.19.0\n')
+  })
+
+  it('fails when a major ref has no tags', () => {
+    const dir = tempDir('vizb-resolve-')
+    const out = join(dir, 'out')
+    writeFileSync(out, '')
+    writeGitStub(join(dir, 'bin'), 'exit 0\n')
+
+    const result = runBash(resolveSh, {
+      GITHUB_ACTION_REF: 'v0',
+      GITHUB_OUTPUT: out,
+      PATH: `${join(dir, 'bin')}:${process.env.PATH}`,
+    })
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr + result.stdout, /No release tags found for v0/)
+  })
+})
+
+describe('install.sh', () => {
+  it('copies vizb-binary to ~/.local/bin/vizb', () => {
+    const dir = tempDir('vizb-install-')
+    const home = join(dir, 'home')
+    const src = join(dir, 'vizb')
+    writeFileSync(src, 'bin')
+    mkdirSync(home, { recursive: true })
+
+    const result = runBash(installSh, {
+      HOME: home,
+      RUNNER_OS: 'Linux',
+      VIZB_BINARY: src,
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(readFileSync(join(home, '.local', 'bin', 'vizb'), 'utf8'), 'bin')
+  })
+
+  it('falls back to vizb-binary.exe and installs vizb.exe on Windows', () => {
+    const dir = tempDir('vizb-install-')
+    const home = join(dir, 'home')
+    const src = join(dir, 'vizb')
+    writeFileSync(`${src}.exe`, 'winbin')
+    mkdirSync(home, { recursive: true })
+
+    const result = runBash(installSh, {
+      HOME: home,
+      RUNNER_OS: 'Windows',
+      VIZB_BINARY: src,
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(readFileSync(join(home, '.local', 'bin', 'vizb.exe'), 'utf8'), 'winbin')
+  })
+
+  it('maps macos/x64 to a darwin/amd64 tar.gz url', () => {
+    const dir = tempDir('vizb-install-')
+    const result = runBash(installSh, {
+      HOME: dir,
+      RUNNER_OS: 'macOS',
+      RUNNER_ARCH: 'X64',
+      VIZB_TAG: 'v0.18.2',
+      VIZB_DRY_RUN: '1',
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /dest=.*\/\.local\/bin\/vizb$/m)
+    assert.match(
+      result.stdout,
+      /url=https:\/\/github.com\/goptics\/vizb\/releases\/download\/v0\.18\.2\/vizb@0\.18\.2-darwin-amd64\.tar\.gz/,
+    )
+  })
+
+  it('maps windows/x64 to a zip url and vizb.exe dest', () => {
+    const dir = tempDir('vizb-install-')
+    const result = runBash(installSh, {
+      HOME: dir,
+      RUNNER_OS: 'Windows',
+      RUNNER_ARCH: 'X64',
+      VIZB_TAG: 'v0.18.2',
+      VIZB_DRY_RUN: '1',
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /dest=.*\/\.local\/bin\/vizb\.exe$/m)
+    assert.match(
+      result.stdout,
+      /url=https:\/\/github.com\/goptics\/vizb\/releases\/download\/v0\.18\.2\/vizb@0\.18\.2-windows-amd64\.zip/,
+    )
+  })
+})

--- a/docs/src/content/docs/ci-cd/github-action.mdx
+++ b/docs/src/content/docs/ci-cd/github-action.mdx
@@ -38,7 +38,7 @@ Use `goptics/vizb@v0` to automatically resolve to the latest `v0.x.x` release:
 
 The action:
 - Resolves the major version tag to the latest patch release
-- Caches the downloaded binary across runs
+- Restores that exact binary from cache when present (skips the download)
 - Falls back to the exact tag for non-major refs (e.g., `@v0.18.2`)
 
 ## Inputs
@@ -78,7 +78,7 @@ The action:
 | `output-json` | `""` | Path for JSON output file. Empty = skip JSON. |
 | `output-html` | `""` | Path for HTML output file. Empty = skip HTML. |
 | `data-url` | `""` | URL to fetch vizb JSON from at runtime (`-U` flag). Accepts a full dataset, a full dataset array, or an automatically detected lazy `[{id,name}]` catalog. When set, no input file is needed. |
-| `vizb-binary` | `""` | Path to a pre-built vizb binary on the runner. When set, skips release download/cache and installs this binary instead — useful for testing local builds or unreleased changes. |
+| `vizb-binary` | `""` | Path to a pre-built vizb binary on the runner. When set, skips version resolution, cache, and release download and installs this binary instead — useful for testing local builds or unreleased changes. |
 
 ## Outputs
 
@@ -267,4 +267,4 @@ Use `vizb-binary` to test unreleased changes without publishing a release. Build
     output-html: pages/index.html
 ```
 
-When `vizb-binary` is set, the action skips version resolution, caching, and the release download — it just installs the binary you provide.
+When `vizb-binary` is set, the action skips version resolution, cache, and the release download — it just installs the binary you provide.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -54,7 +54,7 @@ import LogoAnimation from '../../components/LogoAnimation.astro';
     Interactive UI in one file: sort, swap axes, scale, themes, JPEG export, optional stats. Open it in any browser. See [UI](/ui).
   </Card>
   <Card title="CLI, Action, and API" icon="seti:puppet">
-    Local CLI, composite [GitHub Action](/ci-cd/github-action), and [REST](/commands/serve) for the same pipeline. Merge datasets across runs when you need history.
+    Local CLI, [GitHub Action](/ci-cd/github-action), and [REST](/commands/serve) for the same pipeline. Merge datasets across runs when you need history.
   </Card>
 </CardGrid>
 


### PR DESCRIPTION
## Summary

`@v0` used to skip cache (`is-major=true`) and always download the release archive. The action now resolves the concrete tag, caches `vizb-<tag>-<os>-<arch>`, and skips install on a hit.

- Resolve/install live in `action/resolve.sh` and `action/install.sh`, invoked with `bash` so they run on Linux, macOS, and Windows Git Bash
- Pipeline stays in Node and takes `VIZB_ACTION_INPUTS: ${{ toJSON(inputs) }}` instead of a 34-line `INPUT_*` map
- `vizb-binary` still skips version resolution, cache, and the download

## Test plan

- [x] `node --test action/*.test.mjs` (37 tests)
- [ ] Action CI: `.github/workflows/action-ci.yml` (ubuntu/macos/windows + `vizb-binary`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GitHub Action setup with automatic version resolution and cross-platform binary installation.
  * Cached exact binaries are restored without downloading them again.
  * Local binaries can be installed directly, bypassing version resolution, caching, and release downloads.
  * Major-version references, such as `v0`, resolve to the newest matching release.
* **Documentation**
  * Clarified binary caching, local binary behavior, and supported GitHub Action capabilities.
* **Bug Fixes**
  * Improved handling of action inputs, including multiline values and hyphenated names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->