### PR TITLE
ci: rebuild embed UI on push

### DIFF
--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -44,10 +44,10 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      # PRs and manual dispatch: rebuild so action tests see current ui/.
-      # workflow_call from main/release: tracked gen is enough.
-      - name: Rebuild embed for PR or dispatch
-        if: env.ACT != 'true' && inputs.binary == 'build' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+      # Rebuild so action tests see current ui/ without waiting for
+      # sync-embed-ui to commit the tracked gen (that workflow can lag).
+      - name: Rebuild embed
+        if: env.ACT != 'true' && inputs.binary == 'build'
         uses: ./.github/actions/setup-embed-ui
 
       - name: Build vizb
@@ -87,8 +87,8 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Rebuild embed for PR or dispatch
-        if: env.ACT != 'true' && inputs.binary == 'build' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+      - name: Rebuild embed
+        if: env.ACT != 'true' && inputs.binary == 'build'
         uses: ./.github/actions/setup-embed-ui
 
       - name: Build vizb

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
     paths:
       - '**.go'
+      - 'ui/**'
       - go.mod
       - go.sum
       - .goreleaser.yml
@@ -36,7 +37,6 @@ permissions:
 
 jobs:
   embed:
-    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/embed-ui.yml
     permissions:
       contents: read
@@ -72,10 +72,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # PRs: ephemeral re-embed so CLI tests see unmerged ui/ changes.
-      # main / release (workflow_call): use tracked gen (sync-embed-ui keeps main current).
-      - name: Rebuild embed for PR
-        if: github.event_name == 'pull_request'
+      # Ephemeral re-embed so CLI jobs see current ui/ without waiting for
+      # sync-embed-ui to commit the tracked gen (that workflow can lag).
+      - name: Rebuild embed
         uses: ./.github/actions/setup-embed-ui
 
       - uses: actions/setup-go@v7
@@ -113,8 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Rebuild embed for PR
-        if: github.event_name == 'pull_request'
+      - name: Rebuild embed
         uses: ./.github/actions/setup-embed-ui
 
       - uses: actions/setup-go@v7


### PR DESCRIPTION
## Summary

- Rebuild the Vue embed on push (not only PRs) so CLI lint/test and action CI see current `ui/` without waiting for `sync-embed-ui` to commit `vizb-ui.gen.go`
- Always run the CLI `embed` producer so later jobs restore the SHA-keyed cache
- Add `ui/**` to CLI push paths so a UI-only merge starts CLI immediately

`sync-embed-ui` remains the sole writer of the tracked gen file on main.

## Test Plan

- [ ] On this PR, CLI still rebuilds the embed and later jobs hit `embed-ui-${{ github.sha }}`
- [ ] After merge, a UI-only push to main starts CLI (path filter) and rebuilds before the bot gen commit lands
- [ ] A mixed UI + Go push tests the rebuilt embed, not the previous tracked snapshot
- [ ] `sync-embed-ui` still commits `pkg/template/vizb-ui.gen.go` when `ui/` changes