### PR TITLE
feat(cli): split stdin spinner and report collected records

### DIFF
--- a/cmd/cli/pipeline.go
+++ b/cmd/cli/pipeline.go
@@ -227,6 +227,7 @@ func writeStdinPipedInputs(tempfilePath string) {
 	}
 
 	_ = dataSetProgressManager.Finish()
+	logCollectionResult(dataSetProgressManager.dataCount)
 
 	if err := writer.Flush(); err != nil {
 		shared.ExitWithError("Error writing to file", err)
@@ -337,6 +338,16 @@ func warnTitleIgnored(title string) {
 	if title != "" {
 		cliout.Warn("--title only applies when --col-axis produces one chart; ignoring (use --select … (Title) for multi-stat charts)")
 	}
+}
+
+// logCollectionResult prints one completion line after stdin ingest.
+// In-progress work is the green spinner; we do not log a second "Collecting…" line.
+func logCollectionResult(n int) {
+	if n == 0 {
+		return
+	}
+	count := cliout.Accent(fmt.Sprintf("%d", n), cliout.AccentCount)
+	cliout.Info(fmt.Sprintf("Collected %s benchmark records", count))
 }
 
 // logAggregationResult prints one completion line after summing grouped rows.

--- a/cmd/cli/pipeline_test.go
+++ b/cmd/cli/pipeline_test.go
@@ -435,6 +435,45 @@ func (s *PipelineSuite) TestRunLinearAutoParser() {
 	s.FileExists(out)
 }
 
+func (s *PipelineSuite) TestLogCollectionResult() {
+	out := testutil.CaptureStderr(func() {
+		logCollectionResult(12)
+	})
+	s.Contains(out, "Collected")
+	s.Contains(out, "12")
+	s.Contains(out, "benchmark records")
+}
+
+func (s *PipelineSuite) TestLogCollectionResultZeroIsSilent() {
+	out := testutil.CaptureStderr(func() {
+		logCollectionResult(0)
+	})
+	s.Empty(out)
+}
+
+func (s *PipelineSuite) TestWriteStdinPipedInputsLogsCollection() {
+	origStdin := os.Stdin
+	defer func() { os.Stdin = origStdin }()
+
+	stdinFile, err := os.CreateTemp("", "stdin_collect")
+	s.Require().NoError(err)
+	defer os.Remove(stdinFile.Name())
+
+	_, err = stdinFile.WriteString("BenchmarkFoo-8 \t1000\t2000 ns/op\nBenchmarkBar-8 \t1000\t3000 ns/op\n")
+	s.Require().NoError(err)
+	_, err = stdinFile.Seek(0, 0)
+	s.Require().NoError(err)
+	os.Stdin = stdinFile
+
+	outFile := filepath.Join(s.T().TempDir(), "out.txt")
+	out := testutil.CaptureStderr(func() {
+		writeStdinPipedInputs(outFile)
+	})
+	s.Contains(out, "Collected")
+	s.Contains(out, "2")
+	s.Contains(out, "benchmark records")
+}
+
 func (s *PipelineSuite) TestLogAggregationResultCollapsesDuplicates() {
 	cfg := parser.Config{GroupPattern: "x", Group: []string{"region"}}
 	out := testutil.CaptureStderr(func() {

--- a/cmd/cli/progress.go
+++ b/cmd/cli/progress.go
@@ -73,15 +73,15 @@ func NewDataProgressManager(bar ProgressBar) *DataProgressManager {
 }
 
 func (m *DataProgressManager) updateProgress() {
-	// Detail only — the spinner rotates its own activity phrase.
-	// No trailing ellipsis; keep a tight "name · n records" suffix.
+	// Detail only — the spinner paints this on row 2 as "> …".
+	// Name is the current benchmark, so lead with the count.
 	switch {
 	case m.currentDataName != "" && m.dataCount > 0:
-		m.bar.Describe(fmt.Sprintf("%s · %d records", m.currentDataName, m.dataCount))
+		m.bar.Describe(fmt.Sprintf("Collected %d records - %s", m.dataCount, m.currentDataName))
 	case m.currentDataName != "":
 		m.bar.Describe(m.currentDataName)
 	case m.dataCount > 0:
-		m.bar.Describe(fmt.Sprintf("%d records", m.dataCount))
+		m.bar.Describe(fmt.Sprintf("Collected %d records", m.dataCount))
 	default:
 		m.bar.Describe("")
 	}

--- a/cmd/cli/progress_test.go
+++ b/cmd/cli/progress_test.go
@@ -115,7 +115,7 @@ func (s *ProgressSuite) TestUpdateProgress() {
 	s.Len(mockBar.descriptions, 1)
 	s.Contains(mockBar.descriptions[0], "BenchmarkExample")
 	s.Contains(mockBar.descriptions[0], "5 records")
-	s.Equal("BenchmarkExample · 5 records", mockBar.descriptions[0])
+	s.Equal("Collected 5 records - BenchmarkExample", mockBar.descriptions[0])
 }
 
 func (s *ProgressSuite) TestUpdateProgressDefaultEmptyDescribe() {
@@ -243,13 +243,13 @@ func (s *ProgressSuite) TestProcessLineCountOnlyUpdatesProgress() {
 	s.Equal(1, manager.dataCount)
 	s.Equal("", manager.currentDataName)
 	s.Require().Len(mockBar.descriptions, 1)
-	s.Equal("1 records", mockBar.descriptions[0])
+	s.Equal("Collected 1 records", mockBar.descriptions[0])
 
 	// Later name + count uses the combined form.
 	manager.ProcessLine("BenchmarkNamed-8    1000    2000 ns/op")
 	s.Equal(2, manager.dataCount)
 	s.Equal("BenchmarkNamed", manager.currentDataName)
-	s.Equal("BenchmarkNamed · 2 records", mockBar.descriptions[len(mockBar.descriptions)-1])
+	s.Equal("Collected 2 records - BenchmarkNamed", mockBar.descriptions[len(mockBar.descriptions)-1])
 }
 
 func (s *ProgressSuite) TestRealWorldBenchmarkOutput() {

--- a/cmd/cli/spinner.go
+++ b/cmd/cli/spinner.go
@@ -80,11 +80,14 @@ const parseSpinnerDelay = 250 * time.Millisecond
 const (
 	spinnerTick      = 100 * time.Millisecond
 	phraseEveryTicks = 20 // 20 * 100ms = 2.0s
+	ansiHideCursor   = "\033[?25l"
+	ansiShowCursor   = "\033[?25h"
+	ansiCursorUp     = "\033[1A"
 )
 
 // GreenSpinner is a stderr activity spinner. Implements ProgressBar so
-// DataProgressManager can drive a detail suffix while the verb phrase rotates
-// and the line shimmers green.
+// DataProgressManager can drive a second-row detail while the verb phrase
+// rotates and shimmers green on its own row.
 type GreenSpinner struct {
 	mu       sync.Mutex
 	w        io.Writer
@@ -93,6 +96,7 @@ type GreenSpinner struct {
 	phrases  []string
 	frame    int
 	tick     int
+	rows     int // 1 or 2; last painted height
 	stop     chan struct{}
 	done     chan struct{}
 	active   bool // painting allowed (after Delay)
@@ -154,7 +158,7 @@ func startSpinner(w io.Writer, delay time.Duration, phrases []string) *GreenSpin
 	return s
 }
 
-// Describe sets the optional detail suffix (benchmark name, record count).
+// Describe sets the optional second-row detail (benchmark name, record count).
 func (s *GreenSpinner) Describe(detail string) {
 	s.mu.Lock()
 	s.detail = detail
@@ -164,7 +168,7 @@ func (s *GreenSpinner) Describe(detail string) {
 	}
 }
 
-// Finish stops the spinner and clears the activity line when it was visible.
+// Finish stops the spinner and clears the activity line(s) when they were visible.
 func (s *GreenSpinner) Finish() error {
 	s.mu.Lock()
 	if s.finished {
@@ -179,7 +183,16 @@ func (s *GreenSpinner) Finish() error {
 	close(s.stop)
 	<-s.done
 	if wasActive {
-		_, _ = fmt.Fprint(s.w, "\r\033[K")
+		s.mu.Lock()
+		rows := s.rows
+		s.mu.Unlock()
+		// After a 2-row paint the cursor is parked on the activity row.
+		if rows == 2 {
+			_, _ = fmt.Fprint(s.w, "\r\033[K\n\033[K"+ansiCursorUp)
+		} else {
+			_, _ = fmt.Fprint(s.w, "\r\033[K")
+		}
+		_, _ = fmt.Fprint(s.w, ansiShowCursor)
 	}
 	return nil
 }
@@ -241,16 +254,39 @@ func (s *GreenSpinner) paint() {
 	if !s.active {
 		return
 	}
+
+	_, _ = fmt.Fprint(s.w, ansiHideCursor)
+
 	// Width(2) keeps glyph + phrase baseline aligned in mono fonts.
 	glyph := s.style.Width(2).Render(spinnerFrames[s.frame])
-	line := s.phrase
-	if s.detail != "" {
-		line = s.phrase + " · " + s.detail
-	}
+	phrase := s.phrase
 	if s.color {
-		line = gradientText(line, s.tick, s.render)
+		phrase = gradientText(phrase, s.tick, s.render)
 	}
-	_, _ = fmt.Fprintf(s.w, "\r\033[K%s%s", glyph, line)
+	_, _ = fmt.Fprintf(s.w, "\r\033[K%s%s", glyph, phrase)
+
+	if s.detail != "" {
+		mark := ">"
+		if s.color {
+			mark = s.style.Render(">")
+		}
+		// Park on the activity row so the cursor never sits on "> …" between ticks.
+		_, _ = fmt.Fprintf(s.w, "\n\033[K%s %s%s", mark, s.detail, ansiCursorUp)
+		s.rows = 2
+		return
+	}
+
+	if s.rows == 2 {
+		// Cursor is already on row 1. Clear leftover row 2 and stay put.
+		_, _ = fmt.Fprint(s.w, "\n\033[K"+ansiCursorUp)
+	}
+	s.rows = 1
+}
+
+// gradientStopIndex maps rune i at animation phase to a stop. Subtracting
+// phase walks the highlight toward higher indices (left → right).
+func gradientStopIndex(i, phase, n int) int {
+	return ((i-phase)%n + n) % n
 }
 
 func gradientText(text string, phase int, r *lipgloss.Renderer) string {
@@ -258,13 +294,13 @@ func gradientText(text string, phase int, r *lipgloss.Renderer) string {
 		return text
 	}
 	runes := []rune(text)
+	n := len(greenGradientStops)
 	var b strings.Builder
 	b.Grow(len(runes) * 12)
 	for i, ch := range runes {
-		stop := (i + phase) % len(greenGradientStops)
 		st := lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color(greenGradientStops[stop]))
+			Foreground(lipgloss.Color(greenGradientStops[gradientStopIndex(i, phase, n)]))
 		if r != nil {
 			st = st.Renderer(r)
 		}

--- a/cmd/cli/spinner_test.go
+++ b/cmd/cli/spinner_test.go
@@ -24,7 +24,7 @@ type SpinnerSuite struct {
 func (s *SpinnerSuite) TestFinishOnNonTTYIsNoop() {
 	var buf bytes.Buffer
 	sp := NewGreenSpinner(&buf)
-	sp.Describe("BenchmarkX · 3 records")
+	sp.Describe("Collected 3 records - BenchmarkX")
 	s.NoError(sp.Finish())
 	s.False(sp.tty)
 	s.Empty(buf.String())
@@ -33,9 +33,9 @@ func (s *SpinnerSuite) TestFinishOnNonTTYIsNoop() {
 func (s *SpinnerSuite) TestDescribeAndPhrases() {
 	var buf bytes.Buffer
 	sp := NewGreenSpinner(&buf)
-	sp.Describe("BenchmarkX · 3 records")
+	sp.Describe("Collected 3 records - BenchmarkX")
 	sp.mu.Lock()
-	s.Equal("BenchmarkX · 3 records", sp.detail)
+	s.Equal("Collected 3 records - BenchmarkX", sp.detail)
 	s.NotEmpty(sp.phrase)
 	s.NotContains(sp.phrase, "…")
 	sp.mu.Unlock()
@@ -83,6 +83,15 @@ func (s *SpinnerSuite) TestGradientTextShiftsWithPhase() {
 	s.NotEqual(a, b)
 	s.Contains(a, "\x1b[")
 	s.Equal("", gradientText("", 0, nil))
+}
+
+func (s *SpinnerSuite) TestGradientMovesLeftToRight() {
+	n := len(greenGradientStops)
+	s.Equal(0, gradientStopIndex(0, 0, n))
+	// The color on rune 0 at phase 0 is on rune 1 at phase 1 (band walks right).
+	s.Equal(gradientStopIndex(0, 0, n), gradientStopIndex(1, 1, n))
+	s.Equal(gradientStopIndex(0, 0, n), gradientStopIndex(2, 2, n))
+	s.NotEqual(gradientStopIndex(0, 0, n), gradientStopIndex(0, 1, n))
 }
 
 func (s *SpinnerSuite) TestFinishIdempotent() {
@@ -145,13 +154,42 @@ func (s *SpinnerSuite) forcedTTYSpinner(w io.Writer, color bool) *GreenSpinner {
 func (s *SpinnerSuite) TestPaintActiveWritesLine() {
 	var buf bytes.Buffer
 	sp := s.forcedTTYSpinner(&buf, false)
-	sp.detail = "BenchmarkX · 2 records"
+	sp.detail = "Collected 2 records - BenchmarkX"
 	sp.paint()
 	out := buf.String()
 	s.Contains(out, "\r\033[K")
 	s.Contains(out, "Parsing")
-	s.Contains(out, "BenchmarkX · 2 records")
-	s.Contains(out, " · ")
+	s.Contains(out, "Collected 2 records - BenchmarkX")
+	s.Contains(out, "\n")
+	s.Contains(out, "> ")
+	s.NotContains(out, "Parsing · ")
+	s.Contains(out, "\033[?25l")
+	s.True(bytes.HasSuffix([]byte(out), []byte("\033[1A")), "cursor must park on the activity row")
+	s.NoError(sp.Finish())
+	s.Contains(buf.String(), "\033[?25h")
+}
+
+func (s *SpinnerSuite) TestPaintWithoutDetailIsSingleRow() {
+	var buf bytes.Buffer
+	sp := s.forcedTTYSpinner(&buf, false)
+	sp.paint()
+	out := buf.String()
+	s.Contains(out, "\r\033[K")
+	s.Contains(out, "Parsing")
+	s.NotContains(out, "\n")
+	s.NotContains(out, ">")
+	s.NoError(sp.Finish())
+}
+
+func (s *SpinnerSuite) TestPaintClearsSecondRowWhenDetailRemoved() {
+	var buf bytes.Buffer
+	sp := s.forcedTTYSpinner(&buf, false)
+	sp.detail = "Collected 1 records - BenchmarkX"
+	sp.paint()
+	sp.detail = ""
+	sp.paint()
+	out := buf.String()
+	s.Contains(out, "\033[1A")
 	s.NoError(sp.Finish())
 }
 
@@ -210,8 +248,33 @@ func (s *SpinnerSuite) TestFinishClearsWhenWasActive() {
 	}()
 	s.NoError(sp.Finish())
 	s.Contains(buf.String(), "\r\033[K")
+	s.NotContains(buf.String(), "\033[1A")
 	// Second Finish is idempotent.
 	s.NoError(sp.Finish())
+}
+
+func (s *SpinnerSuite) TestFinishClearsTwoRows() {
+	var buf bytes.Buffer
+	sp := &GreenSpinner{
+		w:       &buf,
+		stop:    make(chan struct{}),
+		done:    make(chan struct{}),
+		tty:     true,
+		active:  true,
+		rows:    2,
+		phrases: []string{"Reading"},
+		phrase:  "Reading",
+		rng:     rand.New(rand.NewSource(1)),
+		style:   lipgloss.NewStyle(),
+	}
+	go func() {
+		<-sp.stop
+		close(sp.done)
+	}()
+	s.NoError(sp.Finish())
+	out := buf.String()
+	s.Contains(out, "\033[1A")
+	s.Equal(2, bytes.Count([]byte(out), []byte("\033[K")))
 }
 
 func (s *SpinnerSuite) TestRotatePhraseLockedSkipsCurrent() {


### PR DESCRIPTION
## Summary

Piped Go benchmark ingest (`go test -bench . | vizb`) used to paint everything on one live TTY line, with the green shimmer walking right to left and the caret sitting on the status text:

```text
● Collecting · BenchmarkFib · 3 records
```

This splits the live frame, reverses the shimmer, and adds a completion line after stdin is fully read.

### Live frame (TTY only)

```text
● Collecting
> Collected 3 records - BenchmarkFib
```

- Row 1 is the spinner glyph + rotating phrase. The gradient highlight now walks **left → right**, and only the phrase shimmers.
- Row 2 appears once a name and/or `ns/op` count exists. Copy is `Collected n records - name` (count-only is `Collected n records`; name-only stays just the name).
- The terminal cursor is hidden while the spinner is active and restored on `Finish`. After each two-row paint the cursor is parked back on the activity row so the caret does not flicker on `> …`.
- Parse / aggregate spinners stay one row. Piped CSV/JSON with no `ns/op` lines never opens the second row.

### After ingest

The spinner is cleared, then:

```text
> Collected 3 benchmark records
```

Silent when the count is 0 (non-bench stdin). The number uses the same accent as aggregation logs.

## Implementation notes

- `GreenSpinner` tracks painted height (1 or 2). Detail is no longer concatenated onto the phrase with ` · `.
- Two-row `Finish` clears both lines; cursor is assumed parked on the activity row after a 2-row paint.
- `gradientStopIndex` uses `i - phase` so the highlight travels toward higher rune indices.
- `logCollectionResult` is the ingest counterpart of `logAggregationResult`.

## Test plan

- [x] `go test -count=1 ./cmd/cli/`
- [x] Lefthook pre-commit (`format` + full `go-test`)
- [ ] Manual TTY check: `go test -bench=. ./some/pkg | ./bin/vizb` — confirm LTR shimmer, two-row layout, no caret on the `>` line, and the final collected-count log
- [ ] Pipe a small CSV/JSON payload and confirm no second row and no “Collected 0 …” line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved command-line progress displays with clearer record counts and benchmark names.
  * Added completion messages showing how many benchmark records were collected from piped input.
  * Enhanced spinner rendering with separate activity and detail lines, improved animation, and cleaner screen updates.
* **Bug Fixes**
  * Prevented unnecessary completion messages when no records are collected.
  * Improved cleanup of progress output when details change or collection finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->