### PR TITLE
docs: document bar --bg / chart bg object form

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ inputs:
     description: "Enable stats panel (--stat flag). Empty = disabled; 'all' or 'true' = all categories; otherwise comma-separated from: counts, center, spread, extremes, shape, percentiles, confidence, correlations"
     default: ""
   chart:
-    description: "Per-chart overrides (--chart flag, repeatable). One override per line: '<type>:<key>=<val>,...'. Keys: swap, sort, scale, stack, labels, 3d-rotate, 3d, symbol, symbol-size, smooth, horizontal, border-radius, stat. E.g. 'bar:scale=log' or 'pie:labels'. Blank lines and #-prefixed lines are ignored."
+    description: "Per-chart overrides (--chart flag, repeatable). One override per line: '<type>:<key>=<val>,...'. Keys: swap, sort, scale, stack, labels, 3d-rotate, 3d, symbol, symbol-size, smooth, horizontal, border-radius, bg, stat. Object props use {field=value;field=value} (semicolons inside braces; commas stay literal). E.g. 'bar:scale=log', 'pie:labels', 'bar:bg', or 'bar:bg={color=rgba(180, 180, 180, 0.2);borderColor=#000}'. Blank lines and #-prefixed lines are ignored."
     default: ""
   charts:
     description: "Chart types to generate (-c flag): bar, line, scatter, pie, heatmap, radar, sankey, chord"

--- a/docs/src/content/docs/charts/bar.mdx
+++ b/docs/src/content/docs/charts/bar.mdx
@@ -113,6 +113,7 @@ These settings apply to bar charts:
 | Swap | `--swap` | Axis switcher | Rotates which column maps to X vs Y |
 | Horizontal | `--horizontal` | Horizontal toggle | Renders grouped bars horizontally — 2D only |
 | Border radius | `--border-radius <int>[,int...]` | — | 1–4 corner radii px (CSS/ECharts TL,TR,BR,BL); single value = all corners; stacked: outer segment only, first two values on free end (rest square) — 2D only (CLI/config; not in UI settings) |
+| Background | `--bg` | — | Category background behind each bar. Bare `--bg` writes `background.active: true` (unspecified style keys keep ECharts defaults). Styled: `--bg 'color=…;borderColor=#000'`. 3D skips the flag — 2D only (CLI/config; not in UI settings) |
 | Scale (log) | `--log-scale` | Scale toggle | Log Y axis — 2D only |
 | 3D view | `--3d` | 3D view | Value 3D for x+y data (y → depth, metric → height) |
 | 3D visual map | `--3d-visualmap` | 3D visual map | Metric gradient coloring — on by default with `--3d`; grouped/value 3D |
@@ -141,6 +142,12 @@ vizb bar sales.csv -g region,category -p x,y --border-radius 8,8,0,0 -o free-out
 
 # Stacked: only top segment rounded; first two values are the free-end cap
 vizb bar sales.csv -g region,category -p x,y --stack --border-radius 8,4 -o stacked-rounded.html
+
+# Category background (bare = on; unspecified style keys keep ECharts defaults)
+vizb bar sales.csv -g region,category -p x,y --bg -o bg.html
+
+# Styled category background (semicolon-separated props; 2D only)
+vizb bar sales.csv -g region,category -p x,y --bg 'color=rgba(180, 180, 180, 0.2);borderColor=#000' -o bg.html
 ```
 
 ## Next Steps

--- a/docs/src/content/docs/charts/index.mdx
+++ b/docs/src/content/docs/charts/index.mdx
@@ -101,7 +101,7 @@ Most settings apply to every chart type. The exceptions are `scale` (log), which
 | `scale` log | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | `3d-rotate` (3D auto-rotate) | ✓ 3D only | ✓ 3D only | ✓ 3D only | ✗ | ✗ | ✗ | ✗ | ✗ |
 
-To override a setting for a single chart type without affecting the others, use the `--chart <type>:key=val` syntax:
+To override a setting for a single chart type without affecting the others, use the `--chart <type>:key=val` syntax. Object props use `{field=value;field=value}` (semicolons inside braces; commas stay literal). Unwrapped `bar:bg=color=…` is invalid.
 
 ```bash
 # Turn on labels for bar only
@@ -109,6 +109,12 @@ vizb data.csv -g category --chart bar:labels=true -o output.html
 
 # Enable sort on radar, keep others unsorted
 vizb data.csv -g category,metric -p x,y -c bar,radar --chart radar:sort=asc -o output.html
+
+# Category background on 2D bars (writes background.active: true; no UI toggle)
+vizb data.csv -g category --chart bar:bg -o output.html
+
+# Styled object: braces required; semicolons inside {}; commas stay literal
+vizb data.csv -g category --chart 'bar:bg={color=rgba(180, 180, 180, 0.2);borderColor=#000}' -o output.html
 ```
 
 See [Commands: root](/commands/root) for the full flag reference.

--- a/docs/src/content/docs/ci-cd/github-action.mdx
+++ b/docs/src/content/docs/ci-cd/github-action.mdx
@@ -67,7 +67,7 @@ The action:
 | `col-axis` | `""` | **csv/json + group:** place numeric column names on this axis (`n`, `x`, `y`, or `z`) so all columns share one chart (`--col-axis` / `-A` flag). Requires group; target axis must not already be used by `group-pattern`. |
 | `json-path` | `""` | **json only:** select a nested array to chart via a jq-like dot path (e.g. `.data.results`) (`--json-path` flag). |
 | `stat` | `""` | Enable stats panel (`--stat` flag). Empty = disabled; `all` or `true` = all categories; otherwise comma-separated from: `counts`, `center`, `spread`, `extremes`, `shape`, `percentiles`, `confidence`, `correlations`. |
-| `chart` | `""` | Per-chart overrides (`--chart` flag, repeatable). One override per line: `<type>:<props>`. Comma separates single-value props; for multi-value props (e.g. `stat=center,spread`) use semicolon between props or put the multi-value prop alone. E.g. `bar:scale=log`, `pie:labels`, `bar:stat=center,spread;labels`. Blank lines and `#`-prefixed lines are ignored. |
+| `chart` | `""` | Per-chart overrides (`--chart` flag, repeatable). One override per line: `<type>:<props>`. Keys include `swap`, `sort`, `scale`, `stack`, `labels`, `3d-rotate`, `3d`, `symbol`, `symbol-size`, `smooth`, `horizontal`, `border-radius`, `bg`, `stat`. Comma separates single-value props; for multi-value props (e.g. `stat=center,spread`) use semicolon between props or put the multi-value prop alone. Object props use `{field=value;field=value}` (semicolons inside braces; commas stay literal) — e.g. `bar:bg`, `bar:bg={color=rgba(180, 180, 180, 0.2);borderColor=#000}`. Unwrapped `bar:bg=color=…` is invalid. Blank lines and `#`-prefixed lines are ignored. |
 | `charts` | `"bar,line,pie"` | Chart types to generate (`-c` flag): `bar`, `line`, `scatter`, `pie`, `heatmap`, `radar`, `sankey`, `chord`. |
 | `parser` | `"auto"` | Parser to use: `csv`, `json`, `go`, `js:tinybench`, `js:vitest`, `rs:criterion`, `rs:divan` (`-P` flag). |
 | `show-labels` | `"false"` | **Deprecated:** use `chart` input instead (e.g. `chart: 'pie:labels'`). Show labels on charts (`-l` flag). |
@@ -219,7 +219,31 @@ Use the `chart` input (one override per line) to configure individual charts wit
     output-html: pages/index.html
 ```
 
-Available override keys: `swap`, `sort`, `scale`, `labels`, `3d-rotate`, `3d`.
+Category background on 2D bars (`background.active: true` on the wire; no UI toggle; 3D skips the flag):
+
+```yaml
+- uses: goptics/vizb@v0
+  with:
+    file: sales.csv
+    charts: bar
+    chart: |
+      bar:bg
+    output-html: pages/index.html
+```
+
+Styled object form — `{field=value;field=value}` (semicolons inside braces; commas stay literal). Unwrapped `bar:bg=color=…` is invalid:
+
+```yaml
+- uses: goptics/vizb@v0
+  with:
+    file: sales.csv
+    charts: bar
+    chart: |
+      bar:bg={color=rgba(180, 180, 180, 0.2);borderColor=#000}
+    output-html: pages/index.html
+```
+
+Available override keys: `swap`, `sort`, `scale`, `stack`, `labels`, `3d-rotate`, `3d`, `symbol`, `symbol-size`, `smooth`, `horizontal`, `border-radius`, `bg`, `stat`.
 
 ## Stats Panel
 

--- a/docs/src/content/docs/commands/charts.mdx
+++ b/docs/src/content/docs/commands/charts.mdx
@@ -64,6 +64,7 @@ Every chart subcommand accepts the common data, grouping, and metadata flags:
 | `--3d-rotate` | ✅ | ✅ | ✅ | — | — | — | — | — | Auto-rotate the 3D scene (only meaningful with 3D data) |
 | `--horizontal` | ✅ | — | — | — | — | — | — | — | Horizontal grouped bars — 2D only |
 | `--border-radius` | ✅ | — | — | — | — | — | — | — | 1–4 corner radii px (CSS/ECharts TL,TR,BR,BL); single value = all corners; stacked: outer segment, first two values as free-end cap |
+| `--bg` | ✅ | — | — | — | — | — | — | — | Category background behind 2D bars; bare = on (`background.active: true`); style props semicolon-separated. 3D skips the flag |
 `bar`, `line`, and `scatter` render in 3D when the data has a z dimension (`-p n/x/y/z`) or auto-value detects 3+ numeric columns. Pie, heatmap, radar, sankey, and chord are 2D-only for those flags — passing an unsupported flag is an error:
 
 ```bash
@@ -84,6 +85,9 @@ go test -bench . | vizb line -p n/y --swap yn -o line.html
 
 # Bar chart with horizontal grouped bars
 vizb bar sales.csv -g region,category -p x,y --horizontal -o bar.html
+
+# Category background on 2D bars (bare = on; writes background.active: true)
+vizb bar sales.csv -g region,category -p x,y --bg -o bar.html
 
 # Scatter from all-numeric columns (auto-value)
 vizb scatter data.csv -o scatter.html

--- a/docs/src/content/docs/commands/root.mdx
+++ b/docs/src/content/docs/commands/root.mdx
@@ -234,6 +234,9 @@ spec is `<type>:<props>` where props are `key=value` pairs or bare flags
     `--chart bar:stat=center,spread`
   - Or separate props with **semicolons** so commas stay inside the value:
     `--chart 'bar:stat=center,spread;labels'`
+- **Object props** use braces: `key={field=value;field=value}`. Inside `{}`,
+  only `;` separates fields so commas stay literal (`rgba(…)`,
+  `borderRadius=8,8,0,0`). Unwrapped `bar:bg=color=…` is invalid.
 
 Semicolon mode matches structured `--theme` specs
 (`name:colors=#hex,...;visualMapColors=...`); both use the same prop grammar.
@@ -256,6 +259,12 @@ vizb sales.csv -c bar --chart bar:stat=center,spread -o out.html
 
 # Multi-value + another prop: use semicolon between props
 vizb sales.csv -c bar --chart 'bar:stat=center,spread;labels' -o out.html
+
+# Category background on 2D bars (writes background.active: true; no UI toggle)
+vizb sales.csv -c bar --chart bar:bg -o out.html
+
+# Styled object (semicolons inside braces; commas stay literal)
+vizb sales.csv -c bar --chart 'bar:bg={color=rgba(180, 180, 180, 0.2);borderColor=#000}' -o out.html
 ```
 
 **Supported keys:**
@@ -267,6 +276,7 @@ vizb sales.csv -c bar --chart 'bar:stat=center,spread;labels' -o out.html
 | `labels` | `labels` | `true`, `false` | all |
 | `scale` | — | `linear`, `log` | `bar`, `line` only |
 | `3d-rotate` | `3d-rotate` | `true`, `false` | `bar`, `line` 3D only |
+| `bg` | `bg` | `{field=value;…}` style object, or bare/`{}` for on | `bar` 2D only |
 | `stat` | `stat` | `all`, or comma-separated categories (`center,spread`, …) | all |
 
 Bare flags (no `=`) default to `true`. Per-chart settings override the chart's own defaults. The root-level `--sort` and `--show-labels` flags are deprecated — use `--chart` overrides instead.

--- a/docs/src/content/docs/ui/settings.mdx
+++ b/docs/src/content/docs/ui/settings.mdx
@@ -19,6 +19,7 @@ Prefer **per-chart** flags when generating multi-chart HTML. Root-level `--sort`
 | `--chart <type>:labels` or `vizb pie --show-labels` | Labels toggle | on / off |
 | `--chart line:smooth` or `vizb line --smooth` | Smooth lines | on / off — 2D line only |
 | `--chart bar:3d-rotate` (or line/scatter) | Auto rotate | on / off — 3D bar / line / scatter |
+| `--chart bar:bg` or `vizb bar --bg` | — | on / off — 2D bar only; CLI/config, no UI toggle; writes `background.active: true` |
 | `--stat` | Statistics button | off unless set; see [Statistics](/ui/stats) |
 
 ## Setting Defaults from CLI
@@ -32,8 +33,16 @@ vizb bar data.csv --scale log --show-labels -o output.html
 
 # Sort descending, bar only
 vizb bar data.csv --sort desc -o output.html
+
+# Category background on 2D bars (no UI toggle; writes background.active: true)
+vizb data.csv --chart bar:bg -o output.html
+vizb bar data.csv --bg -o output.html
+
+# Object props: {field=value;field=value} (semicolons inside braces; commas stay literal)
+# Unwrapped bar:bg=color=… is invalid
+vizb data.csv --chart 'bar:bg={color=rgba(180, 180, 180, 0.2);borderColor=#000}' -o output.html
 ```
 
 <Aside type="note">
-  CLI flags set the initial state. All settings can be changed in the UI without regenerating the file. Deep links keep many of those choices in the URL — see [UI Overview → Deep links](/ui#deep-links).
+  CLI flags set the initial state. Settings that have a UI control can be changed without regenerating the file. Deep links keep many of those choices in the URL — see [UI Overview → Deep links](/ui#deep-links). `--bg` / `--chart bar:bg` has no settings-panel toggle (2D only).
 </Aside>


### PR DESCRIPTION
Document bar `--bg` / `background` on the site and the GitHub Action `chart` input.

Bar settings table covers bare and styled `--bg` (no UI toggle, 2D only). `--chart` and Action docs use `bar:bg` and `bar:bg={field=value;…}` (semicolons inside braces). No new Action input named `bg`.

Parent: #383
Closes #388
