### PR TITLE
feat(cli): parse --scale bag onto chart Scale

### DIFF
--- a/cmd/cli/flagbag.go
+++ b/cmd/cli/flagbag.go
@@ -138,6 +138,8 @@ func (b *FlagBag) Validate(cmd *cobra.Command) {
 			}})
 		case f.Kind == flags.KindObject:
 			b.validateObjectFlag(cmd, f)
+		case f.Name == "scale":
+			b.validateScaleFlag(cmd, f)
 		case f.IsSoft():
 			b.applySoftRule(f)
 		case f.Validate != nil && cmd.Flags().Changed(f.Name):
@@ -146,6 +148,23 @@ func (b *FlagBag) Validate(cmd *cobra.Command) {
 			}
 		}
 	}
+}
+
+// validateScaleFlag accepts a bare linear|log (warn-and-default via ValidSet)
+// or an unwrapped bag. Unknown bag keys are fatal; invalid bases and axis
+// names are handled later by EncodeScaleValue (warn-and-default / skip).
+func (b *FlagBag) validateScaleFlag(cmd *cobra.Command, f flags.Flag) {
+	raw := *b.strs[f.Name]
+	if shared.IsScaleBag(raw) {
+		if !cmd.Flags().Changed(f.Name) {
+			return
+		}
+		if _, err := shared.ParseObjectBagString(raw, f.ObjectFields); err != nil {
+			shared.ExitWithError(fmt.Sprintf("--%s: %v", f.Name, err), nil)
+		}
+		return
+	}
+	b.applySoftRule(f)
 }
 
 // validateObjectFlag fatals on an invalid object-flag bag (unknown field or a
@@ -320,7 +339,11 @@ func (b *FlagBag) ChartSeed(cmd *cobra.Command) map[string]any {
 			}
 		default: // KindString
 			if changed || f.Default != nil {
-				seed[f.JSONKey] = encodeFlag(f, *b.strs[f.Name])
+				if f.Name == "scale" {
+					seed[f.JSONKey] = shared.EncodeScaleValue(*b.strs[f.Name], f.ObjectFields)
+				} else {
+					seed[f.JSONKey] = encodeFlag(f, *b.strs[f.Name])
+				}
 			}
 		}
 	}

--- a/cmd/cli/flagbag.go
+++ b/cmd/cli/flagbag.go
@@ -154,14 +154,8 @@ func (b *FlagBag) Validate(cmd *cobra.Command) {
 // or an unwrapped bag. Unknown bag keys are fatal; invalid bases and axis
 // names are handled later by EncodeScaleValue (warn-and-default / skip).
 func (b *FlagBag) validateScaleFlag(cmd *cobra.Command, f flags.Flag) {
-	raw := *b.strs[f.Name]
-	if shared.IsScaleBag(raw) {
-		if !cmd.Flags().Changed(f.Name) {
-			return
-		}
-		if _, err := shared.ParseObjectBagString(raw, f.ObjectFields); err != nil {
-			shared.ExitWithError(fmt.Sprintf("--%s: %v", f.Name, err), nil)
-		}
+	if shared.IsScaleBag(*b.strs[f.Name]) {
+		b.validateObjectFlag(cmd, f)
 		return
 	}
 	b.applySoftRule(f)

--- a/cmd/cli/flagbag_test.go
+++ b/cmd/cli/flagbag_test.go
@@ -70,6 +70,76 @@ func (s *FlagBagSuite) TestScaleWarnDefault() {
 		testutil.CaptureStderr(func() { bag.Validate(cmd) })
 		s.Equal("linear", bag.String("scale"))
 	})
+	s.Run("nested colon log:axes=x is not a bag", func() {
+		cmd, bag := s.newCmdBag(append(slices.Clone(DataFlags), internal_charts.ScaleFlag))
+		s.Require().NoError(cmd.Flags().Set("scale", "log:axes=x"))
+		testutil.CaptureStderr(func() { bag.Validate(cmd) })
+		s.Equal("linear", bag.String("scale"))
+	})
+}
+
+func (s *FlagBagSuite) TestScaleBagSeed() {
+	fl := append(slices.Clone(DataFlags), internal_charts.ScaleFlag)
+
+	s.Run("bare log stays a string", func() {
+		cmd, bag := s.newCmdBag(fl)
+		s.Require().NoError(cmd.Flags().Set("scale", "log"))
+		bag.Validate(cmd)
+		s.Equal("log", bag.ChartSeed(cmd)["scale"])
+	})
+	s.Run("type=log with no axes stays a string", func() {
+		cmd, bag := s.newCmdBag(fl)
+		s.Require().NoError(cmd.Flags().Set("scale", "type=log"))
+		bag.Validate(cmd)
+		s.Equal("log", bag.ChartSeed(cmd)["scale"])
+	})
+	s.Run("axes bag encodes an object", func() {
+		cmd, bag := s.newCmdBag(fl)
+		s.Require().NoError(cmd.Flags().Set("scale", "type=log;axes=x"))
+		bag.Validate(cmd)
+		s.Equal(map[string]any{
+			"type": "log",
+			"axes": []string{"x"},
+			"base": 10.0,
+		}, bag.ChartSeed(cmd)["scale"])
+	})
+	s.Run("unknown axis warns and skips", func() {
+		cmd, bag := s.newCmdBag(fl)
+		s.Require().NoError(cmd.Flags().Set("scale", "type=log;axes=x,q"))
+		bag.Validate(cmd)
+		var seed map[string]any
+		out := testutil.CaptureStderr(func() { seed = bag.ChartSeed(cmd) })
+		s.Contains(out, "Invalid scale axis")
+		s.Equal(map[string]any{
+			"type": "log",
+			"axes": []string{"x"},
+			"base": 10.0,
+		}, seed["scale"])
+	})
+	s.Run("invalid base warns and defaults", func() {
+		cmd, bag := s.newCmdBag(fl)
+		s.Require().NoError(cmd.Flags().Set("scale", "type=log;axes=x;base=1"))
+		bag.Validate(cmd)
+		var seed map[string]any
+		out := testutil.CaptureStderr(func() { seed = bag.ChartSeed(cmd) })
+		s.Contains(out, "Invalid scale base")
+		s.Equal(map[string]any{
+			"type": "log",
+			"axes": []string{"x"},
+			"base": 10.0,
+		}, seed["scale"])
+	})
+}
+
+func (s *FlagBagSuite) TestScaleBagUnknownKeyIsFatal() {
+	fl := append(slices.Clone(DataFlags), internal_charts.ScaleFlag)
+	cmd, bag := s.newCmdBag(fl)
+	s.Require().NoError(cmd.Flags().Set("scale", "type=log;foo=1"))
+
+	restore, exitCalled := testutil.TrapOsExitPanic(s.T())
+	defer restore()
+	s.Panics(func() { bag.Validate(cmd) })
+	s.True(*exitCalled)
 }
 
 func (s *FlagBagSuite) TestParseConfigMapsSelectGrouped() {

--- a/cmd/cli/pipeline_test.go
+++ b/cmd/cli/pipeline_test.go
@@ -344,10 +344,9 @@ func (s *PipelineSuite) TestChartScaleBagRoundTripsThroughMaterialise() {
 		typed := cfg.(*linechart.Config)
 		s.Equal("log", typed.Scale.Type)
 		s.Equal([]string{"x"}, typed.Scale.Axes)
-		raw, err := json.Marshal(typed)
+		raw, err := json.Marshal(typed.Scale)
 		s.Require().NoError(err)
-		s.Contains(string(raw), `"scale":{"type":"log"`)
-		s.Contains(string(raw), `"axes":["x"]`)
+		s.JSONEq(`{"type":"log","axes":["x"],"base":10}`, string(raw))
 	})
 }
 

--- a/cmd/cli/pipeline_test.go
+++ b/cmd/cli/pipeline_test.go
@@ -254,7 +254,7 @@ func (s *PipelineSuite) TestRunLinearGeneratesOutputFile() {
 
 	meta := RunMeta{Parser: "go"} // no themes → empty Themes (UI default)
 	cfg := parser.Config{GroupPattern: "y", TimeUnit: "ns", MemUnit: "B"}
-	barCfg := &barchart.Config{Type: "bar", Scale: "linear"}
+	barCfg := &barchart.Config{Type: "bar", Scale: shared.ScaleLinear}
 	configs := []internal_charts.ChartConfig{barCfg}
 
 	s.Run("HTML output", func() {
@@ -288,7 +288,7 @@ func (s *PipelineSuite) TestRunLinearGeneratesOutputFile() {
 		s.Equal("bar", ds.Settings[0].ChartType())
 		typed, ok := ds.Settings[0].(*barchart.Config)
 		s.Require().True(ok, "expected *barchart.Config, got %T", ds.Settings[0])
-		s.Equal("linear", typed.Scale)
+		s.Equal(shared.ScaleLinear, typed.Scale)
 	})
 }
 
@@ -296,7 +296,7 @@ func (s *PipelineSuite) TestRunLinearPreservesCustomTheme() {
 	benchFile := s.writeFile("input.txt", `BenchmarkExample-8    1000000    1234 ns/op    1000 B/op    10 allocs/op`)
 	meta := RunMeta{Parser: "go", ThemeSpecs: []string{"#f00,#00ff00"}}
 	cfg := parser.Config{GroupPattern: "y", TimeUnit: "ns", MemUnit: "B"}
-	barCfg := &barchart.Config{Type: "bar", Scale: "linear"}
+	barCfg := &barchart.Config{Type: "bar", Scale: shared.ScaleLinear}
 	out := filepath.Join(s.T().TempDir(), "custom-theme.json")
 	meta.OutputFile = out
 	RunLinear(&cobra.Command{}, []string{benchFile}, meta, cfg, []internal_charts.ChartConfig{barCfg}, false)
@@ -312,6 +312,43 @@ func (s *PipelineSuite) TestRunLinearPreservesCustomTheme() {
 	s.Require().Len(ds.Themes, 1)
 	s.Equal("custom", ds.Themes[0].Name)
 	s.Equal([]string{"#f00", "#00ff00"}, ds.Themes[0].Colors)
+}
+
+func (s *PipelineSuite) TestChartScaleBagRoundTripsThroughMaterialise() {
+	s.Run("string log", func() {
+		overrides, warnings, err := shared.ParseOverrides(
+			[]string{"line:scale=log"},
+			[]string{"line"},
+			[]shared.Axis{{Key: "x"}, {Key: "y"}},
+		)
+		s.Require().NoError(err)
+		s.Empty(warnings)
+		cfg, err := internal_charts.Materialise("line", nil, overrides["line"])
+		s.Require().NoError(err)
+		typed := cfg.(*linechart.Config)
+		s.Equal(shared.ScaleLog, typed.Scale)
+		raw, err := json.Marshal(typed)
+		s.Require().NoError(err)
+		s.Contains(string(raw), `"scale":"log"`)
+	})
+	s.Run("brace bag", func() {
+		overrides, warnings, err := shared.ParseOverrides(
+			[]string{"line:scale={type=log;axes=x;base=10}"},
+			[]string{"line"},
+			[]shared.Axis{{Key: "x"}, {Key: "y"}},
+		)
+		s.Require().NoError(err)
+		s.Empty(warnings)
+		cfg, err := internal_charts.Materialise("line", nil, overrides["line"])
+		s.Require().NoError(err)
+		typed := cfg.(*linechart.Config)
+		s.Equal("log", typed.Scale.Type)
+		s.Equal([]string{"x"}, typed.Scale.Axes)
+		raw, err := json.Marshal(typed)
+		s.Require().NoError(err)
+		s.Contains(string(raw), `"scale":{"type":"log"`)
+		s.Contains(string(raw), `"axes":["x"]`)
+	})
 }
 
 func (s *PipelineSuite) TestChartStackOverrideRoundTripsThroughMaterialise() {
@@ -348,13 +385,13 @@ func (s *PipelineSuite) TestRunLinearDatasetPassthrough() {
 	testutil.WriteJSON(s.T(), input, shared.Dataset{
 		Name: "Baked",
 		Settings: []internal_charts.ChartConfig{
-			&linechart.Config{Type: "line", Scale: "linear"},
+			&linechart.Config{Type: "line", Scale: shared.ScaleLinear},
 		},
 		Data: []shared.DataPoint{{Name: "P1", XAxis: "1", YAxis: "100"}},
 	})
 	out := filepath.Join(dir, "out.json")
 
-	barCfg := &barchart.Config{Type: "bar", Scale: "log"}
+	barCfg := &barchart.Config{Type: "bar", Scale: shared.ScaleLog}
 	meta := RunMeta{Parser: "go", OutputFile: out}
 	cfg := parser.Config{GroupPattern: "y", TimeUnit: "ns", MemUnit: "B"}
 
@@ -370,7 +407,7 @@ func (s *PipelineSuite) TestRunLinearDatasetPassthrough() {
 	s.Equal("bar", ds.Settings[0].ChartType())
 	typed, ok := ds.Settings[0].(*barchart.Config)
 	s.Require().True(ok)
-	s.Equal("log", typed.Scale)
+	s.Equal(shared.ScaleLog, typed.Scale)
 }
 
 func (s *PipelineSuite) TestRunLinearDatasetPassthroughTitleWarns() {
@@ -391,14 +428,14 @@ func (s *PipelineSuite) TestRunLinearPreservesDatasetOnRoot() {
 	testutil.WriteJSON(s.T(), input, shared.Dataset{
 		Name: "Baked",
 		Settings: []internal_charts.ChartConfig{
-			&barchart.Config{Type: "bar", Scale: "linear"},
-			&linechart.Config{Type: "line", Scale: "log"},
+			&barchart.Config{Type: "bar", Scale: shared.ScaleLinear},
+			&linechart.Config{Type: "line", Scale: shared.ScaleLog},
 		},
 		Data: []shared.DataPoint{{Name: "P1", XAxis: "1", YAxis: "100"}},
 	})
 	out := filepath.Join(dir, "out.json")
 
-	barCfg := &barchart.Config{Type: "bar", Scale: "log"}
+	barCfg := &barchart.Config{Type: "bar", Scale: shared.ScaleLog}
 	meta := RunMeta{Parser: "go", OutputFile: out}
 	cfg := parser.Config{GroupPattern: "y", TimeUnit: "ns", MemUnit: "B"}
 
@@ -415,7 +452,7 @@ func (s *PipelineSuite) TestRunLinearPreservesDatasetOnRoot() {
 	s.Equal("line", ds.Settings[1].ChartType())
 	lineCfg, ok := ds.Settings[1].(*linechart.Config)
 	s.Require().True(ok)
-	s.Equal("log", lineCfg.Scale)
+	s.Equal(shared.ScaleLog, lineCfg.Scale)
 }
 
 func (s *PipelineSuite) TestRunLinearAutoParser() {
@@ -423,7 +460,7 @@ func (s *PipelineSuite) TestRunLinearAutoParser() {
 	out := filepath.Join(s.T().TempDir(), "out.json")
 	meta := RunMeta{Parser: "auto", OutputFile: out}
 	cfg := parser.Config{GroupPattern: "x", TimeUnit: "ns", MemUnit: "B"}
-	barCfg := &barchart.Config{Type: "bar", Scale: "linear"}
+	barCfg := &barchart.Config{Type: "bar", Scale: shared.ScaleLinear}
 
 	oldStdout, oldStderr := os.Stdout, os.Stderr
 	devnull, _ := os.Open(os.DevNull)
@@ -1025,7 +1062,7 @@ func (s *PipelineSuite) TestResolveInputStdin() {
 	out := filepath.Join(s.T().TempDir(), "out.json")
 	meta := RunMeta{Parser: "go", OutputFile: out}
 	cfg := parser.Config{GroupPattern: "y", TimeUnit: "ns", MemUnit: "B"}
-	barCfg := &barchart.Config{Type: "bar", Scale: "linear"}
+	barCfg := &barchart.Config{Type: "bar", Scale: shared.ScaleLinear}
 
 	RunLinear(&cobra.Command{}, nil, meta, cfg, []internal_charts.ChartConfig{barCfg}, false)
 	s.FileExists(out)
@@ -1245,7 +1282,7 @@ func (s *PipelineSuite) TestRunLinearColAxisTitleKeepsDatasetName() {
 	cfg, err := parser.ResolveGroupConfig(parser.Config{GroupPattern: "y", Group: []string{"load"}, ColAxis: "x"})
 	s.Require().NoError(err)
 
-	RunLinear(&cobra.Command{}, []string{csvFile}, meta, cfg, []internal_charts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}}, false)
+	RunLinear(&cobra.Command{}, []string{csvFile}, meta, cfg, []internal_charts.ChartConfig{&barchart.Config{Type: "bar", Scale: shared.ScaleLinear}}, false)
 
 	ds := testutil.ReadDataset(s.T(), out)
 	s.Equal("Q1 release", ds.Name)
@@ -1443,7 +1480,7 @@ func (s *PipelineSuite) TestRunLinearMultiSelectProducesSingleDatasetWithStats()
 			{Columns: []parser.ColumnSpec{{Source: "region", AxisKey: "x"}, {Source: "sales", AxisKey: "y"}}},
 		},
 	}
-	scatterCfg := &scatterchart.Config{Type: "scatter", Scale: "linear"}
+	scatterCfg := &scatterchart.Config{Type: "scatter", Scale: shared.ScaleLinear}
 	meta := RunMeta{Parser: "csv", OutputFile: out}
 
 	oldStdout, oldStderr := os.Stdout, os.Stderr

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -143,8 +143,8 @@ func (s *RootSuite) TestRunBenchmarkDatasetPassthrough() {
 	testutil.WriteJSON(s.T(), input, shared.Dataset{
 		Name: "Baked",
 		Settings: []internal_charts.ChartConfig{
-			&barchart.Config{Type: "bar", Scale: "log"},
-			&linechart.Config{Type: "line", Scale: "log"},
+			&barchart.Config{Type: "bar", Scale: shared.ScaleLog},
+			&linechart.Config{Type: "line", Scale: shared.ScaleLog},
 		},
 		Data: []shared.DataPoint{{Name: "P1", XAxis: "1", YAxis: "100"}},
 	})
@@ -160,7 +160,7 @@ func (s *RootSuite) TestRunBenchmarkDatasetPassthrough() {
 	s.Equal("line", ds.Settings[1].ChartType())
 	lineCfg, ok := ds.Settings[1].(*linechart.Config)
 	s.Require().True(ok)
-	s.Equal("log", lineCfg.Scale)
+	s.Equal(shared.ScaleLog, lineCfg.Scale)
 }
 
 func (s *RootSuite) TestRunBenchmarkAutoParser() {
@@ -209,7 +209,25 @@ func (s *RootSuite) TestRunBenchmarkScatterChart() {
 
 	scatterCfg, ok := ds.Settings[0].(*scatterchart.Config)
 	s.Require().True(ok)
-	s.Equal("linear", scatterCfg.Scale)
+	s.Equal(shared.ScaleLinear, scatterCfg.Scale)
+}
+
+func (s *RootSuite) TestRunBenchmarkScaleBagChartOverride() {
+	dir := s.T().TempDir()
+	input := testutil.WriteBenchFile(s.T(), dir, "valid.txt",
+		`BenchmarkTest-8    1000000    1234 ns/op    1000 B/op    10 allocs/op`)
+	out := filepath.Join(dir, "out.json")
+	rootCharts = nil
+
+	rootCmd.SetArgs([]string{"-o", out, "-c", "line", "--chart", "line:scale={type=log;axes=x}", input})
+	s.Require().NoError(rootCmd.Execute())
+
+	ds := testutil.ReadDataset(s.T(), out)
+	s.Require().Len(ds.Settings, 1)
+	lineCfg, ok := ds.Settings[0].(*linechart.Config)
+	s.Require().True(ok)
+	s.Equal("log", lineCfg.Scale.Type)
+	s.Equal([]string{"x"}, lineCfg.Scale.Axes)
 }
 
 func (s *RootSuite) TestRunBenchmarkScatterChartOverride() {
@@ -227,7 +245,7 @@ func (s *RootSuite) TestRunBenchmarkScatterChartOverride() {
 
 	scatterCfg, ok := ds.Settings[0].(*scatterchart.Config)
 	s.Require().True(ok)
-	s.Equal("log", scatterCfg.Scale)
+	s.Equal(shared.ScaleLog, scatterCfg.Scale)
 }
 
 func (s *RootSuite) TestBakesDefaultCharts() {

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -258,7 +258,7 @@ func (s *UISuite) TestRunUIFiltersChartsOnExplicitFlag() {
 		Name: "Test",
 		Settings: []internal_charts.ChartConfig{
 			s.barFromJSON(map[string]any{"type": "bar", "scale": "linear"}),
-			&linechart.Config{Type: "line", Scale: "linear"},
+			&linechart.Config{Type: "line", Scale: shared.ScaleLinear},
 		},
 		Data: []shared.DataPoint{{Name: "Test1", XAxis: "1", YAxis: "100"}},
 	})
@@ -288,7 +288,7 @@ func (s *UISuite) TestRunUIPreservesScatterSettingsWithoutChartsFlag() {
 		Settings: []internal_charts.ChartConfig{
 			&scatterchart.Config{
 				Type:            "scatter",
-				Scale:           "linear",
+				Scale:           shared.ScaleLinear,
 				ThreeDRotate:    &threeD,
 				ThreeDVisualMap: &threeDVisualMap,
 			},
@@ -513,7 +513,7 @@ func (s *UISuite) TestRunUIAppliesStatToMultipleChartTypes() {
 		Name: "Test",
 		Settings: []internal_charts.ChartConfig{
 			s.barFromJSON(map[string]any{"type": "bar", "scale": "linear"}),
-			&linechart.Config{Type: "line", Scale: "linear"},
+			&linechart.Config{Type: "line", Scale: shared.ScaleLinear},
 			&piechart.Config{Type: "pie"},
 			&heatmapchart.Config{Type: "heatmap"},
 			&radarchart.Config{Type: "radar"},

--- a/internal/charts/bar/bar.go
+++ b/internal/charts/bar/bar.go
@@ -17,7 +17,7 @@ type Config struct {
 	Type            string               `json:"type"` // always "bar"
 	Swap            string               `json:"swap,omitempty"`
 	Sort            *shared.Sort         `json:"sort,omitempty"`
-	Scale           string               `json:"scale,omitempty"`
+	Scale           shared.Scale         `json:"scale,omitempty"`
 	Stack           *bool                `json:"stack,omitempty"`
 	ShowLabels      *bool                `json:"showLabels,omitempty"`
 	ThreeDRotate    *bool                `json:"threeDRotate,omitempty"`

--- a/internal/charts/flag.go
+++ b/internal/charts/flag.go
@@ -43,14 +43,19 @@ var BaseChartFlags = []flags.Flag{SwapFlag, SortFlag, LabelsFlag, StatFlag}
 // --- Variable flags: composed by the charts that carry them. ---
 
 var (
+	// ScaleFlag is a hybrid string|bag: --scale log (string) or
+	// --scale type=log;axes=x (unwrapped bag). --chart uses scale=log or
+	// scale={…}; an unwrapped bag there is a hard error. ObjectFields describe
+	// the bag; ValidSet still warn-and-defaults bare linear|log.
 	ScaleFlag = flags.Flag{
-		Name: "scale", Shorthand: "S", Usage: "Value scale (linear, log)",
+		Name: "scale", Shorthand: "S", Usage: "Value scale (linear, log, or type=log;axes=x,y;base=10)",
 		Kind: flags.KindString, Default: "linear", JSONKey: "scale",
-		Validate:   ValidateScaleValue,
-		Encode:     func(v any) any { return strings.ToLower(v.(string)) },
-		Label:      "scale",
-		ValidSet:   []string{"linear", "log"},
-		Normalizer: strings.ToLower,
+		Validate:     ValidateScaleValue,
+		Encode:       func(v any) any { return strings.ToLower(v.(string)) },
+		Label:        "scale",
+		ValidSet:     []string{"linear", "log"},
+		Normalizer:   strings.ToLower,
+		ObjectFields: scaleObjectFields(),
 	}
 	StackFlag = flags.Flag{
 		Name: "stack", Usage: "Stack 2D grouped series",
@@ -129,6 +134,18 @@ var (
 		Rule:         []flags.RuleFn{Excludes3DMode()},
 	}
 )
+
+// scaleObjectFields lists the typed fields accepted inside a --scale bag.
+func scaleObjectFields() []flags.ObjectField {
+	return []flags.ObjectField{
+		{Name: "type", Kind: flags.KindString},
+		{Name: "axes", Kind: flags.KindString},
+		{Name: "base", Kind: flags.KindFloat, Encode: EncodeNumber},
+		{Name: "baseX", Kind: flags.KindFloat, Encode: EncodeNumber},
+		{Name: "baseY", Kind: flags.KindFloat, Encode: EncodeNumber},
+		{Name: "baseZ", Kind: flags.KindFloat, Encode: EncodeNumber},
+	}
+}
 
 // bgObjectFields lists the typed style fields accepted inside the --bg object.
 func bgObjectFields() []flags.ObjectField {

--- a/internal/charts/flag.go
+++ b/internal/charts/flag.go
@@ -51,7 +51,6 @@ var (
 		Name: "scale", Shorthand: "S", Usage: "Value scale (linear, log, or type=log;axes=x,y;base=10)",
 		Kind: flags.KindString, Default: "linear", JSONKey: "scale",
 		Validate:     ValidateScaleValue,
-		Encode:       func(v any) any { return strings.ToLower(v.(string)) },
 		Label:        "scale",
 		ValidSet:     []string{"linear", "log"},
 		Normalizer:   strings.ToLower,

--- a/internal/charts/flag_test.go
+++ b/internal/charts/flag_test.go
@@ -19,6 +19,24 @@ func (s *ChartFlagSuite) TestValidateScaleValue() {
 	require.NoError(t, charts.ValidateScaleValue("linear"))
 	require.NoError(t, charts.ValidateScaleValue("LOG"))
 	assert.Error(t, charts.ValidateScaleValue("sqrt"))
+	assert.Error(t, charts.ValidateScaleValue("type=log;axes=x"), "bags are not validated by the string enum")
+}
+
+func (s *ChartFlagSuite) TestScaleFlagDescriptor() {
+	t := s.T()
+	assert.Equal(t, "scale", charts.ScaleFlag.Name)
+	assert.Equal(t, flags.KindString, charts.ScaleFlag.Kind)
+	assert.Equal(t, "linear", charts.ScaleFlag.Default)
+	assert.Equal(t, []string{"linear", "log"}, charts.ScaleFlag.ValidSet)
+	assert.Len(t, charts.ScaleFlag.ObjectFields, 6)
+
+	known := map[string]bool{}
+	for _, field := range charts.ScaleFlag.ObjectFields {
+		known[field.Name] = true
+	}
+	for _, name := range []string{"type", "axes", "base", "baseX", "baseY", "baseZ"} {
+		assert.True(t, known[name], "field %s", name)
+	}
 }
 
 func (s *ChartFlagSuite) TestValidateSymbolSizeValue() {

--- a/internal/charts/line/line.go
+++ b/internal/charts/line/line.go
@@ -14,7 +14,7 @@ type Config struct {
 	Type            string             `json:"type"`
 	Swap            string             `json:"swap,omitempty"`
 	Sort            *shared.Sort       `json:"sort,omitempty"`
-	Scale           string             `json:"scale,omitempty"`
+	Scale           shared.Scale       `json:"scale,omitempty"`
 	Stack           *bool              `json:"stack,omitempty"`
 	ShowLabels      *bool              `json:"showLabels,omitempty"`
 	Symbol          string             `json:"symbol,omitempty"`

--- a/internal/charts/materialise_test.go
+++ b/internal/charts/materialise_test.go
@@ -1,6 +1,7 @@
 package charts_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	_ "github.com/goptics/vizb/cmd/charts/bar"
@@ -35,10 +36,22 @@ func (s *MaterialiseSuite) materialise(chartType string, seed map[string]any, ov
 func (s *MaterialiseSuite) TestScaleDefault() {
 	// No seed, no override → scale falls back to the descriptor default.
 	got := s.materialise("bar", nil, nil).(*barchart.Config)
-	s.Equal("linear", got.Scale)
+	s.Equal(shared.ScaleLinear, got.Scale)
 	s.Nil(got.ShowLabels)
 	s.Nil(got.Sort)
 	s.Nil(got.BorderRadius)
+}
+
+func (s *MaterialiseSuite) TestScaleObjectSeed() {
+	seed := map[string]any{"scale": map[string]any{"type": "log", "axes": []string{"x"}, "base": 10.0}}
+	got := s.materialise("line", seed, nil).(*linechart.Config)
+	s.Equal("log", got.Scale.Type)
+	s.Equal([]string{"x"}, got.Scale.Axes)
+
+	raw, err := json.Marshal(got)
+	s.Require().NoError(err)
+	s.Contains(string(raw), `"scale":{"type":"log"`)
+	s.Contains(string(raw), `"axes":["x"]`)
 }
 
 func (s *MaterialiseSuite) TestBarBorderRadiusSeed() {
@@ -53,11 +66,11 @@ func (s *MaterialiseSuite) TestBarBorderRadiusSeed() {
 
 func (s *MaterialiseSuite) TestSeedThenOverride() {
 	seed := map[string]any{"swap": "xyn", "scale": "linear", "sort": sortSeed("asc")}
-	override := &barchart.Config{Swap: "yxn", Scale: "log"}
+	override := &barchart.Config{Swap: "yxn", Scale: shared.ScaleLog}
 	got := s.materialise("bar", seed, override).(*barchart.Config)
 
-	s.Equal("yxn", got.Swap)  // override wins
-	s.Equal("log", got.Scale) // override wins
+	s.Equal("yxn", got.Swap)            // override wins
+	s.Equal(shared.ScaleLog, got.Scale) // override wins
 	s.Require().NotNil(got.Sort)
 	s.Equal("asc", got.Sort.Order) // seed survives where override is empty
 }

--- a/internal/charts/materialise_test.go
+++ b/internal/charts/materialise_test.go
@@ -48,10 +48,9 @@ func (s *MaterialiseSuite) TestScaleObjectSeed() {
 	s.Equal("log", got.Scale.Type)
 	s.Equal([]string{"x"}, got.Scale.Axes)
 
-	raw, err := json.Marshal(got)
+	raw, err := json.Marshal(got.Scale)
 	s.Require().NoError(err)
-	s.Contains(string(raw), `"scale":{"type":"log"`)
-	s.Contains(string(raw), `"axes":["x"]`)
+	s.JSONEq(`{"type":"log","axes":["x"],"base":10}`, string(raw))
 }
 
 func (s *MaterialiseSuite) TestBarBorderRadiusSeed() {

--- a/internal/charts/registry_test.go
+++ b/internal/charts/registry_test.go
@@ -98,7 +98,7 @@ func (s *RegistrySuite) TestNewScatterKnownType() {
 }
 
 func (s *RegistrySuite) TestDecodeBarRoundTrip() {
-	original := barchart.Config{Type: "bar", Swap: "yxn", Scale: "log"}
+	original := barchart.Config{Type: "bar", Swap: "yxn", Scale: shared.ScaleLog}
 	raw, err := json.Marshal(original)
 	s.Require().NoError(err)
 

--- a/internal/charts/rules.go
+++ b/internal/charts/rules.go
@@ -74,6 +74,59 @@ func ExcludesAxes(keys ...string) flags.RuleFn {
 	}
 }
 
+// stackedValueAxis is the axis stacking accumulates on: X for horizontal bars,
+// otherwise Y.
+func stackedValueAxis(rc RuleContext) string {
+	if h, ok := rc.Config["horizontal"].(bool); ok && h {
+		return "x"
+	}
+	return "y"
+}
+
+// scaleLogsStackedAxis reports whether scale logs the stacked value axis.
+// String "log" and a log object with omitted axes are today's default value
+// axis. An object that logs only a non-stacked axis does not block stack.
+func scaleLogsStackedAxis(scale any, valueAxis string) bool {
+	switch s := scale.(type) {
+	case string:
+		return strings.EqualFold(s, "log")
+	case map[string]any:
+		typ, _ := s["type"].(string)
+		if !strings.EqualFold(typ, "log") {
+			return false
+		}
+		axes := scaleAxes(s["axes"])
+		if len(axes) == 0 {
+			return true
+		}
+		for _, a := range axes {
+			if strings.EqualFold(a, valueAxis) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+func scaleAxes(raw any) []string {
+	switch v := raw.(type) {
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if a, ok := item.(string); ok {
+				out = append(out, a)
+			}
+		}
+		return out
+	case []string:
+		return v
+	default:
+		return nil
+	}
+}
+
 // StackRequiresLinearScale skips --stack when the same chart config uses a log
 // scale. ECharts stacked bar/line series are not valid on log axes.
 func StackRequiresLinearScale() flags.RuleFn {
@@ -86,8 +139,7 @@ func StackRequiresLinearScale() flags.RuleFn {
 		if ok && !enabled {
 			return flags.Keep, ""
 		}
-		scale, _ := rc.Config["scale"].(string)
-		if strings.EqualFold(scale, "log") {
+		if scaleLogsStackedAxis(rc.Config["scale"], stackedValueAxis(rc)) {
 			return flags.Skip, "stacked bar/line charts require linear scale; ignoring"
 		}
 		return flags.Keep, ""

--- a/internal/charts/rules_test.go
+++ b/internal/charts/rules_test.go
@@ -168,6 +168,18 @@ func (s *RulesSuite) TestStackRequiresLinearScale_KeepWhenLogOnlyOnX() {
 	s.Empty(msg)
 }
 
+func (s *RulesSuite) TestStackRequiresLinearScale_KeepWhenLinearObject() {
+	rule := charts.StackRequiresLinearScale()
+	out, msg := rule(charts.RuleContext{
+		Value: true,
+		Config: map[string]any{
+			"scale": map[string]any{"type": "linear", "axes": []any{"y"}},
+		},
+	})
+	s.Equal(flags.Keep, out)
+	s.Empty(msg)
+}
+
 func (s *RulesSuite) TestStackRequiresLinearScale_SkipWhenLogObjectOmitsAxes() {
 	rule := charts.StackRequiresLinearScale()
 	out, msg := rule(charts.RuleContext{

--- a/internal/charts/rules_test.go
+++ b/internal/charts/rules_test.go
@@ -156,6 +156,30 @@ func (s *RulesSuite) TestStackRequiresLinearScale_SkipWhenLog() {
 	s.Contains(msg, "linear scale")
 }
 
+func (s *RulesSuite) TestStackRequiresLinearScale_KeepWhenLogOnlyOnX() {
+	rule := charts.StackRequiresLinearScale()
+	out, msg := rule(charts.RuleContext{
+		Value: true,
+		Config: map[string]any{
+			"scale": map[string]any{"type": "log", "axes": []any{"x"}},
+		},
+	})
+	s.Equal(flags.Keep, out)
+	s.Empty(msg)
+}
+
+func (s *RulesSuite) TestStackRequiresLinearScale_SkipWhenLogObjectOmitsAxes() {
+	rule := charts.StackRequiresLinearScale()
+	out, msg := rule(charts.RuleContext{
+		Value: true,
+		Config: map[string]any{
+			"scale": map[string]any{"type": "log"},
+		},
+	})
+	s.Equal(flags.Skip, out)
+	s.Contains(msg, "linear scale")
+}
+
 func (s *RulesSuite) TestStackRequiresLinearScale_FatalOnWrongContext() {
 	rule := charts.StackRequiresLinearScale()
 	out, msg := rule(struct{}{})
@@ -236,7 +260,7 @@ func (s *RulesSuite) TestApplyRules_EmptyConfigs() {
 
 func (s *RulesSuite) TestApplyRules_NoRulesOnDescriptors() {
 	// A config with no rule-gated keys present is a no-op.
-	raw, err := json.Marshal(barchart.Config{Type: "bar", Scale: "log"})
+	raw, err := json.Marshal(barchart.Config{Type: "bar", Scale: shared.ScaleLog})
 	s.Require().NoError(err)
 
 	cfg, err := charts.Decode("bar", raw)
@@ -330,7 +354,7 @@ func (s *RulesSuite) TestApplyRules_MultipleRulesWorstWins() {
 func (s *RulesSuite) TestApplyRules_StackKeptForXYLinear() {
 	stack := true
 	configs := []charts.ChartConfig{
-		&barchart.Config{Type: "bar", Scale: "linear", Stack: &stack},
+		&barchart.Config{Type: "bar", Scale: shared.ScaleLinear, Stack: &stack},
 	}
 	ctx := charts.RuleContext{Axes: []charts.AxisInfo{{Key: "x"}, {Key: "y"}}}
 
@@ -346,7 +370,7 @@ func (s *RulesSuite) TestApplyRules_StackKeptForXYLinear() {
 func (s *RulesSuite) TestApplyRules_StackSkippedWhenZPresent() {
 	stack := true
 	configs := []charts.ChartConfig{
-		&barchart.Config{Type: "bar", Scale: "linear", Stack: &stack},
+		&barchart.Config{Type: "bar", Scale: shared.ScaleLinear, Stack: &stack},
 	}
 	ctx := charts.RuleContext{Axes: []charts.AxisInfo{{Key: "x"}, {Key: "y"}, {Key: "z"}}}
 
@@ -363,7 +387,7 @@ func (s *RulesSuite) TestApplyRules_StackSkippedWhenZPresent() {
 func (s *RulesSuite) TestApplyRules_StackSkippedOnLogScale() {
 	stack := true
 	configs := []charts.ChartConfig{
-		&barchart.Config{Type: "bar", Scale: "log", Stack: &stack},
+		&barchart.Config{Type: "bar", Scale: shared.ScaleLog, Stack: &stack},
 	}
 	ctx := charts.RuleContext{Axes: []charts.AxisInfo{{Key: "x"}, {Key: "y"}}}
 
@@ -375,6 +399,55 @@ func (s *RulesSuite) TestApplyRules_StackSkippedOnLogScale() {
 
 	got := configs[0].(*barchart.Config)
 	s.Nil(got.Stack)
+}
+
+func (s *RulesSuite) TestApplyRules_StackSkippedWhenLogObjectOnValueAxis() {
+	stack := true
+	configs := []charts.ChartConfig{
+		&barchart.Config{Type: "bar", Scale: shared.Scale{Type: "log", Axes: []string{"y"}}, Stack: &stack},
+	}
+	ctx := charts.RuleContext{Axes: []charts.AxisInfo{{Key: "x"}, {Key: "y"}}}
+
+	warnings, fatal := charts.ApplyRules(ctx, configs)
+	s.Nil(fatal)
+	s.Len(warnings, 1)
+	s.Contains(warnings[0], `"stack" skipped`)
+	s.Nil(configs[0].(*barchart.Config).Stack)
+}
+
+func (s *RulesSuite) TestApplyRules_StackKeptWhenLogObjectOnCategoryAxis() {
+	stack := true
+	configs := []charts.ChartConfig{
+		&barchart.Config{Type: "bar", Scale: shared.Scale{Type: "log", Axes: []string{"x"}}, Stack: &stack},
+	}
+	ctx := charts.RuleContext{Axes: []charts.AxisInfo{{Key: "x"}, {Key: "y"}}}
+
+	warnings, fatal := charts.ApplyRules(ctx, configs)
+	s.Nil(fatal)
+	s.Empty(warnings)
+	got := configs[0].(*barchart.Config)
+	s.Require().NotNil(got.Stack)
+	s.True(*got.Stack)
+}
+
+func (s *RulesSuite) TestApplyRules_StackSkippedWhenHorizontalLogOnX() {
+	stack := true
+	horizontal := true
+	configs := []charts.ChartConfig{
+		&barchart.Config{
+			Type:       "bar",
+			Scale:      shared.Scale{Type: "log", Axes: []string{"x"}},
+			Stack:      &stack,
+			Horizontal: &horizontal,
+		},
+	}
+	ctx := charts.RuleContext{Axes: []charts.AxisInfo{{Key: "x"}, {Key: "y"}}}
+
+	warnings, fatal := charts.ApplyRules(ctx, configs)
+	s.Nil(fatal)
+	s.Len(warnings, 1)
+	s.Contains(warnings[0], `"stack" skipped`)
+	s.Nil(configs[0].(*barchart.Config).Stack)
 }
 
 // --- Excludes3DMode (bar --bg) ---

--- a/internal/charts/scatter/scatter.go
+++ b/internal/charts/scatter/scatter.go
@@ -14,7 +14,7 @@ type Config struct {
 	Type            string             `json:"type"`
 	Swap            string             `json:"swap,omitempty"`
 	Sort            *shared.Sort       `json:"sort,omitempty"`
-	Scale           string             `json:"scale,omitempty"`
+	Scale           shared.Scale       `json:"scale,omitempty"`
 	ShowLabels      *bool              `json:"showLabels,omitempty"`
 	Symbol          string             `json:"symbol,omitempty"`
 	SymbolSize      *float64           `json:"symbolSize,omitempty"`

--- a/internal/flags/flag.go
+++ b/internal/flags/flag.go
@@ -93,8 +93,9 @@ type Flag struct {
 	// --chart value (or one flag value), not a comma-split list.
 	MultiValue bool
 
-	// ObjectFields: for KindObject flags, the typed fields accepted inside the
-	// object bag (semicolon-separated key=value pairs). Unknown keys are fatal.
+	// ObjectFields: typed fields accepted inside an object bag (semicolon
+	// key=value pairs). Used by KindObject flags and by hybrid KindString flags
+	// that also accept an unwrapped bag (scale). Unknown keys are fatal.
 	ObjectFields []ObjectField
 
 	// --- fatal validation (chart flags): invalid input ⇒ error ---

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -25,7 +25,7 @@ func (s *CoreSuite) TestConvertCSV() {
 		Parser:   "csv",
 		Config:   parser.Config{GroupPattern: "x", Group: []string{"region"}},
 		Metadata: Metadata{Name: "API latency"},
-		Charts:   []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
+		Charts:   []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: shared.ScaleLinear}},
 	})
 	s.Require().NoError(err)
 	s.Equal("API latency", result.Dataset.Name)
@@ -42,7 +42,7 @@ func (s *CoreSuite) TestConvertColAxisTitle() {
 		Metadata: Metadata{
 			Name: "Q1 release",
 		},
-		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
+		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: shared.ScaleLinear}},
 	})
 	s.Require().NoError(err)
 	s.Equal("Q1 release", result.Dataset.Name)
@@ -56,7 +56,7 @@ func (s *CoreSuite) TestConvertColAxisTitle() {
 		Input:  []byte("load,default,chi\n100,1,2\n"),
 		Parser: "csv",
 		Title:  "Ignored",
-		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
+		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: shared.ScaleLinear}},
 	})
 	var optionErr *OptionError
 	s.Require().ErrorAs(err, &optionErr)
@@ -73,7 +73,7 @@ func (s *CoreSuite) TestConvertJSONAndValidationFailures() {
 		Input:  []byte(`[{"region":"west","latency":12},{"region":"east","latency":18}]`),
 		Parser: "json",
 		Config: parser.Config{GroupPattern: "x", Group: []string{"region"}},
-		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
+		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: shared.ScaleLinear}},
 	})
 	s.Require().NoError(err)
 	s.Len(result.Dataset.Data, 2)
@@ -82,7 +82,7 @@ func (s *CoreSuite) TestConvertJSONAndValidationFailures() {
 		Input:  []byte("region,latency\nwest,12\n"),
 		Parser: "csv",
 		Config: parser.Config{GroupPattern: "x", Group: []string{"missing"}},
-		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
+		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: shared.ScaleLinear}},
 	})
 	s.ErrorContains(err, `group column "missing" not found`)
 
@@ -90,13 +90,13 @@ func (s *CoreSuite) TestConvertJSONAndValidationFailures() {
 		Input:  []byte("region,latency\nwest,12\n"),
 		Parser: "csv",
 		Config: parser.Config{Axes: []parser.ColumnSpec{{Source: "missing"}}},
-		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
+		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: shared.ScaleLinear}},
 	})
 	s.ErrorContains(err, `--axes column "missing" not found`)
 }
 
 func (s *CoreSuite) TestOperations() {
-	chart := &barchart.Config{Type: "bar", Scale: "linear"}
+	chart := &barchart.Config{Type: "bar", Scale: shared.ScaleLinear}
 	_, err := Convert(ConvertInput{
 		Input:  []byte("region,latency\nwest,nope\n"),
 		Parser: "csv",
@@ -118,7 +118,7 @@ func (s *CoreSuite) TestOperations() {
 }
 
 func (s *CoreSuite) TestConvertBranchErrorsAndAutoDetection() {
-	chart := []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}}
+	chart := []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: shared.ScaleLinear}}
 	for _, tc := range []struct {
 		name  string
 		input ConvertInput
@@ -159,7 +159,7 @@ func (s *CoreSuite) TestConvertBranchErrorsAndAutoDetection() {
 }
 
 func (s *CoreSuite) TestConvertIdentifiesInapplicableOptions() {
-	chart := []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}}
+	chart := []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: shared.ScaleLinear}}
 	for _, input := range []ConvertInput{
 		{
 			Input:  []byte("BenchmarkFoo-8 100 123 ns/op\n"),
@@ -191,7 +191,7 @@ func (s *CoreSuite) TestConvertIdentifiesInapplicableOptions() {
 }
 
 func (s *CoreSuite) TestConvertBenchmarkFormats() {
-	chart := []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}}
+	chart := []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: shared.ScaleLinear}}
 	cases := []struct {
 		name   string
 		parser string
@@ -254,7 +254,7 @@ func (s *CoreSuite) TestConvertGoBenchmarkMetadataIsRequestLocal() {
 				Input:  []byte(tc.input),
 				Parser: "go",
 				Config: parser.Config{GroupPattern: "y", TimeUnit: "ns"},
-				Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
+				Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: shared.ScaleLinear}},
 			})
 			outcomes <- outcome{index: index, dataset: result.Dataset, err: err}
 		}(i)
@@ -277,7 +277,7 @@ func (s *CoreSuite) TestConvertKeepsExplicitSystemMetadata() {
 		Parser:   "go",
 		Config:   parser.Config{GroupPattern: "y", TimeUnit: "ns"},
 		Metadata: Metadata{System: explicit},
-		Charts:   []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
+		Charts:   []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: shared.ScaleLinear}},
 	})
 
 	s.Require().NoError(err)
@@ -293,7 +293,7 @@ func (s *CoreSuite) TestConvertAutoJSONPathEnvelope() {
 			GroupPattern: "x",
 			Group:        []string{"region"},
 		},
-		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
+		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: shared.ScaleLinear}},
 	})
 
 	s.Require().NoError(err)
@@ -302,7 +302,7 @@ func (s *CoreSuite) TestConvertAutoJSONPathEnvelope() {
 }
 
 func (s *CoreSuite) TestConvertReturnsParserLookupError() {
-	chart := []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}}
+	chart := []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: shared.ScaleLinear}}
 	saved := parser.Parsers["csv"]
 	delete(parser.Parsers, "csv")
 	s.T().Cleanup(func() { parser.Parsers["csv"] = saved })
@@ -327,7 +327,7 @@ func (s *CoreSuite) TestConvertReturnsChartRuleError() {
 		Input:  []byte("region,latency\nwest,12\n"),
 		Parser: "csv",
 		Config: parser.Config{GroupPattern: "x", Group: []string{"region"}},
-		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: "linear"}},
+		Charts: []internalcharts.ChartConfig{&barchart.Config{Type: "bar", Scale: shared.ScaleLinear}},
 	})
 	s.ErrorContains(err, "forced rule failure")
 }

--- a/shared/chart_spec.go
+++ b/shared/chart_spec.go
@@ -236,6 +236,9 @@ func convertFlagValue(f flags.Flag, prop specparse.Prop, axes []Axis) (any, erro
 		return map[string]any{"enabled": true, "math": math}, nil
 
 	default: // KindString, KindFloat, KindInt
+		if f.Name == "scale" {
+			return convertScaleFlagValue(f, prop)
+		}
 		if !hasEq {
 			return nil, fmt.Errorf("--chart: key %q requires a value (e.g. %s=<value>)", f.Name, f.Name)
 		}
@@ -269,6 +272,35 @@ func encode(f flags.Flag, v any) any {
 		return f.Encode(v)
 	}
 	return v
+}
+
+// convertScaleFlagValue converts the hybrid scale --chart token: scale=log
+// (string), scale={type=log;axes=x} (braces), or an unwrapped bag
+// (scale=type=log;…) which is a hard error with a brace hint.
+func convertScaleFlagValue(f flags.Flag, prop specparse.Prop) (any, error) {
+	switch {
+	case !prop.HasValue:
+		return nil, fmt.Errorf("--chart: key %q requires a value (e.g. %s=log or %s={type=log;axes=x})", f.Name, f.Name, f.Name)
+	case prop.Object != nil:
+		payload, err := EncodeScaleBag(prop.Object, f.ObjectFields)
+		if err != nil {
+			return nil, fmt.Errorf("--chart: key %q: %w", f.Name, err)
+		}
+		return payload, nil
+	default:
+		if IsScaleBag(prop.Value) {
+			return nil, fmt.Errorf(
+				"--chart: key %q value %q must be a brace-delimited object, e.g. %s={type=log;axes=x}",
+				f.Name, prop.Value, f.Name,
+			)
+		}
+		if f.Validate != nil {
+			if err := f.Validate(prop.Value); err != nil {
+				return nil, fmt.Errorf("--chart: %w", err)
+			}
+		}
+		return strings.ToLower(prop.Value), nil
+	}
 }
 
 // convertObjectFlagValue converts a KindObject --chart token into its payload:

--- a/shared/chart_spec.go
+++ b/shared/chart_spec.go
@@ -282,11 +282,11 @@ func convertScaleFlagValue(f flags.Flag, prop specparse.Prop) (any, error) {
 	case !prop.HasValue:
 		return nil, fmt.Errorf("--chart: key %q requires a value (e.g. %s=log or %s={type=log;axes=x})", f.Name, f.Name, f.Name)
 	case prop.Object != nil:
-		payload, err := EncodeScaleBag(prop.Object, f.ObjectFields)
+		bag, err := ParseObjectBag(prop.Object, f.ObjectFields)
 		if err != nil {
 			return nil, fmt.Errorf("--chart: key %q: %w", f.Name, err)
 		}
-		return payload, nil
+		return ScaleFromBag(bag).Payload(), nil
 	default:
 		if IsScaleBag(prop.Value) {
 			return nil, fmt.Errorf(

--- a/shared/chart_spec_test.go
+++ b/shared/chart_spec_test.go
@@ -526,6 +526,26 @@ func (s *ChartSpecSuite) TestParseOverridesScaleUnwrappedBagIsError() {
 	s.Contains(err.Error(), "scale={")
 }
 
+func (s *ChartSpecSuite) TestParseOverridesScaleBareIsError() {
+	_, _, err := ParseOverrides([]string{"line:scale"}, []string{"line"}, s.xynAxes)
+	s.Require().Error(err)
+	s.Contains(err.Error(), `key "scale" requires a value`)
+	s.Contains(err.Error(), "scale={type=log;axes=x}")
+}
+
+func (s *ChartSpecSuite) TestParseOverridesScaleBraceUnknownField() {
+	_, _, err := ParseOverrides([]string{"line:scale={nope=1}"}, []string{"line"}, s.xynAxes)
+	s.Require().Error(err)
+	s.Contains(err.Error(), `key "scale"`)
+	s.Contains(err.Error(), "unknown object field")
+}
+
+func (s *ChartSpecSuite) TestParseOverridesScaleInvalidScalar() {
+	_, _, err := ParseOverrides([]string{"line:scale=foo"}, []string{"line"}, s.xynAxes)
+	s.Require().Error(err)
+	s.Contains(err.Error(), `scale value "foo" is invalid`)
+}
+
 func (s *ChartSpecSuite) TestParseOverridesScaleBraceMatchesFlag() {
 	flagPayload := EncodeScaleValue("type=log;axes=x;base=10", internal_charts.ScaleFlag.ObjectFields)
 	got, _, err := ParseOverrides(

--- a/shared/chart_spec_test.go
+++ b/shared/chart_spec_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	internal_charts "github.com/goptics/vizb/internal/charts"
 	"github.com/goptics/vizb/internal/flags"
 	"github.com/goptics/vizb/internal/specparse"
 	"github.com/stretchr/testify/suite"
@@ -464,6 +465,80 @@ func (s *ChartSpecSuite) TestParseOverridesBarBgInvalidFields() {
 			s.Contains(err.Error(), c.want)
 		})
 	}
+}
+
+func (s *ChartSpecSuite) TestParseOverridesScaleStringBackCompat() {
+	got, warnings, err := ParseOverrides([]string{"line:scale=log"}, []string{"line"}, s.xynAxes)
+	s.Require().NoError(err)
+	s.Empty(warnings)
+	s.Equal("log", s.payload(got["line"])["scale"])
+}
+
+func (s *ChartSpecSuite) TestParseOverridesScaleBraceTypeOnlyIsString() {
+	got, warnings, err := ParseOverrides(
+		[]string{"line:scale={type=log}"},
+		[]string{"line"},
+		s.xynAxes,
+	)
+	s.Require().NoError(err)
+	s.Empty(warnings)
+	s.Equal("log", s.payload(got["line"])["scale"])
+}
+
+func (s *ChartSpecSuite) TestParseOverridesScaleBraceBag() {
+	got, warnings, err := ParseOverrides(
+		[]string{"line:scale={type=log;axes=x;base=10}"},
+		[]string{"line"},
+		s.xynAxes,
+	)
+	s.Require().NoError(err)
+	s.Empty(warnings)
+	scale, ok := s.payload(got["line"])["scale"].(map[string]any)
+	s.Require().True(ok, "expected scale object")
+	s.Equal("log", scale["type"])
+	s.Equal([]any{"x"}, scale["axes"])
+	s.Equal(float64(10), scale["base"])
+}
+
+func (s *ChartSpecSuite) TestParseOverridesScaleBraceKeepsSiblingSmooth() {
+	got, warnings, err := ParseOverrides(
+		[]string{"line:scale={type=log;axes=x,y;baseX=5;baseY=10};smooth"},
+		[]string{"line"},
+		s.xynAxes,
+	)
+	s.Require().NoError(err)
+	s.Empty(warnings)
+	m := s.payload(got["line"])
+	s.Equal(true, m["smooth"])
+	scale, ok := m["scale"].(map[string]any)
+	s.Require().True(ok, "expected scale object")
+	s.Equal("log", scale["type"])
+	s.Equal([]any{"x", "y"}, scale["axes"])
+	s.Equal(float64(10), scale["base"])
+	s.Equal(float64(5), scale["baseX"])
+	s.Nil(scale["baseY"])
+}
+
+func (s *ChartSpecSuite) TestParseOverridesScaleUnwrappedBagIsError() {
+	_, _, err := ParseOverrides([]string{"line:scale=type=log;axes=x"}, []string{"line"}, s.xynAxes)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "brace-delimited object")
+	s.Contains(err.Error(), "scale={")
+}
+
+func (s *ChartSpecSuite) TestParseOverridesScaleBraceMatchesFlag() {
+	flagPayload := EncodeScaleValue("type=log;axes=x;base=10", internal_charts.ScaleFlag.ObjectFields)
+	got, _, err := ParseOverrides(
+		[]string{"line:scale={type=log;axes=x;base=10}"},
+		[]string{"line"},
+		s.xynAxes,
+	)
+	s.Require().NoError(err)
+	raw, err := json.Marshal(map[string]any{"scale": flagPayload})
+	s.Require().NoError(err)
+	chartRaw, err := json.Marshal(map[string]any{"scale": s.payload(got["line"])["scale"]})
+	s.Require().NoError(err)
+	s.JSONEq(string(raw), string(chartRaw))
 }
 
 func TestChartSpecSuite(t *testing.T) {

--- a/shared/dataset_test.go
+++ b/shared/dataset_test.go
@@ -49,7 +49,7 @@ func (s *DatasetSuite) TestDatasetUnmarshalJSONDispatchesByType() {
 
 	s.Equal("bar", ds.Settings[0].ChartType())
 	s.Equal("yxn", s.fieldByName(ds.Settings[0], "Swap"))
-	s.Equal("log", s.fieldByName(ds.Settings[0], "Scale"))
+	s.Equal(shared.ScaleLog, s.fieldByName(ds.Settings[0], "Scale"))
 	showLabels, ok := s.fieldByName(ds.Settings[0], "ShowLabels").(*bool)
 	s.Require().True(ok, "ShowLabels should be *bool, got %T", s.fieldByName(ds.Settings[0], "ShowLabels"))
 	s.Require().NotNil(showLabels)

--- a/shared/migrate_external_test.go
+++ b/shared/migrate_external_test.go
@@ -71,7 +71,7 @@ func (s *MigrateExternalSuite) TestMigrateDatasetV0120Settings() {
 	barCfg, ok := ds.Settings[0].(*bar.Config)
 	s.Require().True(ok, "settings[0] = %T, want *bar.Config", ds.Settings[0])
 	s.Equal("bar", barCfg.Type)
-	s.Equal("log", barCfg.Scale)
+	s.Equal(shared.ScaleLog, barCfg.Scale)
 	s.Require().NotNil(barCfg.Sort)
 	s.True(barCfg.Sort.Enabled)
 	s.Equal("desc", barCfg.Sort.Order)
@@ -82,7 +82,7 @@ func (s *MigrateExternalSuite) TestMigrateDatasetV0120Settings() {
 	lineCfg, ok := ds.Settings[1].(*line.Config)
 	s.Require().True(ok, "settings[1] = %T, want *line.Config", ds.Settings[1])
 	s.Equal("line", lineCfg.Type)
-	s.Equal("log", lineCfg.Scale)
+	s.Equal(shared.ScaleLog, lineCfg.Scale)
 
 	// Axes derived from data points: XAxis and YAxis are non-empty, ZAxis is empty.
 	s.Require().Len(ds.Axes, 2)
@@ -190,7 +190,7 @@ func (s *MigrateExternalSuite) TestBuildLegacyConfigPerChartFieldAssignment() {
 		cfg := mustBuildLegacyConfig(s.T(), "bar", shared.Sort{Enabled: true, Order: "asc"}, true, "")
 		barCfg, ok := cfg.(*bar.Config)
 		s.Require().True(ok, "cfg = %T, want *bar.Config", cfg)
-		s.Equal("linear", barCfg.Scale)
+		s.Equal(shared.ScaleLinear, barCfg.Scale)
 		s.True(barCfg.Sort.Enabled)
 		s.Equal("asc", barCfg.Sort.Order)
 		s.Require().NotNil(barCfg.ShowLabels)

--- a/shared/scale.go
+++ b/shared/scale.go
@@ -36,51 +36,26 @@ type Scale struct {
 // IsScaleBag reports whether raw is an unwrapped key=value scale bag
 // (`type=log;axes=x`). Nested-colon `log:axes=x` is not a bag.
 func IsScaleBag(raw string) bool {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return false
-	}
-	if strings.ContainsAny(raw, "{}") {
-		return true
-	}
 	eq := strings.Index(raw, "=")
-	if eq < 0 {
-		return false
-	}
 	colon := strings.Index(raw, ":")
-	if colon >= 0 && colon < eq {
-		return false
-	}
-	return true
+	return eq >= 0 && (colon < 0 || colon > eq)
 }
 
 // EncodeScaleValue converts a --scale flag value (bare linear|log or an
 // unwrapped bag) into the Dataset payload: a string or an object map.
 func EncodeScaleValue(raw string, fields []flags.ObjectField) any {
 	raw = strings.TrimSpace(raw)
-	if !IsScaleBag(raw) {
-		return strings.ToLower(raw)
-	}
 	bag, err := ParseObjectBagString(raw, fields)
-	if err != nil {
-		return "linear"
+	if err == nil {
+		return ScaleFromBag(bag).Payload()
 	}
-	return scaleFromBag(bag).Payload()
-}
-
-// EncodeScaleBag converts brace-delimited --chart scale props into the same
-// Dataset payload EncodeScaleValue produces for the unwrapped flag form.
-func EncodeScaleBag(props []specparse.Prop, fields []flags.ObjectField) (any, error) {
-	bag, err := ParseObjectBag(props, fields)
-	if err != nil {
-		return nil, err
-	}
-	return scaleFromBag(bag).Payload(), nil
+	return strings.ToLower(raw)
 }
 
 // Payload is the JSON-shaped seed value: "linear"/"log" or an object map.
 func (s Scale) Payload() any {
-	if s.isStringForm() {
+	if len(s.Axes) == 0 && !isNonDefaultBase(s.Base) && !isNonDefaultBase(s.BaseX) &&
+		!isNonDefaultBase(s.BaseY) && !isNonDefaultBase(s.BaseZ) {
 		if s.Type == "" {
 			return "linear"
 		}
@@ -96,26 +71,17 @@ func (s Scale) Payload() any {
 			base = *s.Base
 		}
 		m["base"] = base
-		if s.BaseX != nil && *s.BaseX != defaultLogBase {
+		if isNonDefaultBase(s.BaseX) {
 			m["baseX"] = *s.BaseX
 		}
-		if s.BaseY != nil && *s.BaseY != defaultLogBase {
+		if isNonDefaultBase(s.BaseY) {
 			m["baseY"] = *s.BaseY
 		}
-		if s.BaseZ != nil && *s.BaseZ != defaultLogBase {
+		if isNonDefaultBase(s.BaseZ) {
 			m["baseZ"] = *s.BaseZ
 		}
 	}
 	return m
-}
-
-func (s Scale) isStringForm() bool {
-	return len(s.Axes) == 0 && !s.hasNonDefaultBase()
-}
-
-func (s Scale) hasNonDefaultBase() bool {
-	return isNonDefaultBase(s.Base) || isNonDefaultBase(s.BaseX) ||
-		isNonDefaultBase(s.BaseY) || isNonDefaultBase(s.BaseZ)
 }
 
 func isNonDefaultBase(p *float64) bool {
@@ -123,43 +89,7 @@ func isNonDefaultBase(p *float64) bool {
 }
 
 func (s Scale) MarshalJSON() ([]byte, error) {
-	if s.isStringForm() {
-		t := s.Type
-		if t == "" {
-			t = "linear"
-		}
-		return json.Marshal(t)
-	}
-	type wire struct {
-		Type  string   `json:"type"`
-		Axes  []string `json:"axes,omitempty"`
-		Base  *float64 `json:"base,omitempty"`
-		BaseX *float64 `json:"baseX,omitempty"`
-		BaseY *float64 `json:"baseY,omitempty"`
-		BaseZ *float64 `json:"baseZ,omitempty"`
-	}
-	out := wire{
-		Type:  s.Type,
-		Axes:  s.Axes,
-		BaseX: omitDefaultLogBase(s.BaseX),
-		BaseY: omitDefaultLogBase(s.BaseY),
-		BaseZ: omitDefaultLogBase(s.BaseZ),
-	}
-	if strings.EqualFold(s.Type, "log") {
-		base := defaultLogBase
-		if s.Base != nil {
-			base = *s.Base
-		}
-		out.Base = &base
-	}
-	return json.Marshal(out)
-}
-
-func omitDefaultLogBase(p *float64) *float64 {
-	if p == nil || *p == defaultLogBase {
-		return nil
-	}
-	return p
+	return json.Marshal(s.Payload())
 }
 
 func (s *Scale) UnmarshalJSON(data []byte) error {
@@ -242,7 +172,9 @@ func decodeScaleField(key string, raw json.RawMessage, out *Scale) error {
 	return nil
 }
 
-func scaleFromBag(bag map[string]any) Scale {
+// ScaleFromBag maps a parsed object bag onto Scale (warn-and-default invalid
+// type/base; skip unknown axes).
+func ScaleFromBag(bag map[string]any) Scale {
 	sc := Scale{}
 	if t, ok := bag["type"].(string); ok && t != "" {
 		switch strings.ToLower(t) {
@@ -258,7 +190,7 @@ func scaleFromBag(bag map[string]any) Scale {
 	} else {
 		sc.Type = "log"
 	}
-	if raw, ok := bag["axes"]; ok {
+	if raw, ok := bag["axes"].(string); ok {
 		sc.Axes = parseScaleAxes(raw)
 	}
 	sc.Base = parseScaleBase(bag, "base")
@@ -268,20 +200,8 @@ func scaleFromBag(bag map[string]any) Scale {
 	return sc
 }
 
-func parseScaleAxes(raw any) []string {
-	var parts []string
-	switch v := raw.(type) {
-	case string:
-		parts = specparse.SplitList(v)
-	case []string:
-		parts = v
-	case []any:
-		for _, item := range v {
-			if s, ok := item.(string); ok {
-				parts = append(parts, s)
-			}
-		}
-	}
+func parseScaleAxes(raw string) []string {
+	parts := specparse.SplitList(raw)
 	out := make([]string, 0, len(parts))
 	seen := map[string]bool{}
 	for _, p := range parts {
@@ -323,17 +243,6 @@ func asScaleFloat(v any) (float64, bool) {
 	switch n := v.(type) {
 	case float64:
 		return n, !math.IsNaN(n) && !math.IsInf(n, 0)
-	case float32:
-		f := float64(n)
-		return f, !math.IsNaN(f) && !math.IsInf(f, 0)
-	case int:
-		return float64(n), true
-	case json.Number:
-		f, err := n.Float64()
-		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
-			return 0, false
-		}
-		return f, true
 	case string:
 		f, err := strconv.ParseFloat(n, 64)
 		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {

--- a/shared/scale.go
+++ b/shared/scale.go
@@ -1,0 +1,346 @@
+package shared
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/goptics/vizb/internal/flags"
+	"github.com/goptics/vizb/internal/specparse"
+	"github.com/goptics/vizb/pkg/cliout"
+)
+
+const defaultLogBase = 10.0
+
+// ScaleLinear and ScaleLog are the string-form scales (no axes, default base).
+var (
+	ScaleLinear = Scale{Type: "linear"}
+	ScaleLog    = Scale{Type: "log"}
+)
+
+// Scale is a chart value scale. JSON is a string ("linear"|"log") when there
+// are no axes and no non-default base; otherwise an object
+// {type, axes, base, baseX?, baseY?, baseZ?}.
+type Scale struct {
+	Type  string
+	Axes  []string
+	Base  *float64
+	BaseX *float64
+	BaseY *float64
+	BaseZ *float64
+}
+
+// IsScaleBag reports whether raw is an unwrapped key=value scale bag
+// (`type=log;axes=x`). Nested-colon `log:axes=x` is not a bag.
+func IsScaleBag(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false
+	}
+	if strings.ContainsAny(raw, "{}") {
+		return true
+	}
+	eq := strings.Index(raw, "=")
+	if eq < 0 {
+		return false
+	}
+	colon := strings.Index(raw, ":")
+	if colon >= 0 && colon < eq {
+		return false
+	}
+	return true
+}
+
+// EncodeScaleValue converts a --scale flag value (bare linear|log or an
+// unwrapped bag) into the Dataset payload: a string or an object map.
+func EncodeScaleValue(raw string, fields []flags.ObjectField) any {
+	raw = strings.TrimSpace(raw)
+	if !IsScaleBag(raw) {
+		return strings.ToLower(raw)
+	}
+	bag, err := ParseObjectBagString(raw, fields)
+	if err != nil {
+		return "linear"
+	}
+	return scaleFromBag(bag).Payload()
+}
+
+// EncodeScaleBag converts brace-delimited --chart scale props into the same
+// Dataset payload EncodeScaleValue produces for the unwrapped flag form.
+func EncodeScaleBag(props []specparse.Prop, fields []flags.ObjectField) (any, error) {
+	bag, err := ParseObjectBag(props, fields)
+	if err != nil {
+		return nil, err
+	}
+	return scaleFromBag(bag).Payload(), nil
+}
+
+// Payload is the JSON-shaped seed value: "linear"/"log" or an object map.
+func (s Scale) Payload() any {
+	if s.isStringForm() {
+		if s.Type == "" {
+			return "linear"
+		}
+		return s.Type
+	}
+	m := map[string]any{"type": s.Type}
+	if len(s.Axes) > 0 {
+		m["axes"] = append([]string(nil), s.Axes...)
+	}
+	if strings.EqualFold(s.Type, "log") {
+		base := defaultLogBase
+		if s.Base != nil {
+			base = *s.Base
+		}
+		m["base"] = base
+		if s.BaseX != nil && *s.BaseX != defaultLogBase {
+			m["baseX"] = *s.BaseX
+		}
+		if s.BaseY != nil && *s.BaseY != defaultLogBase {
+			m["baseY"] = *s.BaseY
+		}
+		if s.BaseZ != nil && *s.BaseZ != defaultLogBase {
+			m["baseZ"] = *s.BaseZ
+		}
+	}
+	return m
+}
+
+func (s Scale) isStringForm() bool {
+	return len(s.Axes) == 0 && !s.hasNonDefaultBase()
+}
+
+func (s Scale) hasNonDefaultBase() bool {
+	return isNonDefaultBase(s.Base) || isNonDefaultBase(s.BaseX) ||
+		isNonDefaultBase(s.BaseY) || isNonDefaultBase(s.BaseZ)
+}
+
+func isNonDefaultBase(p *float64) bool {
+	return p != nil && *p != defaultLogBase
+}
+
+func (s Scale) MarshalJSON() ([]byte, error) {
+	if s.isStringForm() {
+		t := s.Type
+		if t == "" {
+			t = "linear"
+		}
+		return json.Marshal(t)
+	}
+	type wire struct {
+		Type  string   `json:"type"`
+		Axes  []string `json:"axes,omitempty"`
+		Base  *float64 `json:"base,omitempty"`
+		BaseX *float64 `json:"baseX,omitempty"`
+		BaseY *float64 `json:"baseY,omitempty"`
+		BaseZ *float64 `json:"baseZ,omitempty"`
+	}
+	out := wire{
+		Type:  s.Type,
+		Axes:  s.Axes,
+		BaseX: omitDefaultLogBase(s.BaseX),
+		BaseY: omitDefaultLogBase(s.BaseY),
+		BaseZ: omitDefaultLogBase(s.BaseZ),
+	}
+	if strings.EqualFold(s.Type, "log") {
+		base := defaultLogBase
+		if s.Base != nil {
+			base = *s.Base
+		}
+		out.Base = &base
+	}
+	return json.Marshal(out)
+}
+
+func omitDefaultLogBase(p *float64) *float64 {
+	if p == nil || *p == defaultLogBase {
+		return nil
+	}
+	return p
+}
+
+func (s *Scale) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if bytes.Equal(trimmed, []byte("null")) {
+		*s = Scale{}
+		return nil
+	}
+	if len(trimmed) > 0 && trimmed[0] == '"' {
+		var typ string
+		if err := json.Unmarshal(trimmed, &typ); err != nil {
+			return fmt.Errorf("scale: must be \"linear\" or \"log\"")
+		}
+		switch strings.ToLower(typ) {
+		case "linear", "log":
+			*s = Scale{Type: strings.ToLower(typ)}
+			return nil
+		default:
+			return fmt.Errorf("scale value %q is invalid (must be \"linear\" or \"log\")", typ)
+		}
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &fields); err != nil {
+		return fmt.Errorf("scale: must be a string or object")
+	}
+
+	out := Scale{}
+	for _, key := range sortedRawKeys(fields) {
+		if err := decodeScaleField(key, fields[key], &out); err != nil {
+			return err
+		}
+	}
+	if out.Type == "" {
+		out.Type = "log"
+	}
+	*s = out
+	return nil
+}
+
+func decodeScaleField(key string, raw json.RawMessage, out *Scale) error {
+	path := "scale." + key
+	switch key {
+	case "type":
+		typ, err := decodeBackgroundString(raw)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		switch strings.ToLower(typ) {
+		case "linear", "log":
+			out.Type = strings.ToLower(typ)
+		default:
+			return fmt.Errorf("%s %q is invalid (must be \"linear\" or \"log\")", path, typ)
+		}
+	case "axes":
+		var axes []string
+		if err := json.Unmarshal(raw, &axes); err != nil {
+			return fmt.Errorf("%s: must be an array of axis names", path)
+		}
+		out.Axes = axes
+	case "base", "baseX", "baseY", "baseZ":
+		n, err := decodeBackgroundNumber(raw)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		v := n
+		switch key {
+		case "base":
+			out.Base = &v
+		case "baseX":
+			out.BaseX = &v
+		case "baseY":
+			out.BaseY = &v
+		default:
+			out.BaseZ = &v
+		}
+	default:
+		return fmt.Errorf("scale: unknown field %q", key)
+	}
+	return nil
+}
+
+func scaleFromBag(bag map[string]any) Scale {
+	sc := Scale{}
+	if t, ok := bag["type"].(string); ok && t != "" {
+		switch strings.ToLower(t) {
+		case "linear", "log":
+			sc.Type = strings.ToLower(t)
+		default:
+			cliout.Warn(fmt.Sprintf(
+				"Warning: Invalid scale type '%s'. Reason: must be \"linear\" or \"log\". Using default 'linear'",
+				t,
+			))
+			sc.Type = "linear"
+		}
+	} else {
+		sc.Type = "log"
+	}
+	if raw, ok := bag["axes"]; ok {
+		sc.Axes = parseScaleAxes(raw)
+	}
+	sc.Base = parseScaleBase(bag, "base")
+	sc.BaseX = parseScaleBase(bag, "baseX")
+	sc.BaseY = parseScaleBase(bag, "baseY")
+	sc.BaseZ = parseScaleBase(bag, "baseZ")
+	return sc
+}
+
+func parseScaleAxes(raw any) []string {
+	var parts []string
+	switch v := raw.(type) {
+	case string:
+		parts = specparse.SplitList(v)
+	case []string:
+		parts = v
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				parts = append(parts, s)
+			}
+		}
+	}
+	out := make([]string, 0, len(parts))
+	seen := map[string]bool{}
+	for _, p := range parts {
+		a := strings.ToLower(strings.TrimSpace(p))
+		if a != "x" && a != "y" && a != "z" {
+			cliout.Warn(fmt.Sprintf(
+				"Warning: Invalid scale axis '%s'. Reason: must be x, y, or z. Skipping",
+				p,
+			))
+			continue
+		}
+		if seen[a] {
+			continue
+		}
+		seen[a] = true
+		out = append(out, a)
+	}
+	return out
+}
+
+func parseScaleBase(bag map[string]any, key string) *float64 {
+	raw, ok := bag[key]
+	if !ok {
+		return nil
+	}
+	n, ok := asScaleFloat(raw)
+	if !ok || n <= 0 || n == 1 {
+		cliout.Warn(fmt.Sprintf(
+			"Warning: Invalid scale %s '%v'. Reason: must be greater than 0 and not 1. Using default '%g'",
+			key, raw, defaultLogBase,
+		))
+		ten := defaultLogBase
+		return &ten
+	}
+	return &n
+}
+
+func asScaleFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, !math.IsNaN(n) && !math.IsInf(n, 0)
+	case float32:
+		f := float64(n)
+		return f, !math.IsNaN(f) && !math.IsInf(f, 0)
+	case int:
+		return float64(n), true
+	case json.Number:
+		f, err := n.Float64()
+		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
+			return 0, false
+		}
+		return f, true
+	case string:
+		f, err := strconv.ParseFloat(n, 64)
+		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
+			return 0, false
+		}
+		return f, true
+	default:
+		return 0, false
+	}
+}

--- a/shared/scale_test.go
+++ b/shared/scale_test.go
@@ -153,6 +153,91 @@ func (s *ScaleSuite) TestParseObjectBagThenPayload() {
 	}, got)
 }
 
+func (s *ScaleSuite) TestMarshalPerAxisBases() {
+	baseY, baseZ := 2.0, 8.0
+	sc := shared.Scale{Type: "log", Axes: []string{"y", "z"}, BaseY: &baseY, BaseZ: &baseZ}
+	raw, err := json.Marshal(sc)
+	s.Require().NoError(err)
+	s.JSONEq(`{"type":"log","axes":["y","z"],"base":10,"baseY":2,"baseZ":8}`, string(raw))
+}
+
+func (s *ScaleSuite) TestUnmarshalJSONNullAndObjectFields() {
+	var sc shared.Scale
+	s.Require().NoError(json.Unmarshal([]byte(`null`), &sc))
+	s.Equal(shared.Scale{}, sc)
+
+	s.Require().NoError(json.Unmarshal([]byte(`{}`), &sc))
+	s.Equal("log", sc.Type)
+
+	s.Require().NoError(json.Unmarshal([]byte(`{"type":"log","baseY":2,"baseZ":8}`), &sc))
+	s.Require().NotNil(sc.BaseY)
+	s.Equal(2.0, *sc.BaseY)
+	s.Require().NotNil(sc.BaseZ)
+	s.Equal(8.0, *sc.BaseZ)
+}
+
+func (s *ScaleSuite) TestUnmarshalJSONErrors() {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"invalid string type", `"foo"`, `scale value "foo" is invalid`},
+		{"number", `1`, "must be a string or object"},
+		{"array", `[]`, "must be a string or object"},
+		{"type not string", `{"type":1}`, "scale.type:"},
+		{"type invalid", `{"type":"expo"}`, `scale.type "expo" is invalid`},
+		{"axes not array", `{"axes":"x"}`, "must be an array of axis names"},
+		{"base not number", `{"base":"10"}`, "scale.base:"},
+		{"unknown field", `{"nope":1}`, `unknown field "nope"`},
+	}
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			var sc shared.Scale
+			err := json.Unmarshal([]byte(c.raw), &sc)
+			s.Require().Error(err, c.raw)
+			s.Contains(err.Error(), c.want, c.raw)
+		})
+	}
+}
+
+func (s *ScaleSuite) TestScaleFromBagInvalidTypeWarnsAndDefaults() {
+	var got shared.Scale
+	out := testutil.CaptureStderr(func() {
+		got = shared.ScaleFromBag(map[string]any{"type": "expo", "axes": "x"})
+	})
+	s.Contains(out, "Invalid scale type")
+	s.Equal("linear", got.Type)
+	s.Equal([]string{"x"}, got.Axes)
+}
+
+func (s *ScaleSuite) TestScaleFromBagMissingTypeDefaultsToLog() {
+	got := shared.ScaleFromBag(map[string]any{"axes": "x"})
+	s.Equal("log", got.Type)
+	s.Equal([]string{"x"}, got.Axes)
+}
+
+func (s *ScaleSuite) TestEncodeScaleValueDuplicateAxisSkipped() {
+	got := shared.EncodeScaleValue("type=log;axes=x,x", s.fields)
+	s.Equal(map[string]any{
+		"type": "log",
+		"axes": []string{"x"},
+		"base": 10.0,
+	}, got)
+}
+
+func (s *ScaleSuite) TestScaleFromBagInvalidBaseValues() {
+	for _, raw := range []any{"nope", true} {
+		var got shared.Scale
+		out := testutil.CaptureStderr(func() {
+			got = shared.ScaleFromBag(map[string]any{"type": "log", "base": raw})
+		})
+		s.Contains(out, "Invalid scale base", raw)
+		s.Require().NotNil(got.Base, raw)
+		s.Equal(10.0, *got.Base, raw)
+	}
+}
+
 func TestScaleSuite(t *testing.T) {
 	suite.Run(t, new(ScaleSuite))
 }

--- a/shared/scale_test.go
+++ b/shared/scale_test.go
@@ -137,14 +137,15 @@ func (s *ScaleSuite) TestIsScaleBag() {
 	s.True(shared.IsScaleBag("{type=log;axes=x}"))
 }
 
-func (s *ScaleSuite) TestEncodeScaleBag() {
+func (s *ScaleSuite) TestParseObjectBagThenPayload() {
 	props := []specparse.Prop{
 		{Key: "type", Value: "log", HasValue: true},
 		{Key: "axes", Value: "x", HasValue: true},
 		{Key: "base", Value: "10", HasValue: true},
 	}
-	got, err := shared.EncodeScaleBag(props, s.fields)
+	bag, err := shared.ParseObjectBag(props, s.fields)
 	s.Require().NoError(err)
+	got := shared.ScaleFromBag(bag).Payload()
 	s.Equal(map[string]any{
 		"type": "log",
 		"axes": []string{"x"},

--- a/shared/scale_test.go
+++ b/shared/scale_test.go
@@ -1,0 +1,157 @@
+package shared_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/goptics/vizb/internal/flags"
+	"github.com/goptics/vizb/internal/specparse"
+	"github.com/goptics/vizb/shared"
+	"github.com/goptics/vizb/testutil"
+	"github.com/stretchr/testify/suite"
+)
+
+// ScaleSuite covers the hybrid string|object Scale wire type and bag encode.
+type ScaleSuite struct {
+	suite.Suite
+	fields []flags.ObjectField
+}
+
+func (s *ScaleSuite) SetupTest() {
+	s.fields = []flags.ObjectField{
+		{Name: "type", Kind: flags.KindString},
+		{Name: "axes", Kind: flags.KindString},
+		{Name: "base", Kind: flags.KindFloat},
+		{Name: "baseX", Kind: flags.KindFloat},
+		{Name: "baseY", Kind: flags.KindFloat},
+		{Name: "baseZ", Kind: flags.KindFloat},
+	}
+}
+
+func (s *ScaleSuite) TestMarshalStringForm() {
+	raw, err := json.Marshal(shared.ScaleLog)
+	s.Require().NoError(err)
+	s.JSONEq(`"log"`, string(raw))
+
+	raw, err = json.Marshal(shared.ScaleLinear)
+	s.Require().NoError(err)
+	s.JSONEq(`"linear"`, string(raw))
+}
+
+func (s *ScaleSuite) TestMarshalObjectWhenAxesSet() {
+	sc := shared.Scale{Type: "log", Axes: []string{"x"}}
+	raw, err := json.Marshal(sc)
+	s.Require().NoError(err)
+	s.JSONEq(`{"type":"log","axes":["x"],"base":10}`, string(raw))
+}
+
+func (s *ScaleSuite) TestMarshalObjectWhenNonDefaultBase() {
+	base := 5.0
+	sc := shared.Scale{Type: "log", Base: &base}
+	raw, err := json.Marshal(sc)
+	s.Require().NoError(err)
+	s.JSONEq(`{"type":"log","base":5}`, string(raw))
+}
+
+func (s *ScaleSuite) TestUnmarshalStringAndObject() {
+	var sc shared.Scale
+	s.Require().NoError(json.Unmarshal([]byte(`"log"`), &sc))
+	s.Equal(shared.ScaleLog, sc)
+
+	s.Require().NoError(json.Unmarshal([]byte(`{"type":"log","axes":["x"],"base":10}`), &sc))
+	s.Equal("log", sc.Type)
+	s.Equal([]string{"x"}, sc.Axes)
+	s.Require().NotNil(sc.Base)
+	s.Equal(10.0, *sc.Base)
+}
+
+func (s *ScaleSuite) TestEncodeScaleValueStringBackCompat() {
+	s.Equal("log", shared.EncodeScaleValue("log", s.fields))
+	s.Equal("log", shared.EncodeScaleValue("LOG", s.fields))
+	s.Equal("linear", shared.EncodeScaleValue("linear", s.fields))
+}
+
+func (s *ScaleSuite) TestEncodeScaleValueTypeLogNoAxesIsString() {
+	s.Equal("log", shared.EncodeScaleValue("type=log", s.fields))
+	s.Equal("log", shared.EncodeScaleValue("type=log;base=10", s.fields))
+}
+
+func (s *ScaleSuite) TestEncodeScaleValueAxesObject() {
+	got := shared.EncodeScaleValue("type=log;axes=x", s.fields)
+	s.Equal(map[string]any{
+		"type": "log",
+		"axes": []string{"x"},
+		"base": 10.0,
+	}, got)
+}
+
+func (s *ScaleSuite) TestEncodeScaleValuePerAxisBase() {
+	got := shared.EncodeScaleValue("type=log;axes=x,y;baseX=5;baseY=10", s.fields)
+	s.Equal(map[string]any{
+		"type":  "log",
+		"axes":  []string{"x", "y"},
+		"base":  10.0,
+		"baseX": 5.0,
+	}, got)
+}
+
+func (s *ScaleSuite) TestEncodeScaleValueInvalidBaseWarnsAndDefaults() {
+	for _, raw := range []string{
+		"type=log;axes=x;base=1",
+		"type=log;axes=x;base=0",
+		"type=log;axes=x;base=-2",
+	} {
+		var got any
+		out := testutil.CaptureStderr(func() {
+			got = shared.EncodeScaleValue(raw, s.fields)
+		})
+		s.Contains(out, "Invalid scale base", raw)
+		s.Equal(map[string]any{
+			"type": "log",
+			"axes": []string{"x"},
+			"base": 10.0,
+		}, got, raw)
+	}
+}
+
+func (s *ScaleSuite) TestEncodeScaleValueUnknownAxisWarnsAndSkips() {
+	var got any
+	out := testutil.CaptureStderr(func() {
+		got = shared.EncodeScaleValue("type=log;axes=x,q", s.fields)
+	})
+	s.Contains(out, "Invalid scale axis")
+	s.Contains(out, "Skipping")
+	s.Equal(map[string]any{
+		"type": "log",
+		"axes": []string{"x"},
+		"base": 10.0,
+	}, got)
+}
+
+func (s *ScaleSuite) TestIsScaleBag() {
+	s.True(shared.IsScaleBag("type=log;axes=x"))
+	s.True(shared.IsScaleBag("type=log"))
+	s.False(shared.IsScaleBag("log"))
+	s.False(shared.IsScaleBag("linear"))
+	s.False(shared.IsScaleBag("log:axes=x"))
+	s.True(shared.IsScaleBag("{type=log;axes=x}"))
+}
+
+func (s *ScaleSuite) TestEncodeScaleBag() {
+	props := []specparse.Prop{
+		{Key: "type", Value: "log", HasValue: true},
+		{Key: "axes", Value: "x", HasValue: true},
+		{Key: "base", Value: "10", HasValue: true},
+	}
+	got, err := shared.EncodeScaleBag(props, s.fields)
+	s.Require().NoError(err)
+	s.Equal(map[string]any{
+		"type": "log",
+		"axes": []string{"x"},
+		"base": 10.0,
+	}, got)
+}
+
+func TestScaleSuite(t *testing.T) {
+	suite.Run(t, new(ScaleSuite))
+}


### PR DESCRIPTION
## Summary
- Parse `--scale` as a hybrid string (`linear`/`log`) or unwrapped bag (`type=log;axes=x`), matching `--bg`.
- `--chart` uses braces (`line:scale={type=log;axes=x;base=10}`); unwrapped `line:scale=type=log;axes=x` is a hard error.
- Dataset JSON keeps `"scale": "log"` unless axes or a non-default base is set.

Closes #413
Relates to #412

## Test Plan
- [x] `go test -count=1 ./internal/charts/... ./shared/... ./cmd/... ./cmd/cli/...`
- [x] `vizb line sample.csv --scale log -o out.json` → `"scale":"log"`
- [x] `vizb line sample.csv --scale 'type=log;axes=x' -o out.json` → scale object


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added linear and logarithmic chart scale configuration.
  * Supports axis selection and shared or per-axis logarithmic bases.
  * Scale settings now accept simple values or structured configurations.

* **Bug Fixes**
  * Improved validation for invalid scale values, options, axes, and bases.
  * Chart stacking now responds correctly to logarithmic scales based on orientation and selected axes.

* **Compatibility**
  * Existing scale values remain supported and are normalized consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->