### PR TITLE
feat(cli): show download progress on vizb update

### DIFF
--- a/cmd/cli/downloadbar.go
+++ b/cmd/cli/downloadbar.go
@@ -1,0 +1,194 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/goptics/vizb/pkg/cliout"
+	"github.com/muesli/termenv"
+)
+
+const downloadBarWidth = 24
+
+// DownloadBar is a TTY-only determinate download progress line on stderr.
+type DownloadBar struct {
+	mu        sync.Mutex
+	w         io.Writer
+	tty       bool
+	color     bool
+	finished  bool
+	painted   bool
+	lastPaint time.Time
+	written   int64
+	total     int64
+	label     string
+	style     lipgloss.Style
+}
+
+// NewDownloadBar paints download progress on w when w is a TTY.
+func NewDownloadBar(w io.Writer) *DownloadBar {
+	if w == nil {
+		w = os.Stderr
+	}
+	profile := cliout.ColorProfile(w)
+	b := &DownloadBar{
+		w:     w,
+		tty:   writerIsTerminal(w),
+		color: profile != termenv.Ascii,
+		style: lipgloss.NewStyle().
+			Foreground(lipgloss.Color(cliout.BrandGreen)).
+			Bold(true),
+	}
+	if b.color {
+		r := lipgloss.NewRenderer(w)
+		r.SetColorProfile(profile)
+		b.style = b.style.Renderer(r)
+	}
+	return b
+}
+
+// IsTTY reports whether the bar will paint (stderr is a terminal).
+func (b *DownloadBar) IsTTY() bool {
+	return b != nil && b.tty
+}
+
+// Wrap reports read progress for r. Non-TTY writers return r unchanged.
+// total is Content-Length; values <= 0 omit the percent and bar.
+func (b *DownloadBar) Wrap(r io.Reader, total int64, label string) io.Reader {
+	if b == nil || r == nil || !b.tty {
+		return r
+	}
+	b.mu.Lock()
+	b.total = total
+	b.label = label
+	b.written = 0
+	b.mu.Unlock()
+	return &progressReader{bar: b, r: r}
+}
+
+// Finish clears the progress line when it was painted. Idempotent.
+func (b *DownloadBar) Finish() error {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	if b.finished {
+		b.mu.Unlock()
+		return nil
+	}
+	b.finished = true
+	painted := b.painted
+	b.mu.Unlock()
+	if painted {
+		_, _ = fmt.Fprint(b.w, "\r\033[K"+ansiShowCursor)
+	}
+	return nil
+}
+
+type progressReader struct {
+	bar *DownloadBar
+	r   io.Reader
+}
+
+func (p *progressReader) Read(buf []byte) (int, error) {
+	n, err := p.r.Read(buf)
+	if n > 0 {
+		p.bar.add(int64(n))
+	}
+	if err == io.EOF {
+		p.bar.paint(true)
+	}
+	return n, err
+}
+
+func (p *progressReader) Close() error {
+	return p.bar.Finish()
+}
+
+func (b *DownloadBar) add(n int64) {
+	b.mu.Lock()
+	b.written += n
+	complete := b.total > 0 && b.written >= b.total
+	b.mu.Unlock()
+	b.paint(complete)
+}
+
+func (b *DownloadBar) paint(final bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.finished || !b.tty {
+		return
+	}
+	if !final && !b.lastPaint.IsZero() && time.Since(b.lastPaint) < spinnerTick {
+		if b.total <= 0 || b.written < b.total {
+			return
+		}
+	}
+
+	_, _ = fmt.Fprint(b.w, ansiHideCursor)
+	_, _ = fmt.Fprintf(b.w, "\r\033[K%s", b.lineLocked())
+	b.painted = true
+	b.lastPaint = time.Now()
+}
+
+func (b *DownloadBar) lineLocked() string {
+	var sb strings.Builder
+	sb.WriteString("Downloading")
+	if b.label != "" {
+		sb.WriteByte(' ')
+		sb.WriteString(b.label)
+	}
+	sb.WriteString("  ")
+	if b.total > 0 {
+		sb.WriteString(b.renderBarLocked())
+		sb.WriteString("  ")
+		pct := int(float64(b.written) / float64(b.total) * 100)
+		if b.written >= b.total || pct > 100 {
+			pct = 100
+		}
+		sb.WriteString(strconv.Itoa(pct))
+		sb.WriteString("%  ")
+		sb.WriteString(formatBytes(b.written))
+		sb.WriteByte('/')
+		sb.WriteString(formatBytes(b.total))
+	} else {
+		sb.WriteString(formatBytes(b.written))
+	}
+	return sb.String()
+}
+
+func (b *DownloadBar) renderBarLocked() string {
+	filled := 0
+	if b.total > 0 {
+		filled = int(float64(downloadBarWidth) * float64(b.written) / float64(b.total))
+		if filled > downloadBarWidth {
+			filled = downloadBarWidth
+		}
+	}
+	empty := downloadBarWidth - filled
+	if b.color {
+		return b.style.Render(strings.Repeat("█", filled)) + strings.Repeat("░", empty)
+	}
+	return strings.Repeat("#", filled) + strings.Repeat(" ", empty)
+}
+
+func formatBytes(n int64) string {
+	const (
+		kb = 1024.0
+		mb = 1024.0 * 1024.0
+	)
+	switch {
+	case n >= 1024*1024:
+		return fmt.Sprintf("%.1f MB", float64(n)/mb)
+	case n >= 1024:
+		return fmt.Sprintf("%.1f KB", float64(n)/kb)
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/cmd/cli/downloadbar.go
+++ b/cmd/cli/downloadbar.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,9 +32,6 @@ type DownloadBar struct {
 
 // NewDownloadBar paints download progress on w when w is a TTY.
 func NewDownloadBar(w io.Writer) *DownloadBar {
-	if w == nil {
-		w = os.Stderr
-	}
 	profile := cliout.ColorProfile(w)
 	b := &DownloadBar{
 		w:     w,
@@ -55,13 +51,12 @@ func NewDownloadBar(w io.Writer) *DownloadBar {
 
 // IsTTY reports whether the bar will paint (stderr is a terminal).
 func (b *DownloadBar) IsTTY() bool {
-	return b != nil && b.tty
+	return b.tty
 }
 
-// Wrap reports read progress for r. Non-TTY writers return r unchanged.
-// total is Content-Length; values <= 0 omit the percent and bar.
+// Wrap reports read progress for r. Non-TTY writers and unknown totals return r unchanged.
 func (b *DownloadBar) Wrap(r io.Reader, total int64, label string) io.Reader {
-	if b == nil || r == nil || !b.tty {
+	if !b.tty || total <= 0 {
 		return r
 	}
 	b.mu.Lock()
@@ -74,9 +69,6 @@ func (b *DownloadBar) Wrap(r io.Reader, total int64, label string) io.Reader {
 
 // Finish clears the progress line when it was painted. Idempotent.
 func (b *DownloadBar) Finish() error {
-	if b == nil {
-		return nil
-	}
 	b.mu.Lock()
 	if b.finished {
 		b.mu.Unlock()
@@ -114,7 +106,7 @@ func (p *progressReader) Close() error {
 func (b *DownloadBar) add(n int64) {
 	b.mu.Lock()
 	b.written += n
-	complete := b.total > 0 && b.written >= b.total
+	complete := b.written >= b.total
 	b.mu.Unlock()
 	b.paint(complete)
 }
@@ -122,13 +114,8 @@ func (b *DownloadBar) add(n int64) {
 func (b *DownloadBar) paint(final bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.finished || !b.tty {
+	if !final && b.written < b.total && !b.lastPaint.IsZero() && time.Since(b.lastPaint) < spinnerTick {
 		return
-	}
-	if !final && !b.lastPaint.IsZero() && time.Since(b.lastPaint) < spinnerTick {
-		if b.total <= 0 || b.written < b.total {
-			return
-		}
 	}
 
 	_, _ = fmt.Fprint(b.w, ansiHideCursor)
@@ -145,32 +132,22 @@ func (b *DownloadBar) lineLocked() string {
 		sb.WriteString(b.label)
 	}
 	sb.WriteString("  ")
-	if b.total > 0 {
-		sb.WriteString(b.renderBarLocked())
-		sb.WriteString("  ")
-		pct := int(float64(b.written) / float64(b.total) * 100)
-		if b.written >= b.total || pct > 100 {
-			pct = 100
-		}
-		sb.WriteString(strconv.Itoa(pct))
-		sb.WriteString("%  ")
-		sb.WriteString(formatBytes(b.written))
-		sb.WriteByte('/')
-		sb.WriteString(formatBytes(b.total))
-	} else {
-		sb.WriteString(formatBytes(b.written))
+	sb.WriteString(b.renderBarLocked())
+	sb.WriteString("  ")
+	pct := int(float64(b.written) / float64(b.total) * 100)
+	if b.written >= b.total {
+		pct = 100
 	}
+	sb.WriteString(strconv.Itoa(pct))
+	sb.WriteString("%  ")
+	sb.WriteString(formatBytes(b.written))
+	sb.WriteByte('/')
+	sb.WriteString(formatBytes(b.total))
 	return sb.String()
 }
 
 func (b *DownloadBar) renderBarLocked() string {
-	filled := 0
-	if b.total > 0 {
-		filled = int(float64(downloadBarWidth) * float64(b.written) / float64(b.total))
-		if filled > downloadBarWidth {
-			filled = downloadBarWidth
-		}
-	}
+	filled := min(downloadBarWidth, int(float64(downloadBarWidth)*float64(b.written)/float64(b.total)))
 	empty := downloadBarWidth - filled
 	if b.color {
 		return b.style.Render(strings.Repeat("█", filled)) + strings.Repeat("░", empty)

--- a/cmd/cli/downloadbar_test.go
+++ b/cmd/cli/downloadbar_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/goptics/vizb/pkg/cliout"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/suite"
+)
+
+type DownloadBarSuite struct {
+	suite.Suite
+}
+
+func (s *DownloadBarSuite) TestNonTTYIsSilent() {
+	var buf bytes.Buffer
+	bar := NewDownloadBar(&buf)
+	src := strings.NewReader("hello")
+	s.Same(src, bar.Wrap(src, 5, "v1.0.0"))
+	s.False(bar.IsTTY())
+	s.NoError(bar.Finish())
+	s.Empty(buf.String())
+}
+
+func (s *DownloadBarSuite) TestTTYPaintsThenFinishClears() {
+	var buf bytes.Buffer
+	bar := NewDownloadBar(&buf)
+	bar.tty = true
+	wrapped := bar.Wrap(bytes.NewReader(bytes.Repeat([]byte("a"), 100)), 100, "v1.1.0")
+	_, err := io.Copy(io.Discard, wrapped)
+	s.Require().NoError(err)
+	out := buf.String()
+	s.Contains(out, "Downloading v1.1.0")
+	s.Contains(out, "100%")
+	s.Contains(out, "#")
+
+	closer, ok := wrapped.(io.Closer)
+	s.Require().True(ok)
+	s.NoError(closer.Close())
+	s.Contains(buf.String(), "\033[?25h")
+	s.NoError(bar.Finish())
+}
+
+func (s *DownloadBarSuite) TestFillFollowsColor() {
+	payload := bytes.Repeat([]byte("a"), 50)
+
+	var off bytes.Buffer
+	plain := NewDownloadBar(&off)
+	plain.tty, plain.color = true, false
+	_, err := io.Copy(io.Discard, plain.Wrap(bytes.NewReader(payload), 50, "v1.2.0"))
+	s.Require().NoError(err)
+	s.Contains(off.String(), "#")
+	s.NotContains(off.String(), "█")
+
+	var on bytes.Buffer
+	color := NewDownloadBar(&on)
+	color.tty, color.color = true, true
+	r := lipgloss.NewRenderer(&on)
+	r.SetColorProfile(termenv.TrueColor)
+	color.style = lipgloss.NewStyle().
+		Foreground(lipgloss.Color(cliout.BrandGreen)).
+		Bold(true).
+		Renderer(r)
+	_, err = io.Copy(io.Discard, color.Wrap(bytes.NewReader(payload), 50, "v1.2.0"))
+	s.Require().NoError(err)
+	s.Contains(on.String(), "█")
+	s.Contains(on.String(), "\x1b[")
+}
+
+func TestDownloadBarSuite(t *testing.T) {
+	suite.Run(t, new(DownloadBarSuite))
+}

--- a/cmd/cli/downloadbar_test.go
+++ b/cmd/cli/downloadbar_test.go
@@ -37,6 +37,8 @@ func (s *DownloadBarSuite) TestTTYPaintsThenFinishClears() {
 	s.Contains(out, "Downloading v1.1.0")
 	s.Contains(out, "100%")
 	s.Contains(out, "#")
+	s.Equal("1.0 KB", formatBytes(1024))
+	s.Equal("1.0 MB", formatBytes(1<<20))
 
 	closer, ok := wrapped.(io.Closer)
 	s.Require().True(ok)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -74,9 +74,7 @@ func isDevBuild(ver, distribution string) bool {
 func previewUpdateDownload(bar *cli.DownloadBar, stdout io.Writer, total int64, pace time.Duration) error {
 	src := bar.Wrap(newPacedReader(total, pace), total, "(devel)")
 	_, err := io.Copy(io.Discard, src)
-	if closer, ok := src.(io.Closer); ok {
-		_ = closer.Close()
-	}
+	_ = bar.Finish()
 	if err != nil {
 		return err
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -2,11 +2,16 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"strings"
+	"time"
 
+	"github.com/goptics/vizb/cmd/cli"
 	"github.com/goptics/vizb/internal/updater"
 	"github.com/goptics/vizb/version"
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/module"
 )
 
 type updateRunner func(context.Context, io.Reader, io.Writer, io.Writer) error
@@ -28,10 +33,80 @@ func newUpdateCommand(run updateRunner) *cobra.Command {
 	}
 }
 
+const (
+	updateDemoBytes = 8 << 20
+	updateDemoEvery = 512 << 10
+	updateDemoPace  = 80 * time.Millisecond
+)
+
 func runUpdate(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer) error {
 	service, err := updater.New(version.Version, version.Distribution)
 	if err != nil {
 		return err
 	}
+	bar := cli.NewDownloadBar(stderr)
+	defer func() { _ = bar.Finish() }()
+	if isDevBuild(version.Version, version.Distribution) && bar.IsTTY() {
+		return previewUpdateDownload(bar, stdout, updateDemoBytes, updateDemoPace)
+	}
+	service.ProgressWrap = bar.Wrap
 	return service.Run(ctx, stdin, stdout, stderr)
+}
+
+func isDevBuild(ver, distribution string) bool {
+	if strings.TrimSpace(distribution) != "" {
+		return false
+	}
+	v := strings.TrimSpace(ver)
+	switch v {
+	case "", "devel", "(devel)":
+		return true
+	}
+	// Local `go build` / `task build:cli` often VCS-stamps a pseudo-version
+	// and/or +dirty. Release and `go install` stay on a clean tag.
+	if strings.Contains(v, "+dirty") {
+		return true
+	}
+	base, _, _ := strings.Cut(v, "+")
+	return module.IsPseudoVersion(base)
+}
+
+func previewUpdateDownload(bar *cli.DownloadBar, stdout io.Writer, total int64, pace time.Duration) error {
+	src := bar.Wrap(newPacedReader(total, pace), total, "(devel)")
+	_, err := io.Copy(io.Discard, src)
+	if closer, ok := src.(io.Closer); ok {
+		_ = closer.Close()
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(stdout, "Development build: download progress demo only; binary not updated.")
+	return nil
+}
+
+type pacedReader struct {
+	remain     int64
+	pace       time.Duration
+	sinceSleep int64
+}
+
+func newPacedReader(total int64, pace time.Duration) *pacedReader {
+	return &pacedReader{remain: total, pace: pace}
+}
+
+func (p *pacedReader) Read(b []byte) (int, error) {
+	if p.remain <= 0 {
+		return 0, io.EOF
+	}
+	n := len(b)
+	if int64(n) > p.remain {
+		n = int(p.remain)
+	}
+	p.remain -= int64(n)
+	p.sinceSleep += int64(n)
+	if p.pace > 0 && p.sinceSleep >= updateDemoEvery && p.remain > 0 {
+		time.Sleep(p.pace)
+		p.sinceSleep = 0
+	}
+	return n, nil
 }

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
+	"github.com/goptics/vizb/cmd/cli"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -60,6 +62,24 @@ func (s *UpdateCommandSuite) TestReturnsRunnerError() {
 	})
 
 	s.ErrorIs(command.Execute(), want)
+}
+
+func (s *UpdateCommandSuite) TestDevBuildDetection() {
+	s.True(isDevBuild("devel", ""))
+	s.True(isDevBuild("(devel)", ""))
+	s.True(isDevBuild("v0.19.1-0.20260823054904-a55200997252+dirty", ""))
+	s.True(isDevBuild("v0.19.1+dirty", ""))
+	s.False(isDevBuild("v0.19.1", ""))
+	s.False(isDevBuild("devel", "standalone"))
+}
+
+func (s *UpdateCommandSuite) TestDevPreviewAndNonTTYRefusal() {
+	var stdout bytes.Buffer
+	s.Require().NoError(previewUpdateDownload(cli.NewDownloadBar(io.Discard), &stdout, 2048, 0))
+	s.Contains(stdout.String(), "binary not updated")
+
+	err := runUpdate(context.Background(), strings.NewReader(""), io.Discard, io.Discard)
+	s.ErrorContains(err, "cannot safely update")
 }
 
 func TestUpdateCommandSuite(t *testing.T) {

--- a/docs/src/content/docs/commands/update.mdx
+++ b/docs/src/content/docs/commands/update.mdx
@@ -32,3 +32,7 @@ elevates privileges automatically.
 The update is installed only after the release archive SHA-256 matches its entry
 in the existing GoReleaser `checksums.txt` asset. An invalid or missing checksum
 leaves the current executable unchanged.
+
+On a TTY, standalone updates show archive download progress on stderr.
+Local development builds (`go build`, `task build:cli`) play a mock download on
+a TTY so the bar can be previewed; the running binary is not replaced.

--- a/internal/updater/download.go
+++ b/internal/updater/download.go
@@ -18,7 +18,7 @@ const (
 	maxChecksumSize = 1 << 20
 )
 
-func downloadFile(ctx context.Context, client *http.Client, sourceURL, destination, userAgent string, maxSize int64) error {
+func downloadFile(ctx context.Context, client *http.Client, sourceURL, destination, userAgent string, maxSize int64, wrap func(io.Reader, int64, string) io.Reader, label string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sourceURL, nil)
 	if err != nil {
 		return fmt.Errorf("create download request: %w", err)
@@ -43,7 +43,14 @@ func downloadFile(ctx context.Context, client *http.Client, sourceURL, destinati
 		return fmt.Errorf("create download destination: %w", err)
 	}
 
-	written, copyErr := io.Copy(output, io.LimitReader(resp.Body, maxSize+1))
+	src := io.Reader(io.LimitReader(resp.Body, maxSize+1))
+	if wrap != nil {
+		src = wrap(src, resp.ContentLength, label)
+	}
+	written, copyErr := io.Copy(output, src)
+	if closer, ok := src.(io.Closer); ok {
+		_ = closer.Close()
+	}
 	syncErr := output.Sync()
 	closeErr := output.Close()
 	if copyErr != nil {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -35,6 +35,8 @@ type Updater struct {
 	latestURL           string
 	releaseDownloadURL  string
 	replace             func(string, string) error
+	// ProgressWrap optionally reports archive download progress. Checksums skip it.
+	ProgressWrap func(r io.Reader, total int64, label string) io.Reader
 }
 
 // New constructs an updater for the currently running executable.
@@ -145,7 +147,7 @@ func (u *Updater) prepareCandidate(ctx context.Context, version string) (string,
 
 	checksumsPath := filepath.Join(tempDir, "checksums.txt")
 	checksumsURL := u.releaseURL(version, "checksums.txt")
-	if err := downloadFile(ctx, u.client, checksumsURL, checksumsPath, u.userAgent(), maxChecksumSize); err != nil {
+	if err := downloadFile(ctx, u.client, checksumsURL, checksumsPath, u.userAgent(), maxChecksumSize, nil, ""); err != nil {
 		cleanup()
 		return "", func() {}, fmt.Errorf("download release checksums: %w", err)
 	}
@@ -156,7 +158,7 @@ func (u *Updater) prepareCandidate(ctx context.Context, version string) (string,
 	}
 
 	archivePath := filepath.Join(tempDir, asset.Name)
-	if err := downloadFile(ctx, u.client, u.releaseURL(version, asset.Name), archivePath, u.userAgent(), maxArchiveSize); err != nil {
+	if err := downloadFile(ctx, u.client, u.releaseURL(version, asset.Name), archivePath, u.userAgent(), maxArchiveSize, u.ProgressWrap, version); err != nil {
 		cleanup()
 		return "", func() {}, fmt.Errorf("download release archive: %w", err)
 	}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -186,6 +186,27 @@ func (s *UpdaterSuite) TestStandaloneUpdateDownloadsVerifiesAndReplaces() {
 	s.Contains(stdout.String(), "Updated vizb from v1.0.0 to v1.1.0")
 }
 
+func (s *UpdaterSuite) TestArchiveDownloadInvokesProgressWrapOnce() {
+	archive := tarGzipArchive(s.T(), "vizb", []byte("new-vizb"))
+	server := newReleaseServer(s.T(), "v1.1.0", "vizb@1.1.0-linux-amd64.tar.gz", archive, false)
+	defer server.Close()
+
+	target := filepath.Join(s.T().TempDir(), "vizb")
+	s.Require().NoError(os.WriteFile(target, []byte("old-vizb"), 0o755))
+
+	var calls, closed int
+	service := standaloneUpdater(server, target, "v1.0.0", "linux", "amd64")
+	service.ProgressWrap = func(r io.Reader, total int64, label string) io.Reader {
+		calls++
+		s.Equal("v1.1.0", label)
+		s.Equal(int64(len(archive)), total)
+		return closeNotify{Reader: r, n: &closed}
+	}
+	s.Require().NoError(service.Run(context.Background(), strings.NewReader(""), io.Discard, io.Discard))
+	s.Equal(1, calls)
+	s.Equal(1, closed)
+}
+
 func (s *UpdaterSuite) TestChecksumFailurePreservesExecutable() {
 	archive := tarGzipArchive(s.T(), "vizb", []byte("new-vizb"))
 	server := newReleaseServer(s.T(), "v1.1.0", "vizb@1.1.0-linux-amd64.tar.gz", archive, true)
@@ -474,6 +495,16 @@ func tarGzipArchive(t *testing.T, name string, content []byte) []byte {
 		t.Fatal(err)
 	}
 	return buffer.Bytes()
+}
+
+type closeNotify struct {
+	io.Reader
+	n *int
+}
+
+func (c closeNotify) Close() error {
+	*c.n++
+	return nil
 }
 
 func TestUpdaterSuite(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add a TTY determinate download bar (brand green) while `vizb update` fetches the release archive.
- Checksums skip the bar; the line clears before the success message so stdout stays clean.
- Local `go build` / `task build:cli` builds play a mock download on a TTY so the bar can be previewed without replacing the binary.

## Test Plan
- [ ] `go test -count=1 ./cmd/cli ./cmd ./internal/updater`
- [ ] `task lint:cli`
- [ ] Standalone TTY: `vizb update` shows the bar, then `Updated vizb from …`
- [ ] Piped / CI: no bar
- [ ] Local build: `go build -o /tmp/vizb . && /tmp/vizb update` — mock bar, then `binary not updated`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal download progress indicators for update downloads, including percentage and human-readable size details.
  * Development builds now show a preview download without replacing the current binary.
  * Progress output automatically remains silent in non-terminal environments.

* **Documentation**
  * Documented update download progress and development-build preview behavior.

* **Bug Fixes**
  * Improved update download handling while preserving size limits, checksums, and safe update checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->