### PR TITLE
ci: cache embed UI gen across workflows

### DIFF
--- a/.github/actions/setup-embed-ui/action.yml
+++ b/.github/actions/setup-embed-ui/action.yml
@@ -1,20 +1,31 @@
 name: Setup embed UI
-description: Install UI deps and generate pkg/template/vizb-ui.gen.go for Go build/test
+description: Restore or generate pkg/template/vizb-ui.gen.go for Go build/test
 
 runs:
   using: composite
   steps:
+    - name: Restore embed UI
+      id: embed-cache
+      uses: actions/cache@v6
+      with:
+        path: pkg/template/vizb-ui.gen.go
+        key: embed-ui-${{ github.sha }}
+        enableCrossOsArchive: true
+
     - name: Setup Node and pnpm
+      if: steps.embed-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/setup-js
       with:
         cache-dependency-path: ui/pnpm-lock.yaml
 
     - name: Install UI dependencies
+      if: steps.embed-cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ui
       run: pnpm install --frozen-lockfile
 
     - name: Build embed UI
+      if: steps.embed-cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ui
       run: pnpm build:embed

--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -14,6 +14,10 @@ on:
         options: [build, released]
         default: build
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   # Fast gate: Node unit tests before multi-OS action runs.
   unit:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -33,6 +33,18 @@ permissions:
   actions: write
 
 jobs:
+  embed:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-slim
+    concurrency:
+      group: embed-ui-${{ github.sha }}
+      queue: max
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Rebuild embed for PR
+        uses: ./.github/actions/setup-embed-ui
+
   # Feature branches must not land gen churn; main is owned by sync-embed-ui.
   forbid-gen-commit:
     if: github.event_name == 'pull_request'
@@ -57,6 +69,8 @@ jobs:
           echo "OK: gen file not modified in this PR"
 
   lint:
+    needs: [embed]
+    if: ${{ !cancelled() && (needs.embed.result == 'success' || needs.embed.result == 'skipped') }}
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7
@@ -96,6 +110,8 @@ jobs:
           fi
 
   test:
+    needs: [embed]
+    if: ${{ !cancelled() && (needs.embed.result == 'success' || needs.embed.result == 'skipped') }}
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -13,6 +13,7 @@ on:
       - action/**
       - .github/workflows/action-ci.yml
       - .github/workflows/cli.yml
+      - .github/workflows/embed-ui.yml
       - .github/actions/setup-embed-ui/**
   pull_request:
     branches: [main]
@@ -26,6 +27,7 @@ on:
       - action/**
       - .github/workflows/action-ci.yml
       - .github/workflows/cli.yml
+      - .github/workflows/embed-ui.yml
       - .github/actions/setup-embed-ui/**
 
 permissions:
@@ -35,15 +37,10 @@ permissions:
 jobs:
   embed:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-slim
-    concurrency:
-      group: embed-ui-${{ github.sha }}
-      queue: max
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Rebuild embed for PR
-        uses: ./.github/actions/setup-embed-ui
+    uses: ./.github/workflows/embed-ui.yml
+    permissions:
+      contents: read
+      actions: write
 
   # Feature branches must not land gen churn; main is owned by sync-embed-ui.
   forbid-gen-commit:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -30,6 +30,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   # Feature branches must not land gen churn; main is owned by sync-embed-ui.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,8 +10,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  embed:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      actions: write
+    concurrency:
+      group: embed-ui-${{ github.sha }}
+      queue: max
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Generate embedded UI
+        uses: ./.github/actions/setup-embed-ui
+
   analyze:
     name: Analyze (${{ matrix.language }})
+    needs: [embed]
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,18 +11,10 @@ on:
 
 jobs:
   embed:
-    runs-on: ubuntu-slim
+    uses: ./.github/workflows/embed-ui.yml
     permissions:
       contents: read
       actions: write
-    concurrency:
-      group: embed-ui-${{ github.sha }}
-      queue: max
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Generate embedded UI
-        uses: ./.github/actions/setup-embed-ui
 
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
-      actions: read
+      actions: write
       contents: read
       packages: read
       security-events: write

--- a/.github/workflows/embed-ui.yml
+++ b/.github/workflows/embed-ui.yml
@@ -1,0 +1,20 @@
+name: Embed UI
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-slim
+    concurrency:
+      group: embed-ui-${{ github.sha }}
+      queue: max
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup embed UI
+        uses: ./.github/actions/setup-embed-ui

--- a/.github/workflows/sync-embed-ui.yml
+++ b/.github/workflows/sync-embed-ui.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/sync-embed-ui.yml
+++ b/.github/workflows/sync-embed-ui.yml
@@ -24,6 +24,7 @@ on:
       - "ui/pnpm-lock.yaml"
       - ".github/actions/setup-embed-ui/**"
       - ".github/actions/setup-js/**"
+      - ".github/workflows/embed-ui.yml"
       - ".github/workflows/sync-embed-ui.yml"
 
 concurrency:
@@ -34,7 +35,14 @@ permissions:
   contents: read
 
 jobs:
+  embed:
+    uses: ./.github/workflows/embed-ui.yml
+    permissions:
+      contents: read
+      actions: write
+
   generate:
+    needs: [embed]
     runs-on: ubuntu-slim
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- cache `pkg/template/vizb-ui.gen.go` in `setup-embed-ui` with key `embed-ui-${{ github.sha }}`
- skip Node, pnpm install, and `pnpm build:embed` on a cache hit
- enable cross-OS restore so action-ci Windows/macOS reuse the Ubuntu file
- grant `actions: write` on workflows that call the composite so a miss can save

Later jobs and workflows on the same SHA restore instead of rebuilding. First parallel jobs on a new SHA may all miss; the first successful save wins.

## Test Plan

- [ ] On this PR, the first `setup-embed-ui` for the SHA shows a cache miss and a Vue embed build
- [ ] Later jobs on the same SHA (CLI test, action-ci matrix, CodeQL Go) show a cache hit and skip Node
- [ ] Re-run a job on the same SHA and confirm it still hits
- [ ] Confirm main-style / non-PR CLI still uses tracked gen (no rebuild step)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Embedded UI assets can now be restored from a cache, reducing repeated generation during automated builds.
  * Automated workflows have updated permissions to support required action and asset operations.
  * CI, command-line, security analysis, and UI synchronization workflows continue running with their existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->