### PR TITLE
feat(api): accept background on BarChartConfig

### DIFF
--- a/api/openapi_test.go
+++ b/api/openapi_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -214,6 +215,63 @@ func (s *OpenAPISuite) TestLineAndScatterSymbolsMatchServerValidation() {
 			}
 			s.Error(validateSchema(contract, schema, map[string]any{"type": strings.TrimSuffix(strings.ToLower(schemaName), "chartconfig"), "symbol": "star"}, schemaName))
 		})
+	}
+}
+
+// TestBarBackgroundMatchesServerValidation keeps the BarChartConfig.background
+// schema and the server's strict decode in lockstep: every background the
+// schema accepts unmarshals into the Go wire type, and every background it
+// rejects also fails the server decode (request error, not a 500).
+func (s *OpenAPISuite) TestBarBackgroundMatchesServerValidation() {
+	contract := readContract(s.T())
+	schemas := mustMap(s.T(), mustMap(s.T(), contract["components"], "components")["schemas"], "components.schemas")
+	schema := schemas["BarChartConfig"]
+
+	valid := []map[string]any{
+		{"active": true},
+		{"active": false},
+		{},
+		{
+			"active": true, "color": "rgba(180, 180, 180, 0.2)", "borderColor": "#000",
+			"borderWidth": 0, "borderType": "solid", "shadowBlur": 10,
+			"shadowColor": "rgba(0, 0, 0, 0.5)", "shadowOffsetX": -2, "shadowOffsetY": 2.5,
+			"opacity": 1,
+		},
+		{"active": true, "borderRadius": 8},
+		{"active": true, "borderRadius": []any{8, 8, 0, 0}},
+	}
+	for _, background := range valid {
+		config := map[string]any{"type": "bar", "background": background}
+		s.NoError(validateSchema(contract, schema, config, "BarChartConfig"), fmt.Sprint(background))
+		raw, err := json.Marshal(config)
+		s.Require().NoError(err)
+		s.NoError(json.Unmarshal(raw, &bar.Config{}), string(raw))
+	}
+
+	invalid := []map[string]any{
+		{"decal": 1},
+		{"active": "yes"},
+		{"color": 5},
+		{"borderType": "dash"},
+		{"borderWidth": -1},
+		{"shadowBlur": -0.5},
+		{"opacity": 1.5},
+		{"opacity": -0.1},
+		{"opacity": "0.5"},
+		{"borderWidth": "2"},
+		{"borderRadius": 8.5},
+		{"borderRadius": -1},
+		{"borderRadius": "8"},
+		{"borderRadius": []any{8, "8"}},
+		{"borderRadius": []any{8, 8, 0, 0, 1}},
+		{"borderRadius": []any{-1}},
+	}
+	for _, background := range invalid {
+		config := map[string]any{"type": "bar", "background": background}
+		s.Error(validateSchema(contract, schema, config, "BarChartConfig"), fmt.Sprint(background))
+		raw, err := json.Marshal(config)
+		s.Require().NoError(err)
+		s.Error(json.Unmarshal(raw, &bar.Config{}), string(raw))
 	}
 }
 
@@ -439,6 +497,9 @@ func validateSchema(root map[string]any, rawSchema, value any, location string) 
 		if min, ok := schema["minItems"].(int); ok && len(array) < min {
 			return fmt.Errorf("%s has %d items, want at least %d", location, len(array), min)
 		}
+		if max, ok := schema["maxItems"].(int); ok && len(array) > max {
+			return fmt.Errorf("%s has %d items, want at most %d", location, len(array), max)
+		}
 		if child, exists := schema["items"]; exists {
 			for i, childValue := range array {
 				if err := validateSchema(root, child, childValue, location+"/"+strconv.Itoa(i)); err != nil {
@@ -473,14 +534,51 @@ func validateSchema(root map[string]any, rawSchema, value any, location string) 
 		default:
 			return fmt.Errorf("%s must be an integer, got %T", location, value)
 		}
+		if err := validateNumericBounds(schema, value, location); err != nil {
+			return err
+		}
 	case "number":
 		switch value.(type) {
 		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
 		default:
 			return fmt.Errorf("%s must be a number, got %T", location, value)
 		}
+		if err := validateNumericBounds(schema, value, location); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+// validateNumericBounds enforces the minimum/maximum keywords for integer and
+// number schemas (JSON numbers arrive from YAML examples as int or float64).
+func validateNumericBounds(schema map[string]any, value any, location string) error {
+	number, ok := numericValue(value)
+	if !ok {
+		return nil
+	}
+	if min, ok := numericValue(schema["minimum"]); ok && number < min {
+		return fmt.Errorf("%s = %v is less than minimum %v", location, number, min)
+	}
+	if max, ok := numericValue(schema["maximum"]); ok && number > max {
+		return fmt.Errorf("%s = %v is greater than maximum %v", location, number, max)
+	}
+	return nil
+}
+
+func numericValue(value any) (float64, bool) {
+	switch v := value.(type) {
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case float64:
+		return v, true
+	default:
+		return 0, false
+	}
 }
 
 func dereference(root map[string]any, raw any) (any, error) {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -703,6 +703,165 @@ func (s *ServeSuite) TestConvertEndpointValidatesStructuredOptions() {
 	}
 }
 
+// TestConvertEndpointBarBackgroundRoundTrip covers the REST wire for the bar
+// category background: a valid object persists onto Dataset settings,
+// active:false / an omitted background leave it off, and a scalar borderRadius
+// normalises to the array form.
+func (s *ServeSuite) TestConvertEndpointBarBackgroundRoundTrip() {
+	handler := newRESTHandler()
+
+	s.Run("styled background persists onto settings", func() {
+		body := `{"input":"region,value\nwest,12\n","parser":"csv","charts":{"types":["bar"],"configs":[{"type":"bar","background":{` +
+			`"active":true,"color":"rgba(180, 180, 180, 0.2)","borderColor":"#000","borderWidth":0,"borderType":"solid",` +
+			`"shadowBlur":10,"shadowColor":"rgba(0, 0, 0, 0.5)","shadowOffsetX":-2,"shadowOffsetY":2.5,"opacity":0.8}}]}}`
+		recorder := s.apiRequest(handler, "/", body, "application/json", "application/json")
+		s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+
+		background, ok := s.responseBackground(recorder)
+		s.Require().True(ok, "expected a background object on settings")
+		s.Equal(true, background["active"])
+		s.Equal("rgba(180, 180, 180, 0.2)", background["color"])
+		s.Equal("#000", background["borderColor"])
+		s.Equal(float64(0), background["borderWidth"])
+		s.Equal("solid", background["borderType"])
+		s.Equal(float64(10), background["shadowBlur"])
+		s.Equal("rgba(0, 0, 0, 0.5)", background["shadowColor"])
+		s.Equal(float64(-2), background["shadowOffsetX"])
+		s.Equal(float64(2.5), background["shadowOffsetY"])
+		s.Equal(float64(0.8), background["opacity"])
+	})
+
+	s.Run("scalar borderRadius normalises to array", func() {
+		body := `{"input":"region,value\nwest,12\n","parser":"csv","charts":{"types":["bar"],"configs":[{"type":"bar","background":{"active":true,"borderRadius":8}}]}}`
+		recorder := s.apiRequest(handler, "/", body, "application/json", "application/json")
+		s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+
+		background, ok := s.responseBackground(recorder)
+		s.Require().True(ok)
+		s.Equal([]any{float64(8)}, background["borderRadius"])
+	})
+
+	s.Run("active false stays off but persists", func() {
+		body := `{"input":"region,value\nwest,12\n","parser":"csv","charts":{"types":["bar"],"configs":[{"type":"bar","background":{"active":false,"color":"#fff"}}]}}`
+		recorder := s.apiRequest(handler, "/", body, "application/json", "application/json")
+		s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+		s.Contains(recorder.Body.String(), `"background":{"active":false,"color":"#fff"}`)
+	})
+
+	s.Run("omitted background leaves no field", func() {
+		body := `{"input":"region,value\nwest,12\n","parser":"csv","charts":{"types":["bar"]}}`
+		recorder := s.apiRequest(handler, "/", body, "application/json", "application/json")
+		s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+		s.NotContains(recorder.Body.String(), "background")
+	})
+}
+
+// responseBackground extracts settings[0].background from a Dataset response.
+func (s *ServeSuite) responseBackground(recorder *httptest.ResponseRecorder) (map[string]any, bool) {
+	var dataset struct {
+		Settings []map[string]any `json:"settings"`
+	}
+	s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &dataset))
+	s.Require().Len(dataset.Settings, 1)
+	background, ok := dataset.Settings[0]["background"].(map[string]any)
+	return background, ok
+}
+
+// TestUIEndpointBarBackgroundRoundTrip covers POST /ui: the config's
+// background round-trips onto the materialised Dataset settings for the UI,
+// and a background without active stays off.
+func (s *ServeSuite) TestUIEndpointBarBackgroundRoundTrip() {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleUIWithGenerator(w, r, func(datasets []shared.Dataset, charts []string) (string, error) {
+			background := s.settingBackground(datasets)
+			s.True(background["active"].(bool))
+			s.Equal(0.2, background["opacity"])
+			return "<html>ok</html>", nil
+		})
+	})
+	body := `{"datasets":` + validDatasetJSON + `,"charts":{"types":["bar"],"configs":[{"type":"bar","background":{"active":true,"opacity":0.2}}]}}`
+	recorder := s.apiRequest(handler, "/ui", body, "application/json", "text/html")
+	s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+
+	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleUIWithGenerator(w, r, func(datasets []shared.Dataset, charts []string) (string, error) {
+			background := s.settingBackground(datasets)
+			active, _ := background["active"].(bool)
+			s.False(active, "background without active must stay off")
+			return "<html>ok</html>", nil
+		})
+	})
+	body = `{"datasets":` + validDatasetJSON + `,"charts":{"configs":[{"type":"bar","background":{"opacity":0.2}}]}}`
+	recorder = s.apiRequest(handler, "/ui", body, "application/json", "text/html")
+	s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+}
+
+// settingBackground marshals settings[0] and returns its background object.
+func (s *ServeSuite) settingBackground(datasets []shared.Dataset) map[string]any {
+	s.Require().Len(datasets, 1)
+	s.Require().Len(datasets[0].Settings, 1)
+	raw, err := json.Marshal(datasets[0].Settings[0])
+	s.Require().NoError(err)
+	var config map[string]any
+	s.Require().NoError(json.Unmarshal(raw, &config))
+	background, _ := config["background"].(map[string]any)
+	s.Require().NotNil(background)
+	return background
+}
+
+// TestConvertEndpointRejectsInvalidBackground confirms malformed background
+// objects are request errors (422), never 500s.
+func (s *ServeSuite) TestConvertEndpointRejectsInvalidBackground() {
+	handler := newRESTHandler()
+	for _, test := range []struct {
+		name string
+		body string
+	}{
+		{name: "unknown field", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","background":{"decal":1}}]}}`},
+		{name: "background not object", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","background":true}]}}`},
+		{name: "null background", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","background":null}]}}`},
+		{name: "active wrong type", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","background":{"active":"yes"}}]}}`},
+		{name: "color wrong type", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","background":{"color":5}}]}}`},
+		{name: "borderType enum", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","background":{"borderType":"dash"}}]}}`},
+		{name: "borderWidth negative", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","background":{"borderWidth":-1}}]}}`},
+		{name: "opacity above one", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","background":{"opacity":1.5}}]}}`},
+		{name: "opacity not number", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","background":{"opacity":"0.5"}}]}}`},
+		{name: "borderRadius quoted number", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","background":{"borderRadius":"8"}}]}}`},
+		{name: "borderRadius quoted array element", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","background":{"borderRadius":[8,"8"]}}]}}`},
+		{name: "borderRadius float", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","background":{"borderRadius":8.5}}]}}`},
+		{name: "borderRadius negative array", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","background":{"borderRadius":[8,-1]}}]}}`},
+		{name: "borderRadius too many", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","background":{"borderRadius":[1,2,3,4,5]}}]}}`},
+		{name: "background on line", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"line","background":{"active":true}}]}}`},
+	} {
+		s.Run(test.name, func() {
+			recorder := s.apiRequest(handler, "/", test.body, "application/json", "application/json")
+			s.Equal(http.StatusUnprocessableEntity, recorder.Code, recorder.Body.String())
+			var problem struct {
+				Errors []apiValidationError `json:"errors"`
+			}
+			s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &problem))
+			s.NotEmpty(problem.Errors)
+		})
+	}
+}
+
+// TestConvertEndpointBackgroundInapplicableOn3D keeps REST consistent with the
+// CLI: the rule warning for a 3D bar becomes a 422 pointing at the config.
+func (s *ServeSuite) TestConvertEndpointBackgroundInapplicableOn3D() {
+	handler := newRESTHandler()
+	body := `{"input":"x,y,z\n1,2,3\n","charts":{"configs":[{"type":"bar","background":{"active":true}}]}}`
+	recorder := s.apiRequest(handler, "/", body, "application/json", "application/json")
+	s.Equal(http.StatusUnprocessableEntity, recorder.Code, recorder.Body.String())
+
+	var problem struct {
+		Errors []apiValidationError `json:"errors"`
+	}
+	s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &problem))
+	s.Require().Len(problem.Errors, 1)
+	s.Equal("/charts/configs/0/background", problem.Errors[0].Path)
+	s.Equal("inapplicable_option", problem.Errors[0].Code)
+}
+
 func (s *ServeSuite) TestConvertEndpointReportsUIGenerationFailure() {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		handleConvertWithGenerator(w, r, func([]shared.Dataset, []string) (string, error) {

--- a/shared/background.go
+++ b/shared/background.go
@@ -1,5 +1,13 @@
 package shared
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
 // Background is the bar category background: one wire object folding ECharts
 // showBackground (Active) and backgroundStyle (the style fields). Active is
 // the on-switch; every style field is optional and maps straight onto the
@@ -17,4 +25,200 @@ type Background struct {
 	ShadowOffsetX *float64      `json:"shadowOffsetX,omitempty"`
 	ShadowOffsetY *float64      `json:"shadowOffsetY,omitempty"`
 	Opacity       *float64      `json:"opacity,omitempty"`
+}
+
+// UnmarshalJSON accepts only the known style keys with their declared types
+// and ranges, so a strict decode of a chart config validates the object for
+// free: active is a boolean; colors are strings; borderWidth/shadowBlur are
+// numbers ≥ 0; borderType is solid|dashed|dotted; borderRadius is a
+// non-negative integer or 1–4 of them; shadow offsets are numbers; opacity is
+// 0..1. Unknown fields are rejected. Quoted JSON numbers are rejected so
+// the REST decode stays as strict as the OpenAPI schema.
+func (b *Background) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &fields); err != nil {
+		return fmt.Errorf("background: must be a JSON object")
+	}
+
+	out := Background{}
+	for _, key := range sortedRawKeys(fields) {
+		if err := decodeBackgroundField(key, fields[key], &out); err != nil {
+			return err
+		}
+	}
+	*b = out
+	return nil
+}
+
+func decodeBackgroundField(key string, raw json.RawMessage, out *Background) error {
+	path := "background." + key
+	switch key {
+	case "active":
+		b, err := decodeBackgroundBool(raw)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		out.Active = b
+	case "color", "borderColor", "shadowColor":
+		s, err := decodeBackgroundString(raw)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		switch key {
+		case "color":
+			out.Color = s
+		case "borderColor":
+			out.BorderColor = s
+		default:
+			out.ShadowColor = s
+		}
+	case "borderType":
+		s, err := decodeBackgroundString(raw)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		switch s {
+		case "solid", "dashed", "dotted":
+		default:
+			return fmt.Errorf("%s %q must be solid, dashed, or dotted", path, s)
+		}
+		out.BorderType = s
+	case "borderWidth", "shadowBlur":
+		n, err := decodeBackgroundNumber(raw)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		if n < 0 {
+			return fmt.Errorf("%s must be non-negative (>= 0), got %s", path, trimmedRaw(raw))
+		}
+		v := n
+		if key == "borderWidth" {
+			out.BorderWidth = &v
+		} else {
+			out.ShadowBlur = &v
+		}
+	case "shadowOffsetX", "shadowOffsetY":
+		n, err := decodeBackgroundNumber(raw)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		v := n
+		if key == "shadowOffsetX" {
+			out.ShadowOffsetX = &v
+		} else {
+			out.ShadowOffsetY = &v
+		}
+	case "opacity":
+		n, err := decodeBackgroundNumber(raw)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		if n < 0 || n > 1 {
+			return fmt.Errorf("%s must be between 0 and 1, got %s", path, trimmedRaw(raw))
+		}
+		out.Opacity = &n
+	case "borderRadius":
+		r, err := decodeBackgroundBorderRadius(raw)
+		if err != nil {
+			return err
+		}
+		out.BorderRadius = &r
+	default:
+		return fmt.Errorf("background: unknown field %q", key)
+	}
+	return nil
+}
+
+func decodeBackgroundBool(raw json.RawMessage) (bool, error) {
+	var b bool
+	if err := json.Unmarshal(raw, &b); err != nil {
+		return false, fmt.Errorf("must be a boolean, got %s", trimmedRaw(raw))
+	}
+	return b, nil
+}
+
+func decodeBackgroundString(raw json.RawMessage) (string, error) {
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return "", fmt.Errorf("must be a string, got %s", trimmedRaw(raw))
+	}
+	return s, nil
+}
+
+func decodeBackgroundNumber(raw json.RawMessage) (float64, error) {
+	trimmed := trimmedRaw(raw)
+	// A JSON string unmarshals into json.Number's string kind, so reject
+	// quoted values explicitly before the numeric parse.
+	if trimmed == "" || trimmed[0] == '"' {
+		return 0, fmt.Errorf("must be a number, got %s", trimmed)
+	}
+	var n json.Number
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return 0, fmt.Errorf("must be a number, got %s", trimmed)
+	}
+	f, err := n.Float64()
+	if err != nil {
+		return 0, fmt.Errorf("must be a number, got %s", trimmed)
+	}
+	return f, nil
+}
+
+// decodeBackgroundBorderRadius accepts a non-negative integer or an array of
+// 1–4 non-negative integers (normalised to the array wire form).
+func decodeBackgroundBorderRadius(raw json.RawMessage) (BorderRadius, error) {
+	trimmed := trimmedRaw(raw)
+	if strings.HasPrefix(trimmed, "[") {
+		// A JSON string unmarshals into json.Number's string kind, so reject
+		// quoted elements explicitly before delegating to BorderRadius.
+		var elems []json.RawMessage
+		if err := json.Unmarshal(raw, &elems); err != nil {
+			return nil, fmt.Errorf("background.borderRadius must be an array of 1–4 integers, got %s", trimmed)
+		}
+		for _, elem := range elems {
+			e := trimmedRaw(elem)
+			if e == "" || e[0] == '"' {
+				return nil, fmt.Errorf("background.borderRadius must be an integer, got %s", e)
+			}
+		}
+		var r BorderRadius
+		if err := json.Unmarshal(raw, &r); err != nil {
+			return nil, fmt.Errorf("background.%s", err.Error())
+		}
+		return r, nil
+	}
+	// A JSON string unmarshals into json.Number's string kind, so reject
+	// quoted values explicitly before the integer parse.
+	if trimmed == "" || trimmed[0] == '"' {
+		return nil, fmt.Errorf("background.borderRadius must be an integer or an array of 1–4 integers, got %s", trimmed)
+	}
+	var n json.Number
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return nil, fmt.Errorf("background.borderRadius must be an integer or an array of 1–4 integers, got %s", trimmed)
+	}
+	if strings.ContainsAny(n.String(), ".eE") {
+		return nil, fmt.Errorf("background.borderRadius must be an integer, got %s", n.String())
+	}
+	v, err := n.Int64()
+	if err != nil || v < 0 {
+		return nil, fmt.Errorf("background.borderRadius must be a non-negative integer, got %s", n.String())
+	}
+	return BorderRadius{int(v)}, nil
+}
+
+func trimmedRaw(raw json.RawMessage) string {
+	return strings.TrimSpace(string(raw))
+}
+
+func sortedRawKeys(fields map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/shared/background_test.go
+++ b/shared/background_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-// BackgroundSuite covers the Background wire type (marshal omitempty) and the
-// object-bag converters shared by --chart braces and the raw --bg flag form.
+// BackgroundSuite covers the Background wire type (strict unmarshal + marshal
+// omitempty) and the object-bag converters shared by --chart braces and the
+// raw --bg flag form.
 type BackgroundSuite struct {
 	suite.Suite
 	fields []flags.ObjectField
@@ -77,6 +78,59 @@ func (s *BackgroundSuite) TestMarshalOmitsUnsetFields() {
 	s.Require().NoError(err)
 	// An explicit zero survives (pointer field); unset fields are omitted.
 	s.JSONEq(`{"active":true,"borderWidth":0}`, string(out))
+}
+
+func (s *BackgroundSuite) TestUnmarshalBorderRadiusForms() {
+	s.Run("single integer normalises to array", func() {
+		var bg Background
+		s.Require().NoError(json.Unmarshal([]byte(`{"active":true,"borderRadius":8}`), &bg))
+		s.Equal(BorderRadius{8}, *bg.BorderRadius)
+	})
+	s.Run("array passes through", func() {
+		var bg Background
+		s.Require().NoError(json.Unmarshal([]byte(`{"active":true,"borderRadius":[8,8,0,0]}`), &bg))
+		s.Equal(BorderRadius{8, 8, 0, 0}, *bg.BorderRadius)
+	})
+}
+
+func (s *BackgroundSuite) TestUnmarshalRejectsInvalid() {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"unknown field", `{"decal":1}`, `unknown field "decal"`},
+		{"active wrong type", `{"active":"yes"}`, "background.active: must be a boolean"},
+		{"color wrong type", `{"color":5}`, "background.color: must be a string"},
+		{"borderType enum", `{"borderType":"dash"}`, "solid, dashed, or dotted"},
+		{"borderWidth negative", `{"borderWidth":-1}`, "non-negative"},
+		{"shadowBlur negative", `{"shadowBlur":-0.5}`, "non-negative"},
+		{"borderWidth not number", `{"borderWidth":"thick"}`, "must be a number"},
+		{"opacity above one", `{"opacity":1.5}`, "between 0 and 1"},
+		{"opacity below zero", `{"opacity":-0.1}`, "between 0 and 1"},
+		{"opacity quoted number", `{"opacity":"0.5"}`, "must be a number"},
+		{"borderWidth quoted number", `{"borderWidth":"2"}`, "must be a number"},
+		{"borderRadius float", `{"borderRadius":8.5}`, "must be an integer"},
+		{"borderRadius quoted number", `{"borderRadius":"8"}`, "must be an integer"},
+		{"borderRadius quoted array element", `{"borderRadius":[8,"8"]}`, "must be an integer"},
+		{"borderRadius negative", `{"borderRadius":[-1]}`, "non-negative"},
+		{"borderRadius too many", `{"borderRadius":[1,2,3,4,5]}`, "1–4 values"},
+		{"not an object", `[]`, "must be a JSON object"},
+	}
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			var bg Background
+			err := json.Unmarshal([]byte(c.raw), &bg)
+			s.Require().Error(err)
+			s.Contains(err.Error(), c.want)
+		})
+	}
+}
+
+func (s *BackgroundSuite) TestUnmarshalNullIsNoOp() {
+	bg := Background{Active: true}
+	s.Require().NoError(json.Unmarshal([]byte("null"), &bg))
+	s.True(bg.Active)
 }
 
 func (s *BackgroundSuite) TestParseObjectBag() {


### PR DESCRIPTION
Stacked on #384 (`feat/bar-bg-flag-384`).

Accepts optional `BarChartConfig.background` on `POST /` and `POST /ui`. `additionalProperties: false`. `active: true` is the on-switch; omitted object or `active: false` does not enable the background. Invalid keys/types/enums return a 422 request error, not a 500.

Parent: #383
Closes #385
