### PR TITLE
fix(ui): align heatmap visual map with logo green

### DIFF
--- a/docs/src/components/logo-animation/constants.ts
+++ b/docs/src/components/logo-animation/constants.ts
@@ -7,7 +7,7 @@ export const LOGO_COLORS = [
 	'#EE6666',
 ] as const;
 
-export const HEATMAP_LOW = LOGO_COLORS[0];
+export const HEATMAP_LOW = LOGO_COLORS[2];
 export const HEATMAP_HIGH = LOGO_COLORS[4];
 export const GRID_GRAY = '#4a5568';
 

--- a/pkg/style/style_test.go
+++ b/pkg/style/style_test.go
@@ -113,7 +113,7 @@ func (s *ThemeSuite) TestParseThemeSpecDefaultHasColors() {
 		"#5470C6", "#3BA272", "#FC8452", "#73C0DE", "#EE6666",
 		"#FAC858", "#9A60B4", "#EA7CCC", "#91CC75", "#FF9F7F",
 	}, theme.Colors)
-	s.Equal([]string{"#91CC75", "#EE6666"}, theme.VisualMapColors)
+	s.Equal([]string{"#3BA272", "#EE6666"}, theme.VisualMapColors)
 }
 
 func (s *ThemeSuite) TestResolveThemesSkipsDefault() {

--- a/pkg/style/themes.go
+++ b/pkg/style/themes.go
@@ -24,7 +24,7 @@ var themeCatalog = map[string]Theme{
 			"#5470C6", "#3BA272", "#FC8452", "#73C0DE", "#EE6666",
 			"#FAC858", "#9A60B4", "#EA7CCC", "#91CC75", "#FF9F7F",
 		},
-		VisualMapColors: []string{"#91CC75", "#EE6666"},
+		VisualMapColors: []string{"#3BA272", "#EE6666"},
 	},
 	"vintage": {
 		Name: "vintage",

--- a/ui/src/lib/themes.test.ts
+++ b/ui/src/lib/themes.test.ts
@@ -148,7 +148,7 @@ describe('themes', () => {
   })
 
   it("uses the active theme's visualMapColors, with gradient fallback", () => {
-    expect(resolveVisualMapColors('default')).toEqual(['#91CC75', '#EE6666'])
+    expect(resolveVisualMapColors('default')).toEqual(['#3BA272', '#EE6666'])
     registerDatasetThemes([westeros])
     expect(resolveVisualMapColors('westeros')).toEqual(['#59c4e6', '#d58fc4'])
     expect(resolveVisualMapColors('#111,#222,#333')).toEqual(['#111', '#333'])

--- a/ui/src/lib/themes.ts
+++ b/ui/src/lib/themes.ts
@@ -16,7 +16,7 @@ export const DEFAULT_THEME = {
     '#91CC75',
     '#FF9F7F',
   ],
-  visualMapColors: ['#91CC75', '#EE6666'],
+  visualMapColors: ['#3BA272', '#EE6666'],
 } as const satisfies Theme
 
 const HEX_COLOR = /^#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?$/


### PR DESCRIPTION
## Summary

Align the default heatmap visual map with the logo green → red pair used by the docs hero animation.

- Docs logo animation low cells: `#5470C6` → `#3BA272`
- UI default theme visual map: `#91CC75` → `#3BA272`
- CLI default catalog kept in sync (`pkg/style`)
- High remains logo red `#EE6666`

The categorical series palette is unchanged. `#91CC75` is still a series swatch; it is no longer the visual-map start.

## Test plan

- [x] `go test -count=1 ./pkg/style/`
- [x] `pnpm exec vitest run src/lib/themes.test.ts` (UI)
- [x] Lefthook pre-commit: format + `task test:cli` + UI tests + action tests
- [ ] Docs homepage: wait for the heatmap phase of the logo animation
- [ ] Open a heatmap (or scatter visual map) on the default theme and confirm green → red

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the default visual-map color palette, changing the starting color to green for improved visual consistency across the application.
  * Updated logo animation heatmap colors to match the revised palette.

* **Tests**
  * Updated theme and visual-map color checks to reflect the new default color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->