### PR TITLE
feat(ui): render bar background onto echarts series

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -6,7 +6,6 @@ on:
     branches: [main]
     paths:
       - '**.go'
-      - 'ui/**'
       - go.mod
       - go.sum
       - .goreleaser.yml
@@ -20,7 +19,6 @@ on:
     branches: [main]
     paths:
       - '**.go'
-      - 'ui/**'
       - go.mod
       - go.sum
       - .goreleaser.yml

--- a/ui/src/components/ChartCard.vue
+++ b/ui/src/components/ChartCard.vue
@@ -88,6 +88,7 @@ const {
   smooth,
   horizontal,
   borderRadius,
+  background,
 } = useActiveChartShape()
 const { activeArrangement, activeDataset } = useDataPoint()
 const activeAxes = computed(() => activeDataset.value?.axes)
@@ -149,7 +150,8 @@ const { options } = useChartOptions(
   symbolSize,
   smooth,
   horizontal,
-  borderRadius
+  borderRadius,
+  background
 )
 
 const initOptions = {

--- a/ui/src/composables/charts/baseChartOptions.ts
+++ b/ui/src/composables/charts/baseChartOptions.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import type { EChartsOption } from 'echarts'
-import type { Axis, ChartData, Sort, ScaleType, ChartType } from '@/types'
+import type { Axis, BarBackground, ChartData, Sort, ScaleType, ChartType } from '@/types'
 import { createTooltipConfig, createToolboxConfig, getChartStyling } from './shared/chartConfig'
 import { fontSize } from './shared/common'
 import { is3D } from '@/lib/utils'
@@ -35,6 +35,8 @@ export interface BaseChartConfig {
    * Passed through to ECharts; when stacked, only the outer segment is rounded.
    */
   borderRadius?: Ref<number[] | undefined>
+  /** Bar-only category background (`--bg`); `active` gates ECharts `showBackground`. */
+  background?: Ref<BarBackground | undefined>
   /** Active swap target (e.g. xyz) — scatter value-mode 3D is swap-driven. */
   arrangementTarget?: Ref<string>
   chartAxes?: Ref<Axis[] | undefined>

--- a/ui/src/composables/charts/useBarChartOptions.test.ts
+++ b/ui/src/composables/charts/useBarChartOptions.test.ts
@@ -699,3 +699,177 @@ describe('useBarChartOptions — borderRadius', () => {
     }
   })
 })
+
+describe('useBarChartOptions — background', () => {
+  const makeMultiSeriesChartData = (): ChartData => ({
+    title: 'background test',
+    statType: 'sum',
+    yAxis: ['Series A', 'Series B', 'Series C'],
+    zAxis: [],
+    series: [
+      { xAxis: 'X1', values: [10, 20, 30], benchmarkId: '' },
+      { xAxis: 'X2', values: [15, 25, 35], benchmarkId: '' },
+    ],
+    points: [],
+    axisLabels: { x: 'category', y: 'series' },
+  })
+
+  type SeriesBackground = {
+    showBackground?: boolean
+    backgroundStyle?: Record<string, unknown>
+  }
+
+  const activeBg = {
+    active: true,
+    color: 'rgba(180, 180, 180, 0.2)',
+    borderColor: '#000',
+    shadowBlur: 10,
+    opacity: 1,
+  }
+
+  it('writes explicit showBackground false and omits backgroundStyle when unset or inactive', () => {
+    for (const background of [undefined, { active: false }, { active: false, color: '#000' }]) {
+      const { options } = useBarChartOptions({
+        chartData: ref(makeSimpleChartData()),
+        sort: ref({ enabled: false, order: 'asc' }),
+        showLabels: ref(false),
+        isDark: ref(false),
+        ...(background === undefined ? {} : { background: ref(background) }),
+      })
+      const series = options.value.series as SeriesBackground[]
+      // Explicit false (ECharts' own default) so the setOption merge cannot
+      // keep a previous chart's `true` after switching the active chart.
+      expect(series[0]?.showBackground).toBe(false)
+      expect(series[0]?.backgroundStyle).toBeUndefined()
+    }
+  })
+
+  it('sets showBackground true and passes defined style keys through unchanged', () => {
+    const { options } = useBarChartOptions({
+      chartData: ref(makeSimpleChartData()),
+      sort: ref({ enabled: false, order: 'asc' }),
+      showLabels: ref(false),
+      isDark: ref(false),
+      background: ref(activeBg),
+    })
+    const series = options.value.series as SeriesBackground[]
+    expect(series[0]?.showBackground).toBe(true)
+    // Exact object: unset keys stay absent — no invented ECharts defaults.
+    expect(series[0]?.backgroundStyle).toEqual({
+      color: 'rgba(180, 180, 180, 0.2)',
+      borderColor: '#000',
+      shadowBlur: 10,
+      opacity: 1,
+    })
+  })
+
+  it('drops explicitly-undefined style keys', () => {
+    const { options } = useBarChartOptions({
+      chartData: ref(makeSimpleChartData()),
+      sort: ref({ enabled: false, order: 'asc' }),
+      showLabels: ref(false),
+      isDark: ref(false),
+      background: ref({ active: true, color: 'rgba(9, 9, 9, 0.4)', shadowColor: undefined }),
+    })
+    const series = options.value.series as SeriesBackground[]
+    expect(series[0]?.backgroundStyle).toEqual({ color: 'rgba(9, 9, 9, 0.4)' })
+  })
+
+  it('uses an empty backgroundStyle when active with no style keys', () => {
+    const { options } = useBarChartOptions({
+      chartData: ref(makeSimpleChartData()),
+      sort: ref({ enabled: false, order: 'asc' }),
+      showLabels: ref(false),
+      isDark: ref(false),
+      background: ref({ active: true }),
+    })
+    const series = options.value.series as SeriesBackground[]
+    expect(series[0]?.showBackground).toBe(true)
+    expect(series[0]?.backgroundStyle).toEqual({})
+  })
+
+  it('applies background to horizontal 1D bars', () => {
+    const { options } = useBarChartOptions({
+      chartData: ref(makeSimpleChartData()),
+      sort: ref({ enabled: false, order: 'asc' }),
+      showLabels: ref(false),
+      isDark: ref(false),
+      horizontal: ref(true),
+      background: ref(activeBg),
+    })
+    const series = options.value.series as SeriesBackground[]
+    expect(series[0]?.showBackground).toBe(true)
+    expect(series[0]?.backgroundStyle).toEqual({
+      color: 'rgba(180, 180, 180, 0.2)',
+      borderColor: '#000',
+      shadowBlur: 10,
+      opacity: 1,
+    })
+  })
+
+  it('applies background to every grouped series', () => {
+    const { options } = useBarChartOptions({
+      chartData: ref(makeGroupedChartData()),
+      sort: ref({ enabled: false, order: 'asc' }),
+      showLabels: ref(false),
+      isDark: ref(false),
+      background: ref(activeBg),
+    })
+    const series = options.value.series as SeriesBackground[]
+    expect(series).toHaveLength(2)
+    expect(series.every((s) => s.showBackground === true)).toBe(true)
+    expect(series.every((s) => s.backgroundStyle?.color === 'rgba(180, 180, 180, 0.2)')).toBe(true)
+  })
+
+  it('applies background to every stacked segment (no outer-only capping)', () => {
+    const { options } = useBarChartOptions({
+      chartData: ref(makeMultiSeriesChartData()),
+      sort: ref({ enabled: false, order: 'asc' }),
+      showLabels: ref(false),
+      isDark: ref(false),
+      stack: ref(true),
+      background: ref(activeBg),
+    })
+    const series = options.value.series as SeriesBackground[]
+    expect(series).toHaveLength(3)
+    expect(series.every((s) => s.showBackground === true)).toBe(true)
+    expect(series.every((s) => s.backgroundStyle?.shadowBlur === 10)).toBe(true)
+  })
+
+  it('passes background through in mixed and value modes', () => {
+    for (const chartData of [makeMixedChartData(), makeValueChartData()]) {
+      const { options } = useBarChartOptions({
+        chartData: ref(chartData),
+        sort: ref({ enabled: false, order: 'asc' }),
+        showLabels: ref(false),
+        isDark: ref(false),
+        background: ref(activeBg),
+      })
+      const series = options.value.series as (SeriesBackground & { type: string })[]
+      expect(series[0]?.type).toBe('bar')
+      expect(series[0]?.showBackground).toBe(true)
+      expect(series[0]?.backgroundStyle).toEqual({
+        color: 'rgba(180, 180, 180, 0.2)',
+        borderColor: '#000',
+        shadowBlur: 10,
+        opacity: 1,
+      })
+    }
+  })
+
+  it('composes background with borderRadius on grouped bars', () => {
+    const { options } = useBarChartOptions({
+      chartData: ref(makeMultiSeriesChartData()),
+      sort: ref({ enabled: false, order: 'asc' }),
+      showLabels: ref(false),
+      isDark: ref(false),
+      borderRadius: ref([8]),
+      background: ref(activeBg),
+    })
+    const series = options.value.series as (SeriesBackground & {
+      itemStyle?: { borderRadius?: number[] }
+    })[]
+    expect(series.every((s) => s.itemStyle?.borderRadius !== undefined)).toBe(true)
+    expect(series.every((s) => s.showBackground === true)).toBe(true)
+  })
+})

--- a/ui/src/composables/charts/useBarChartOptions.test.ts
+++ b/ui/src/composables/charts/useBarChartOptions.test.ts
@@ -727,8 +727,8 @@ describe('useBarChartOptions — background', () => {
     opacity: 1,
   }
 
-  it('writes explicit showBackground false and omits backgroundStyle when unset or inactive', () => {
-    for (const background of [undefined, { active: false }, { active: false, color: '#000' }]) {
+  it('leaves showBackground and backgroundStyle unset when missing, empty, or inactive', () => {
+    for (const background of [undefined, {}, { active: false }, { active: false, color: '#000' }]) {
       const { options } = useBarChartOptions({
         chartData: ref(makeSimpleChartData()),
         sort: ref({ enabled: false, order: 'asc' }),
@@ -737,9 +737,7 @@ describe('useBarChartOptions — background', () => {
         ...(background === undefined ? {} : { background: ref(background) }),
       })
       const series = options.value.series as SeriesBackground[]
-      // Explicit false (ECharts' own default) so the setOption merge cannot
-      // keep a previous chart's `true` after switching the active chart.
-      expect(series[0]?.showBackground).toBe(false)
+      expect(series[0]?.showBackground).toBeUndefined()
       expect(series[0]?.backgroundStyle).toBeUndefined()
     }
   })

--- a/ui/src/composables/charts/useBarChartOptions.ts
+++ b/ui/src/composables/charts/useBarChartOptions.ts
@@ -1,5 +1,6 @@
 import { computed } from 'vue'
 import type { EChartsOption } from 'echarts'
+import type { BarBackground } from '@/types'
 import { type BaseChartConfig, getBaseOptions } from './baseChartOptions'
 import { getNextColorFor, hasXAxis } from '@/lib/utils'
 import {
@@ -27,6 +28,19 @@ const barNullable = (val: number | null, scale: string): number | null =>
 // ECharts itemStyle.borderRadius: [TL, TR, BR, BL] (len 1–4; [8] = all corners).
 type BarItemStyle = { color?: string; borderRadius?: number[] }
 
+// Style payload for ECharts series.backgroundStyle — the wire background minus
+// its `active` on-switch.
+type BarBackgroundStyle = Omit<BarBackground, 'active'>
+
+// Loose bar-series shape mutated by the background post-pass. `itemStyle` is
+// part of the shape only so the series literals (which always carry it) stay
+// assignable to this otherwise all-optional weak type.
+type BarSeriesLike = {
+  itemStyle?: BarItemStyle
+  showBackground?: boolean
+  backgroundStyle?: BarBackgroundStyle
+}
+
 function isActiveRadius(r: number[] | undefined): r is number[] {
   return !!r && r.length > 0 && r.some((n) => n > 0)
 }
@@ -48,8 +62,44 @@ function applyBorderRadiusToSeries(result: EChartsOption, radius: number[]): ECh
   return result
 }
 
+/** Style keys for ECharts `backgroundStyle`: every defined key of the wire
+ * background, with the `active` on-switch stripped. Unset keys stay absent so
+ * ECharts applies its own defaults (no invented defaults in the UI). */
+function backgroundStyleOf(background: BarBackground): BarBackgroundStyle {
+  const style = { ...background }
+  delete style.active
+  return Object.fromEntries(
+    Object.entries(style).filter(([, value]) => value !== undefined)
+  ) as BarBackgroundStyle
+}
+
+/** Stamp the wire background onto every bar series. `showBackground` is always
+ * written — explicit `false` when off (ECharts' own default) so the
+ * vue-echarts/ECharts merge cannot keep a previous chart's `true` after the
+ * active chart index switches. `backgroundStyle` is only written when on. */
+function applyBackgroundToSeries(
+  seriesList: BarSeriesLike[],
+  showBackground: boolean,
+  backgroundStyle: BarBackgroundStyle | undefined
+): void {
+  for (const series of seriesList) {
+    series.showBackground = showBackground
+    if (backgroundStyle) series.backgroundStyle = backgroundStyle
+  }
+}
+
 export function useBarChartOptions(config: BaseChartConfig) {
-  const { chartData, sort, showLabels, isDark, scale, stack, horizontal, borderRadius } = config
+  const {
+    chartData,
+    sort,
+    showLabels,
+    isDark,
+    scale,
+    stack,
+    horizontal,
+    borderRadius,
+    background,
+  } = config
 
   const sortedData = useSortedSeriesData(chartData, sort)
 
@@ -57,14 +107,29 @@ export function useBarChartOptions(config: BaseChartConfig) {
     const isHorizontal = horizontal?.value ?? false
     const radius = borderRadius?.value
     const activeRadius = isActiveRadius(radius)
+    const bg = background?.value
+    const activeBackground = bg?.active === true
+    const backgroundStyle = activeBackground ? backgroundStyleOf(bg!) : undefined
 
     if (chartData.value.mixedTuples?.length) {
       const result = buildMixedAxes2DOptions(config, 'bar')
-      return activeRadius ? applyBorderRadiusToSeries(result, radius) : result
+      const withRadius = activeRadius ? applyBorderRadiusToSeries(result, radius) : result
+      applyBackgroundToSeries(
+        withRadius.series as BarSeriesLike[],
+        activeBackground,
+        backgroundStyle
+      )
+      return withRadius
     }
     if (chartData.value.valueTuples?.length) {
       const result = buildValueAxes2DOptions(config, 'bar')
-      return activeRadius ? applyBorderRadiusToSeries(result, radius) : result
+      const withRadius = activeRadius ? applyBorderRadiusToSeries(result, radius) : result
+      applyBackgroundToSeries(
+        withRadius.series as BarSeriesLike[],
+        activeBackground,
+        backgroundStyle
+      )
+      return withRadius
     }
 
     const { series, xAxisData, hasYAxis } = sortedData.value
@@ -94,6 +159,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
       if (activeRadius) {
         seriesItem.itemStyle = { ...seriesItem.itemStyle, borderRadius: radius }
       }
+      applyBackgroundToSeries([seriesItem], activeBackground, backgroundStyle)
       return {
         ...baseOptions,
         grid: {
@@ -128,6 +194,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
       if (activeRadius) {
         seriesItem.itemStyle = { ...seriesItem.itemStyle, borderRadius: radius }
       }
+      applyBackgroundToSeries([seriesItem], activeBackground, backgroundStyle)
       return {
         ...baseOptions,
         grid: createGridConfig(1, largeX),
@@ -180,6 +247,10 @@ export function useBarChartOptions(config: BaseChartConfig) {
         }
       })
     }
+
+    // Unlike the stack-cap radius, the background applies uniformly to every
+    // grouped/stacked segment (it spans the whole category column).
+    applyBackgroundToSeries(transposedSeries, activeBackground, backgroundStyle)
 
     const hasMultipleSeries = transposedSeries.length > 1
     const seriesTotals = computeSeriesTotals(transposedSeries)

--- a/ui/src/composables/charts/useBarChartOptions.ts
+++ b/ui/src/composables/charts/useBarChartOptions.ts
@@ -73,18 +73,19 @@ function backgroundStyleOf(background: BarBackground): BarBackgroundStyle {
   ) as BarBackgroundStyle
 }
 
-/** Stamp the wire background onto every bar series. `showBackground` is always
- * written — explicit `false` when off (ECharts' own default) so the
- * vue-echarts/ECharts merge cannot keep a previous chart's `true` after the
- * active chart index switches. `backgroundStyle` is only written when on. */
+/** Stamp the wire background onto every bar series. Only `active: true` writes
+ * ECharts keys; `active: false` / missing `background` leave `showBackground`
+ * and `backgroundStyle` unset so this renderer does not invent defaults.
+ * ChartCard assigns a new option reference on each update, so vue-echarts
+ * uses `notMerge: true` and omitted keys cannot stick from a previous chart. */
 function applyBackgroundToSeries(
   seriesList: BarSeriesLike[],
-  showBackground: boolean,
   backgroundStyle: BarBackgroundStyle | undefined
 ): void {
+  if (!backgroundStyle) return
   for (const series of seriesList) {
-    series.showBackground = showBackground
-    if (backgroundStyle) series.backgroundStyle = backgroundStyle
+    series.showBackground = true
+    series.backgroundStyle = backgroundStyle
   }
 }
 
@@ -114,21 +115,13 @@ export function useBarChartOptions(config: BaseChartConfig) {
     if (chartData.value.mixedTuples?.length) {
       const result = buildMixedAxes2DOptions(config, 'bar')
       const withRadius = activeRadius ? applyBorderRadiusToSeries(result, radius) : result
-      applyBackgroundToSeries(
-        withRadius.series as BarSeriesLike[],
-        activeBackground,
-        backgroundStyle
-      )
+      applyBackgroundToSeries(withRadius.series as BarSeriesLike[], backgroundStyle)
       return withRadius
     }
     if (chartData.value.valueTuples?.length) {
       const result = buildValueAxes2DOptions(config, 'bar')
       const withRadius = activeRadius ? applyBorderRadiusToSeries(result, radius) : result
-      applyBackgroundToSeries(
-        withRadius.series as BarSeriesLike[],
-        activeBackground,
-        backgroundStyle
-      )
+      applyBackgroundToSeries(withRadius.series as BarSeriesLike[], backgroundStyle)
       return withRadius
     }
 
@@ -159,7 +152,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
       if (activeRadius) {
         seriesItem.itemStyle = { ...seriesItem.itemStyle, borderRadius: radius }
       }
-      applyBackgroundToSeries([seriesItem], activeBackground, backgroundStyle)
+      applyBackgroundToSeries([seriesItem], backgroundStyle)
       return {
         ...baseOptions,
         grid: {
@@ -194,7 +187,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
       if (activeRadius) {
         seriesItem.itemStyle = { ...seriesItem.itemStyle, borderRadius: radius }
       }
-      applyBackgroundToSeries([seriesItem], activeBackground, backgroundStyle)
+      applyBackgroundToSeries([seriesItem], backgroundStyle)
       return {
         ...baseOptions,
         grid: createGridConfig(1, largeX),
@@ -250,7 +243,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
 
     // Unlike the stack-cap radius, the background applies uniformly to every
     // grouped/stacked segment (it spans the whole category column).
-    applyBackgroundToSeries(transposedSeries, activeBackground, backgroundStyle)
+    applyBackgroundToSeries(transposedSeries, backgroundStyle)
 
     const hasMultipleSeries = transposedSeries.length > 1
     const seriesTotals = computeSeriesTotals(transposedSeries)

--- a/ui/src/composables/useActiveChartShape.test.ts
+++ b/ui/src/composables/useActiveChartShape.test.ts
@@ -122,7 +122,7 @@ describe('useActiveChartShape', () => {
     expect(scale.value).toBe('log')
   })
 
-  it('reads sort/threeD/visualMap/stat/symbol/smooth/horizontal/borderRadius fields', async () => {
+  it('reads sort/threeD/visualMap/stat/symbol/smooth/horizontal/borderRadius/background fields', async () => {
     holder.ref = ref(
       ds([
         {
@@ -145,6 +145,7 @@ describe('useActiveChartShape', () => {
           type: 'bar' as ChartType,
           horizontal: true,
           borderRadius: [8],
+          background: { active: true, color: 'rgba(180, 180, 180, 0.2)', shadowBlur: 10 },
         },
       ])
     )
@@ -160,6 +161,7 @@ describe('useActiveChartShape', () => {
     expect(shape.smooth.value).toBe(true)
     expect(shape.horizontal.value).toBe(false)
     expect(shape.borderRadius.value).toBeUndefined()
+    expect(shape.background.value).toBeUndefined()
 
     holder.activeIndex = 1
     shape = useActiveChartShape()
@@ -168,11 +170,17 @@ describe('useActiveChartShape', () => {
     expect(shape.symbolSize.value).toBe(8)
     expect(shape.smooth.value).toBe(false)
     expect(shape.borderRadius.value).toBeUndefined()
+    expect(shape.background.value).toBeUndefined()
 
     holder.activeIndex = 2
     shape = useActiveChartShape()
     expect(shape.horizontal.value).toBe(true)
     expect(shape.borderRadius.value).toEqual([8])
+    expect(shape.background.value).toEqual({
+      active: true,
+      color: 'rgba(180, 180, 180, 0.2)',
+      shadowBlur: 10,
+    })
     expect(shape.threeD.value).toBe(false)
     expect(shape.visualMap.value).toBe(false)
     expect(shape.stat.value).toBeUndefined()
@@ -208,7 +216,7 @@ describe('useActiveChartShape', () => {
     expect(again.hasThreeDOption.value).toBe(false)
   })
 
-  it('defaults threeDVisualMap/visualMap/smooth/horizontal/borderRadius when absent', async () => {
+  it('defaults threeDVisualMap/visualMap/smooth/horizontal/borderRadius/background when absent', async () => {
     holder.ref = ref(ds([{ type: 'bar' as ChartType }]))
     const { useActiveChartShape } = await import('./useActiveChartShape')
     const shape = useActiveChartShape()
@@ -217,6 +225,7 @@ describe('useActiveChartShape', () => {
     expect(shape.smooth.value).toBe(false)
     expect(shape.horizontal.value).toBe(false)
     expect(shape.borderRadius.value).toBeUndefined()
+    expect(shape.background.value).toBeUndefined()
     expect(shape.threeD.value).toBe(false)
     expect(shape.sort.value).toBeUndefined()
   })

--- a/ui/src/composables/useActiveChartShape.ts
+++ b/ui/src/composables/useActiveChartShape.ts
@@ -1,5 +1,13 @@
 import { computed } from 'vue'
-import type { BarConfig, LineConfig, ScatterConfig, ScaleType, Sort, StatConfig } from '../types'
+import type {
+  BarBackground,
+  BarConfig,
+  LineConfig,
+  ScatterConfig,
+  ScaleType,
+  Sort,
+  StatConfig,
+} from '../types'
 import { arrangementHasChartZ } from '../lib/swap'
 import { canOfferValue3D } from '../lib/utils'
 import { useDataPoint } from './useDataPoint'
@@ -89,6 +97,10 @@ export function useActiveChartShape() {
     () => (activeConfig.value as BarConfig | undefined)?.borderRadius
   )
 
+  const background = computed<BarBackground | undefined>(
+    () => (activeConfig.value as BarConfig | undefined)?.background
+  )
+
   return {
     scale,
     stack,
@@ -106,5 +118,6 @@ export function useActiveChartShape() {
     smooth,
     horizontal,
     borderRadius,
+    background,
   }
 }

--- a/ui/src/composables/useChartOptions.test.ts
+++ b/ui/src/composables/useChartOptions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { ref } from 'vue'
-import type { ChartData, ChartType, ScaleType, Axis } from '@/types'
+import type { BarBackground, ChartData, ChartType, ScaleType, Axis } from '@/types'
 import {
   baseConfig,
   makeGroupedChartData,
@@ -25,6 +25,7 @@ function dispatch(
     threeD?: boolean
     arrangementTarget?: string
     chartAxes?: Axis[]
+    background?: BarBackground
   } = {}
 ) {
   // baseConfig is the shared shape; useChartOptions takes loose refs in chart-card order.
@@ -53,7 +54,8 @@ function dispatch(
     ref(undefined),
     cfg.smooth ?? ref(false),
     cfg.horizontal ?? ref(false),
-    cfg.borderRadius ?? ref(undefined)
+    cfg.borderRadius ?? ref(undefined),
+    cfg.background ?? ref(opts.background)
   )
 }
 
@@ -169,5 +171,32 @@ describe('useChartOptions dispatch', () => {
   it('default branch falls back to bar3D when use3D is true', () => {
     const { options } = dispatch('unknown' as ChartType, grouped3DData(), { threeD: true })
     expect(firstSeriesType(options.value)).toBe('bar3D')
+  })
+
+  it('threads an active bar background config onto 2D bar series', () => {
+    const { options } = dispatch('bar', makeGroupedChartData(), {
+      background: { active: true, color: 'rgba(180, 180, 180, 0.2)', shadowBlur: 10 },
+    })
+    const series = options.value.series as {
+      showBackground?: boolean
+      backgroundStyle?: Record<string, unknown>
+    }[]
+    expect(series.every((s) => s.showBackground === true)).toBe(true)
+    expect(series[0]?.backgroundStyle).toEqual({
+      color: 'rgba(180, 180, 180, 0.2)',
+      shadowBlur: 10,
+    })
+  })
+
+  it('writes showBackground false on 2D bar series when background is inactive', () => {
+    const { options } = dispatch('bar', makeGroupedChartData(), {
+      background: { active: false },
+    })
+    const series = options.value.series as {
+      showBackground?: boolean
+      backgroundStyle?: Record<string, unknown>
+    }[]
+    expect(series.every((s) => s.showBackground === false)).toBe(true)
+    expect(series.every((s) => s.backgroundStyle === undefined)).toBe(true)
   })
 })

--- a/ui/src/composables/useChartOptions.test.ts
+++ b/ui/src/composables/useChartOptions.test.ts
@@ -188,7 +188,7 @@ describe('useChartOptions dispatch', () => {
     })
   })
 
-  it('writes showBackground false on 2D bar series when background is inactive', () => {
+  it('leaves showBackground unset on 2D bar series when background is inactive', () => {
     const { options } = dispatch('bar', makeGroupedChartData(), {
       background: { active: false },
     })
@@ -196,7 +196,22 @@ describe('useChartOptions dispatch', () => {
       showBackground?: boolean
       backgroundStyle?: Record<string, unknown>
     }[]
-    expect(series.every((s) => s.showBackground === false)).toBe(true)
+    expect(series.every((s) => s.showBackground === undefined)).toBe(true)
+    expect(series.every((s) => s.backgroundStyle === undefined)).toBe(true)
+  })
+
+  it('does not apply bar background to 3D bar series', () => {
+    const { options } = dispatch('bar', grouped3DData(), {
+      threeD: true,
+      background: { active: true, color: 'rgba(180, 180, 180, 0.2)', shadowBlur: 10 },
+    })
+    const series = options.value.series as {
+      type?: string
+      showBackground?: boolean
+      backgroundStyle?: Record<string, unknown>
+    }[]
+    expect(series[0]?.type).toBe('bar3D')
+    expect(series.every((s) => s.showBackground === undefined)).toBe(true)
     expect(series.every((s) => s.backgroundStyle === undefined)).toBe(true)
   })
 })

--- a/ui/src/composables/useChartOptions.ts
+++ b/ui/src/composables/useChartOptions.ts
@@ -1,5 +1,5 @@
 import { computed, type Ref } from 'vue'
-import type { Axis, ChartData, Sort, ChartType, ScaleType } from '../types'
+import type { Axis, BarBackground, ChartData, Sort, ChartType, ScaleType } from '../types'
 import type { EChartsOption } from 'echarts'
 import { useBarChartOptions } from './charts/useBarChartOptions'
 import { useLineChartOptions } from './charts/useLineChartOptions'
@@ -34,7 +34,8 @@ export function useChartOptions(
   symbolSize: Ref<number | undefined>,
   smooth: Ref<boolean>,
   horizontal: Ref<boolean>,
-  borderRadius: Ref<number[] | undefined>
+  borderRadius: Ref<number[] | undefined>,
+  background: Ref<BarBackground | undefined>
 ) {
   const config: BaseChartConfig = {
     chartData,
@@ -53,6 +54,7 @@ export function useChartOptions(
     smooth,
     horizontal,
     borderRadius,
+    background,
     arrangementTarget,
     chartAxes,
     chartType,

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -74,6 +74,23 @@ export type Axis = {
   type?: string // 'value' = continuous numeric axis; absent or '' = category (default)
 }
 
+// Bar-only category background (wire `--bg` / `bar:bg`). `active` is the
+// on-switch; every other key maps 1:1 onto ECharts `backgroundStyle`. All keys
+// are optional — unset keys stay absent so ECharts applies its own defaults.
+export type BarBackground = {
+  active?: boolean
+  color?: string
+  borderColor?: string
+  borderWidth?: number
+  borderType?: string
+  borderRadius?: number | number[]
+  shadowBlur?: number
+  shadowColor?: string
+  shadowOffsetX?: number
+  shadowOffsetY?: number
+  opacity?: number
+}
+
 // Per-chart typed configs (wire format: `Dataset.Settings []ChartConfig`).
 // Each chart type carries only the fields that apply to it. The `type`
 // discriminator narrows the union at the call site — chart-rendering code may
@@ -91,6 +108,8 @@ export type BarConfig = {
   horizontal?: boolean
   /** Corner radii in px [TL, TR, BR, BL]; length 1–4 (ECharts expands [8] to all corners). */
   borderRadius?: number[]
+  /** Category background behind each bar (2D only; bar-only). */
+  background?: BarBackground
   threeDRotate?: boolean
   threeD?: boolean
   threeDVisualMap?: boolean


### PR DESCRIPTION
Render-only: map Dataset `background` onto ECharts 2D bar series.

When `background.active === true`, grouped / stacked / horizontal / value / mixed paths set `showBackground: true` and pass defined keys as `backgroundStyle`. Unset keys stay absent. `active: false` or a missing object leaves those ECharts keys unset. 3D options, the settings panel, `fieldRegistry`, and the URL hash are unchanged.

Parent: #383
Closes #386


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable backgrounds for 2D bar charts, including color, borders, shadows, and opacity.
  * Background styling is supported across single, grouped, stacked, mixed, and value-based bar charts.
  * Background settings are ignored when inactive and excluded from 3D bar charts.

* **Bug Fixes**
  * Ensured incomplete background settings do not produce undefined chart styling values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->