### PR TITLE
feat(ui): apply per-axis log scale and logBase

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -21,3 +21,7 @@ pre-commit:
       priority: 3
       glob: "*.go"
       run: task test
+    ui-test:
+      priority: 4
+      glob: "ui/**"
+      run: task test:ui:coverage

--- a/ui/src/components/SettingsPanel.vue
+++ b/ui/src/components/SettingsPanel.vue
@@ -24,7 +24,7 @@ import {
   type SettingFieldValueMap,
 } from '../composables/settings/fieldRegistry'
 import type { ChartType, ScaleInput } from '../types'
-import { scaleTabValue } from '../lib/scale'
+import { parseScale } from '../lib/scale'
 
 // Generic, schema-less settings panel: walks `Object.keys(activeConfig)` via
 // `getRenderableFields` and renders the registered control for each key. The
@@ -150,7 +150,7 @@ const valueFor = (key: SettingFieldKey) => {
   if (!activeConfig.value) return undefined
   if (key === 'scale') {
     if (stack.value) return 'linear'
-    return scaleTabValue((activeConfig.value as { scale?: ScaleInput }).scale)
+    return parseScale((activeConfig.value as { scale?: ScaleInput }).scale).type
   }
   return (activeConfig.value as Partial<SettingFieldValueMap>)[key]
 }

--- a/ui/src/components/SettingsPanel.vue
+++ b/ui/src/components/SettingsPanel.vue
@@ -23,7 +23,8 @@ import {
   type SettingFieldKey,
   type SettingFieldValueMap,
 } from '../composables/settings/fieldRegistry'
-import type { ChartType } from '../types'
+import type { ChartType, ScaleInput } from '../types'
+import { scaleTabValue } from '../lib/scale'
 
 // Generic, schema-less settings panel: walks `Object.keys(activeConfig)` via
 // `getRenderableFields` and renders the registered control for each key. The
@@ -147,7 +148,10 @@ const handlers = {
 
 const valueFor = (key: SettingFieldKey) => {
   if (!activeConfig.value) return undefined
-  if (key === 'scale' && stack.value) return 'linear'
+  if (key === 'scale') {
+    if (stack.value) return 'linear'
+    return scaleTabValue((activeConfig.value as { scale?: ScaleInput }).scale)
+  }
   return (activeConfig.value as Partial<SettingFieldValueMap>)[key]
 }
 

--- a/ui/src/composables/charts/baseChartOptions.ts
+++ b/ui/src/composables/charts/baseChartOptions.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import type { EChartsOption } from 'echarts'
-import type { Axis, BarBackground, ChartData, Sort, ScaleType, ChartType } from '@/types'
+import type { Axis, BarBackground, ChartData, Sort, ScaleInput, ChartType } from '@/types'
 import { createTooltipConfig, createToolboxConfig, getChartStyling } from './shared/chartConfig'
 import { fontSize } from './shared/common'
 import { is3D } from '@/lib/utils'
@@ -14,7 +14,7 @@ export interface BaseChartConfig {
   // config carries them). Pie/heatmap/radar configs don't produce a Ref for
   // these fields, so they're relaxed to optional here; chart composables that
   // access them default at the call site (e.g. `scale?.value ?? "linear"`).
-  scale?: Ref<ScaleType>
+  scale?: Ref<ScaleInput>
   stack?: Ref<boolean>
   threeDRotate?: Ref<boolean>
   // Legend selection state for z series (3D); key = z name, false = hidden.

--- a/ui/src/composables/charts/shared/3d.test.ts
+++ b/ui/src/composables/charts/shared/3d.test.ts
@@ -639,6 +639,19 @@ describe('resolve3DZAxisType', () => {
     ).toBe('log')
   })
 
+  it('ignores grouped 3D x-only log for the metric axis', () => {
+    expect(
+      resolve3DZAxisType({ type: 'log', axes: ['x'] }, [
+        { name: 'a', data: [{ value: [0, 0, 3] }] },
+      ])
+    ).toBe('value')
+    expect(
+      resolve3DZAxisType({ type: 'log', axes: ['z'], base: 2 }, [
+        { name: 'a', data: [{ value: [0, 0, 3] }] },
+      ])
+    ).toBe('log')
+  })
+
   it('falls back to value for empty or non-positive metrics', () => {
     expect(resolve3DZAxisType('log', [])).toBe('value')
     expect(
@@ -660,6 +673,20 @@ describe('remaining 3d branch coverage', () => {
     expect(axes.xAxis3D.type).toBe('log')
     expect(axes.yAxis3D.type).toBe('log')
     expect(axes.zAxis3D.type).toBe('log')
+    expect(axes.xAxis3D.logBase).toBe(10)
+  })
+
+  it('createContinuous3DAxes logs only requested axes', async () => {
+    const { createContinuous3DAxes } = await import('./3d')
+    const axes = createContinuous3DAxes(styling, 'x', 'y', 'z', {
+      type: 'log',
+      axes: ['x'],
+      base: 2,
+    })
+    expect(axes.xAxis3D.type).toBe('log')
+    expect(axes.xAxis3D.logBase).toBe(2)
+    expect(axes.yAxis3D.type).toBe('value')
+    expect(axes.zAxis3D.type).toBe('value')
   })
 
   it('createContinuous3DTooltipFormatter default labels', async () => {

--- a/ui/src/composables/charts/shared/3d.test.ts
+++ b/ui/src/composables/charts/shared/3d.test.ts
@@ -636,7 +636,7 @@ describe('resolve3DZAxisType', () => {
       resolve3DZAxisType('log', [
         { name: 'a', data: [{ value: [0, 0, 0.2] }, { value: [1, 0, 3] }] },
       ])
-    ).toBe('log')
+    ).toEqual({ type: 'log', logBase: 10 })
   })
 
   it('ignores grouped 3D x-only log for the metric axis', () => {
@@ -644,25 +644,27 @@ describe('resolve3DZAxisType', () => {
       resolve3DZAxisType({ type: 'log', axes: ['x'] }, [
         { name: 'a', data: [{ value: [0, 0, 3] }] },
       ])
-    ).toBe('value')
+    ).toEqual({ type: 'value' })
     expect(
       resolve3DZAxisType({ type: 'log', axes: ['z'], base: 2 }, [
         { name: 'a', data: [{ value: [0, 0, 3] }] },
       ])
-    ).toBe('log')
+    ).toEqual({ type: 'log', logBase: 2 })
   })
 
   it('falls back to value for empty or non-positive metrics', () => {
-    expect(resolve3DZAxisType('log', [])).toBe('value')
+    expect(resolve3DZAxisType('log', [])).toEqual({ type: 'value' })
     expect(
       resolve3DZAxisType('log', [
         { name: 'a', data: [{ value: [0, 0, 0] }, { value: [1, 0, -1] }] },
       ])
-    ).toBe('value')
+    ).toEqual({ type: 'value' })
   })
 
   it('treats missing metric height (no value[2]) as non-positive', () => {
-    expect(resolve3DZAxisType('log', [{ name: 'a', data: [{ value: [0, 0] }] }])).toBe('value')
+    expect(resolve3DZAxisType('log', [{ name: 'a', data: [{ value: [0, 0] }] }])).toEqual({
+      type: 'value',
+    })
   })
 })
 

--- a/ui/src/composables/charts/shared/3d.ts
+++ b/ui/src/composables/charts/shared/3d.ts
@@ -1,6 +1,6 @@
 import type { EChartsOption } from 'echarts'
 import type { Render3D, Point3D, ScaleInput, Series3DData } from '@/types'
-import { axisIsLog, axisLogBase, DEFAULT_LOG_AXES, parseScale } from '@/lib/scale'
+import { axisIsLog, axisLogBase, parseScale } from '@/lib/scale'
 import { valuePoints3DToSeries } from '@/lib/transform'
 import { getDefaultThemeColor, getNextColorFor, formatChartNumber } from '@/lib/utils'
 import {
@@ -55,15 +55,16 @@ export function* series3DMetricValues(series: Series3DData[]): Generator<number 
 }
 
 /** Log z-axis only when metric heights have a positive domain. */
-export function resolve3DZAxisType(scale: ScaleInput, series: Series3DData[]): 'log' | 'value' {
-  const want = axisIsLog(parseScale(scale), 'z', DEFAULT_LOG_AXES.grouped3d)
-  return resolveLogScale(want ? 'log' : 'linear', series3DMetricValues(series)) === 'log'
-    ? 'log'
-    : 'value'
-}
-
-export function zAxisLogBase(scale: ScaleInput): number {
-  return axisLogBase(parseScale(scale), 'z')
+export function resolve3DZAxisType(
+  scale: ScaleInput,
+  series: Series3DData[]
+): { type: 'log'; logBase: number } | { type: 'value' } {
+  const parsed = parseScale(scale)
+  const want = axisIsLog(parsed, 'z', ['z'])
+  if (resolveLogScale(want ? 'log' : 'linear', series3DMetricValues(series)) !== 'log') {
+    return { type: 'value' }
+  }
+  return { type: 'log', logBase: axisLogBase(parsed, 'z') }
 }
 
 export function create3DVisualMap(max: number, styling: ChartStyling, dimension: 1 | 2 | 3 = 2) {
@@ -308,7 +309,7 @@ export function createContinuous3DAxes(
   scale: ScaleInput = 'linear'
 ) {
   const parsed = parseScale(scale)
-  const defaults = DEFAULT_LOG_AXES.continuous3d
+  const defaults = ['x', 'y', 'z'] as const
   const axisCommon = makeAxis3DCommon(styling)
   const valueAxis = (axis: 'x' | 'y' | 'z', label?: string) => {
     const isLog = axisIsLog(parsed, axis, defaults)

--- a/ui/src/composables/charts/shared/3d.ts
+++ b/ui/src/composables/charts/shared/3d.ts
@@ -1,5 +1,6 @@
 import type { EChartsOption } from 'echarts'
-import type { Render3D, Point3D, ScaleType, Series3DData } from '@/types'
+import type { Render3D, Point3D, ScaleInput, Series3DData } from '@/types'
+import { axisIsLog, axisLogBase, DEFAULT_LOG_AXES, parseScale } from '@/lib/scale'
 import { valuePoints3DToSeries } from '@/lib/transform'
 import { getDefaultThemeColor, getNextColorFor, formatChartNumber } from '@/lib/utils'
 import {
@@ -54,8 +55,15 @@ export function* series3DMetricValues(series: Series3DData[]): Generator<number 
 }
 
 /** Log z-axis only when metric heights have a positive domain. */
-export function resolve3DZAxisType(scale: ScaleType, series: Series3DData[]): 'log' | 'value' {
-  return resolveLogScale(scale, series3DMetricValues(series)) === 'log' ? 'log' : 'value'
+export function resolve3DZAxisType(scale: ScaleInput, series: Series3DData[]): 'log' | 'value' {
+  const want = axisIsLog(parseScale(scale), 'z', DEFAULT_LOG_AXES.grouped3d)
+  return resolveLogScale(want ? 'log' : 'linear', series3DMetricValues(series)) === 'log'
+    ? 'log'
+    : 'value'
+}
+
+export function zAxisLogBase(scale: ScaleInput): number {
+  return axisLogBase(parseScale(scale), 'z')
 }
 
 export function create3DVisualMap(max: number, styling: ChartStyling, dimension: 1 | 2 | 3 = 2) {
@@ -297,26 +305,24 @@ export function createContinuous3DAxes(
   xLabel?: string,
   yLabel?: string,
   zLabel?: string,
-  scale: ScaleType = 'linear'
+  scale: ScaleInput = 'linear'
 ) {
-  const valueType = scale === 'log' ? ('log' as const) : ('value' as const)
+  const parsed = parseScale(scale)
+  const defaults = DEFAULT_LOG_AXES.continuous3d
   const axisCommon = makeAxis3DCommon(styling)
+  const valueAxis = (axis: 'x' | 'y' | 'z', label?: string) => {
+    const isLog = axisIsLog(parsed, axis, defaults)
+    return {
+      type: isLog ? ('log' as const) : ('value' as const),
+      ...(isLog ? { logBase: axisLogBase(parsed, axis) } : {}),
+      ...axisCommon,
+      ...axis3DName(label, styling),
+    }
+  }
   return {
-    xAxis3D: {
-      type: valueType,
-      ...axisCommon,
-      ...axis3DName(xLabel, styling),
-    },
-    yAxis3D: {
-      type: valueType,
-      ...axisCommon,
-      ...axis3DName(yLabel, styling),
-    },
-    zAxis3D: {
-      type: valueType,
-      ...axisCommon,
-      ...axis3DName(zLabel, styling),
-    },
+    xAxis3D: valueAxis('x', xLabel),
+    yAxis3D: valueAxis('y', yLabel),
+    zAxis3D: valueAxis('z', zLabel),
   }
 }
 
@@ -507,7 +513,7 @@ export type Continuous3DParams = {
   useVisualMap: boolean
   defaultColor: string
   threeDRotate: boolean
-  scale: ScaleType
+  scale: ScaleInput
   seriesData: Series3DData[]
   axisLabels?: { x?: string; y?: string; z?: string; metric?: string }
   symbol?: string

--- a/ui/src/composables/charts/shared/chartConfig.test.ts
+++ b/ui/src/composables/charts/shared/chartConfig.test.ts
@@ -4,6 +4,7 @@ import {
   createValueAxisConfig,
   createDataZoomConfig,
   createGridConfig,
+  legendBandPx,
   createTooltipConfig,
   createLabelConfig,
   createValueModeGridConfig,
@@ -124,6 +125,32 @@ describe('createGridConfig', () => {
 
   it('keeps dataZoom bottom larger than the no-zoom tier', () => {
     expect(createGridConfig(1, true).bottom).toBeGreaterThan(createGridConfig(1, false).bottom)
+  })
+
+  it('uses a compact pixel legend top instead of a percentage', () => {
+    expect(createGridConfig(1).top).toBe(28)
+    expect(createGridConfig(15).top).toBe(28)
+    expect(typeof createGridConfig(2).top).toBe('number')
+  })
+
+  it('adds title space and wrap rows', () => {
+    expect(createGridConfig(2, false, true).top).toBe(48)
+    expect(createGridConfig(16).top).toBe(44)
+    expect(createGridConfig(16, false, true).top).toBe(64)
+  })
+
+  it('keeps slider bottom with compact top when dataZoom is set', () => {
+    const grid = createGridConfig(2, true)
+    expect(grid.top).toBe(28)
+    expect(grid.bottom).toBe(100)
+    expect(grid.containLabel).toBe(false)
+  })
+})
+
+describe('legendBandPx', () => {
+  it('uses the same pixel band as vertical legend top', () => {
+    expect(legendBandPx(2)).toBe(createGridConfig(2).top)
+    expect(legendBandPx(16)).toBe(createGridConfig(16).top)
   })
 })
 

--- a/ui/src/composables/charts/shared/chartConfig.test.ts
+++ b/ui/src/composables/charts/shared/chartConfig.test.ts
@@ -522,6 +522,26 @@ describe('remaining chartConfig branches', () => {
     expect(typeof html).toBe('string')
   })
 
+  it('createTooltipConfig line pointer and [x, y] pair metrics', () => {
+    const totals = new Map<string, number>([['A', 10]])
+    const tip = createTooltipConfig(true, false, totals, 'line') as {
+      axisPointer?: { type?: string; snap?: boolean }
+      formatter: (p: unknown) => string
+    }
+    expect(tip.axisPointer?.type).toBe('line')
+    expect(tip.axisPointer?.snap).toBe(true)
+    const html = tip.formatter([
+      { name: '1', seriesName: 'A', value: [1, 4], color: '#a00', marker: 'm' },
+      { name: '1', seriesName: 'B', value: [1, 6], color: '#00c', marker: 'n' },
+      { name: '1', seriesName: 'Gap', value: [1, null], color: '#ccc', marker: 'g' },
+    ])
+    expect(html).toContain('A')
+    expect(html).toContain('B')
+    expect(html).not.toContain('Gap')
+    expect(html).toContain('4')
+    expect(html).toContain('6')
+  })
+
   it('createTooltipConfig seriesTotals and non-string colors', () => {
     const totals = new Map<string, number>([['A', 10]])
     const tip = createTooltipConfig(true, false, totals) as { formatter: (p: unknown) => string }

--- a/ui/src/composables/charts/shared/chartConfig.ts
+++ b/ui/src/composables/charts/shared/chartConfig.ts
@@ -11,7 +11,11 @@ export const DATAZOOM_INITIAL_END_PERCENT = 20
 const axisTitleFontSize = 16
 const LOG_AXIS_RANGE = { min: 'dataMin' as const, max: 'dataMax' as const }
 const LINEAR_AXIS_RANGE = { min: null, max: null }
-const valueAxisRange = (scale: ScaleType) => (scale === 'log' ? LOG_AXIS_RANGE : LINEAR_AXIS_RANGE)
+
+const logAxisProps = (scale: ScaleType, logBase = 10) =>
+  scale === 'log'
+    ? { type: 'log' as const, logBase, ...LOG_AXIS_RANGE }
+    : { type: 'value' as const, ...LINEAR_AXIS_RANGE }
 
 // Bottom chrome for heatmap / correlation — visualMap always, dataZoom when len > 50.
 export const HEATMAP_VISUAL_MAP_BOTTOM = 8
@@ -227,26 +231,33 @@ export function hasRotatedXLabels(xAxisData: string[], hasDataZoom = false): boo
   return xAxisData.reduce((acc, cur) => acc + cur.length, 0) > 100
 }
 
+export type ValueAxisScaleOpts = {
+  xScale?: ScaleType
+  xLogBase?: number
+  yLogBase?: number
+}
+
 /** Dual numeric axes for scatter --axes value mode — mirrors createAxisConfig styling. */
 export function createValueAxisConfig(
   styling: ChartStyling,
   xAxisName?: string,
   yAxisName?: string,
   yScale: ScaleType = 'linear',
-  fitYAxisToData = false
+  fitYAxisToData = false,
+  opts?: ValueAxisScaleOpts
 ): { xAxis: any; yAxis: any } {
   const nameStyle = {
     color: styling.textColor,
     fontSize: axisTitleFontSize,
     fontWeight: 'bold' as const,
   }
+  const xScale = opts?.xScale ?? 'linear'
 
   const yAxisConfig: any = {
-    type: yScale === 'log' ? 'log' : 'value',
+    ...logAxisProps(yScale, opts?.yLogBase ?? 10),
     // ECharts 6 moves axis names to avoid label overlap by default. Vizb's
     // nameGap values already reserve their position using the v5 behavior.
     nameMoveOverlap: false,
-    ...valueAxisRange(yScale),
     ...(yAxisName
       ? { name: yAxisName, nameLocation: 'middle', nameGap: 45, nameTextStyle: nameStyle }
       : {}),
@@ -261,7 +272,7 @@ export function createValueAxisConfig(
 
   return {
     xAxis: {
-      type: 'value',
+      ...logAxisProps(xScale, opts?.xLogBase ?? 10),
       nameMoveOverlap: false,
       ...(xAxisName
         ? { name: xAxisName, nameLocation: 'middle', nameGap: 30, nameTextStyle: nameStyle }
@@ -337,12 +348,12 @@ export function createAxisConfig(
   scale: ScaleType = 'linear',
   xAxisName?: string,
   hasDataZoom = false,
-  fitYAxisToData = false
+  fitYAxisToData = false,
+  yLogBase = 10
 ): { xAxis: any; yAxis: any } {
   const yAxisConfig: any = {
-    type: scale === 'log' ? 'log' : 'value',
+    ...logAxisProps(scale, yLogBase),
     nameMoveOverlap: false,
-    ...valueAxisRange(scale),
     inverse: false,
     data: null,
     splitLine: {
@@ -413,7 +424,8 @@ export function createHorizontalAxisConfig(
   yAxisData: string[],
   scale: ScaleType = 'linear',
   categoryAxisName?: string,
-  hasDataZoom = false
+  hasDataZoom = false,
+  xLogBase = 10
 ): { xAxis: any; yAxis: any } {
   const axisNameStyle = {
     color: styling.textColor,
@@ -422,9 +434,8 @@ export function createHorizontalAxisConfig(
   }
 
   const xAxisConfig: any = {
-    type: scale === 'log' ? 'log' : 'value',
+    ...logAxisProps(scale, xLogBase),
     nameMoveOverlap: false,
-    ...valueAxisRange(scale),
     inverse: false,
     data: null,
     splitLine: {
@@ -679,16 +690,30 @@ export function createPinnedAxisTooltip(isDark = false): EChartsOption['tooltip'
   }
 }
 
+/** Metric from a category value or a coerced `[x, y]` pair. */
+export function tooltipMetric(value: unknown): unknown {
+  if (Array.isArray(value)) return value[1]
+  return value
+}
+
+function tooltipHeader(params: { name?: string; value?: unknown }[]): string {
+  const p = params[0]
+  if (Array.isArray(p?.value)) return formatTooltipValue(p.value[0])
+  return p?.name ?? ''
+}
+
 /**
  * Creates common tooltip configuration
  * @param hasXYAxis - Whether the chart has both X and Y axes
  * @param isDark - Dark mode flag for tooltip theming
  * @param seriesTotals - Per-series totals across all x, appended after each name
+ * @param pointer - Category band (`shadow`) or continuous-X snap line
  */
 export function createTooltipConfig(
   hasXYAxis: boolean,
   isDark = false,
-  seriesTotals?: Map<string, number>
+  seriesTotals?: Map<string, number>,
+  pointer: 'shadow' | 'line' = 'shadow'
 ): EChartsOption['tooltip'] {
   const theme = getTooltipTheme(isDark)
   const styling = getChartStyling(isDark)
@@ -696,41 +721,49 @@ export function createTooltipConfig(
   if (hasXYAxis) {
     return {
       trigger: 'axis',
-      axisPointer: createShadowAxisPointer(styling, theme),
+      axisPointer:
+        pointer === 'line'
+          ? createLineAxisPointer(styling, theme, true)
+          : createShadowAxisPointer(styling, theme),
       ...theme,
       formatter: (params) => {
         if (!Array.isArray(params)) return ''
 
         // null = missing cell (no data for that series at this category) — skip from tooltip
-        const present = params.filter((p) => p.value !== null && p.value !== undefined)
+        const present = params.filter((p) => {
+          const metric = tooltipMetric(p.value)
+          return metric !== null && metric !== undefined
+        })
         if (!present.length) return ''
 
         const legendRows = present.map((cur) => {
           const seriesSum = seriesTotals?.get(cur.seriesName ?? '')
           const sumTag = seriesSum === undefined ? '' : ` (Σ${formatChartNumber(seriesSum)})`
-          return `${cur.marker} ${cur.seriesName}${sumTag}: ${formatTooltipValue(cur.value)}`
+          return `${cur.marker} ${cur.seriesName}${sumTag}: ${formatTooltipValue(tooltipMetric(cur.value))}`
         })
-        const body = `<strong>${params[0]?.name}</strong><br/>${renderTooltipLegendColumns(legendRows)}`
+        const header = tooltipHeader(params)
+        const body = `<strong>${header}</strong><br/>${renderTooltipLegendColumns(legendRows)}`
 
         // Σ across all series at this x = the x marginal. Label with the x name
         // to match the 3D tooltip's "Σ <name>" lines. Only meaningful with >1 series.
         if (present.length <= 1) return body
-        const total = present.reduce(
-          (sum, cur) => sum + (typeof cur.value === 'number' ? cur.value : 0),
+        const metrics = present.map((p) => tooltipMetric(p.value))
+        const total = metrics.reduce<number>(
+          (sum, cur) => sum + (typeof cur === 'number' ? cur : 0),
           0
         )
-        const xName = params[0]?.name ?? ''
-        const sumLine = `${tooltipDivider(isDark)}Σ ${xName}: <b>${formatChartNumber(total)}</b>`
+        const sumLine = `${tooltipDivider(isDark)}Σ ${header}: <b>${formatChartNumber(total)}</b>`
         const spread = tooltipSpreadRows(
-          present.map((p) => (typeof p.value === 'number' ? p.value : NaN)),
+          metrics.map((v) => (typeof v === 'number' ? v : NaN)),
           isDark
         )
         const donut = renderDonutSvg(
           params.flatMap((p) => {
-            if (typeof p.value !== 'number') return []
+            const value = tooltipMetric(p.value)
+            if (typeof value !== 'number') return []
             return [
               {
-                value: p.value,
+                value,
                 color: typeof p.color === 'string' ? p.color : String(p.color),
                 name: p.seriesName ?? '',
               },

--- a/ui/src/composables/charts/shared/chartConfig.ts
+++ b/ui/src/composables/charts/shared/chartConfig.ts
@@ -85,6 +85,11 @@ export function isLargeXAxis(xAxisData: string[]): boolean {
 // above it the optimized path keeps a 100k-point dataset's draw on one frame.
 export const LARGE_DATA_THRESHOLD = 2000
 
+export const INSIDE_XY_ZOOM = [
+  { type: 'inside' as const, xAxisIndex: 0 },
+  { type: 'inside' as const, yAxisIndex: 0 },
+]
+
 // ECharts skips visualMap on scatter when `large` is on — disable it for gradient mode.
 export function scatterSeriesLargeOpts(useVisualMap: boolean) {
   return useVisualMap

--- a/ui/src/composables/charts/shared/chartConfig.ts
+++ b/ui/src/composables/charts/shared/chartConfig.ts
@@ -418,10 +418,10 @@ export function createAxisConfig(
   }
 }
 
-/** Bottom band (%) for a horizontal chart legend — mirrors createGridConfig top band. */
-export function horizontalLegendBottom(seriesLength = 1): string {
-  const legendSpace = Math.min(15 + Math.floor((seriesLength - 1) / 15) * 2, 35)
-  return `${legendSpace}%`
+/** Pixel legend band — same size for vertical `grid.top` and horizontal `grid.bottom`. */
+export function legendBandPx(seriesLength = 1, hasLegendTitle = false): number {
+  const extraRows = Math.floor((Math.max(seriesLength, 1) - 1) / 15)
+  return (hasLegendTitle ? 48 : 28) + extraRows * 16
 }
 
 export function createHorizontalAxisConfig(
@@ -845,7 +845,7 @@ export function makeLegendTitle(text: string, styling: ChartStyling): any {
 // Fixed px (not %) so the plot area stays predictable across card heights.
 const SERIES_TICK_BAND = 28 // series names on the x axis (no slider)
 
-/** Value-mode charts hide the legend — skip the legend % top band (see heatmap). */
+/** Value-mode charts hide the legend — skip the legend top band (see heatmap). */
 export const VALUE_MODE_GRID_TOP = 8
 
 export function createValueModeGridConfig(hasDataZoom = false): any {
@@ -855,8 +855,12 @@ export function createValueModeGridConfig(hasDataZoom = false): any {
   }
 }
 
-export function createGridConfig(seriesLength = 1, hasDataZoom = false): any {
-  const legendSpace = Math.min(15 + Math.floor((seriesLength - 1) / 15) * 2, 35)
+export function createGridConfig(
+  seriesLength = 1,
+  hasDataZoom = false,
+  hasLegendTitle = false
+): any {
+  const top = legendBandPx(seriesLength, hasLegendTitle)
 
   // With a dataZoom slider we turn containLabel OFF and reserve label space in
   // fixed px. containLabel pins both the tick labels and the axis name to the
@@ -869,7 +873,7 @@ export function createGridConfig(seriesLength = 1, hasDataZoom = false): any {
       left: 55,
       right: 24,
       bottom: 100,
-      top: `${legendSpace}%`,
+      top,
       containLabel: false,
       outerBoundsMode: 'none',
     }
@@ -881,7 +885,7 @@ export function createGridConfig(seriesLength = 1, hasDataZoom = false): any {
     left: '3%',
     right: '3%',
     bottom: SERIES_TICK_BAND,
-    top: `${legendSpace}%`,
+    top,
     containLabel: true,
     outerBoundsMode: 'none',
   }

--- a/ui/src/composables/charts/shared/common.test.ts
+++ b/ui/src/composables/charts/shared/common.test.ts
@@ -115,6 +115,20 @@ describe('computeSeriesTotals', () => {
     ])
     expect(totals.get('legacy')).toBe(10)
   })
+
+  it('sums y from coerced [x, y] pairs', () => {
+    const totals = computeSeriesTotals([
+      {
+        name: 'train',
+        data: [
+          [1, 10],
+          [2, null],
+          [4, 5],
+        ],
+      },
+    ])
+    expect(totals.get('train')).toBe(15)
+  })
 })
 
 describe('sortByAxisTotal', () => {

--- a/ui/src/composables/charts/shared/common.ts
+++ b/ui/src/composables/charts/shared/common.ts
@@ -51,13 +51,17 @@ export function resolveLogScale(scale: ScaleType, values: Iterable<number | null
 }
 
 // Sum each named series' data values — used for tooltip axis-sum display. Data
-// items are plain numbers (or null for log gaps); also tolerates the legacy
-// `{ value }` item shape.
-type SeriesDatum = number | null | { value?: number }
+// items are plain numbers (or null for log gaps), coerced `[x, y]` pairs, or
+// the legacy `{ value }` item shape.
+type SeriesDatum = number | null | [number, number | null] | { value?: number }
 export function computeSeriesTotals(
   series: Array<{ name: string; data: SeriesDatum[] }>
 ): Map<string, number> {
-  const valueOf = (d: SeriesDatum): number => (typeof d === 'number' ? d : (d?.value ?? 0))
+  const valueOf = (d: SeriesDatum): number => {
+    if (typeof d === 'number') return d
+    if (Array.isArray(d)) return typeof d[1] === 'number' ? d[1] : 0
+    return d?.value ?? 0
+  }
   return new Map(
     series.map((s) => [s.name, s.data.reduce<number>((sum, d) => sum + valueOf(d), 0)])
   )

--- a/ui/src/composables/charts/shared/mixedMode.test.ts
+++ b/ui/src/composables/charts/shared/mixedMode.test.ts
@@ -147,6 +147,30 @@ describe('buildMixedAxes2DOptions', () => {
     expect(option.legend).toEqual({ show: false })
   })
 
+  it('coerces numeric category X to log and uses cross tooltip', () => {
+    const option = buildMixedAxes2DOptions(
+      cfg({
+        scale: { type: 'log', axes: ['x'], base: 2 },
+        chartData: makeMixedChartData({
+          xCategories: ['1', '10'],
+          mixedTuples: [
+            [0, 5],
+            [1, 0],
+          ],
+        }),
+      }),
+      'line'
+    )
+    expect((option.xAxis as { type?: string; logBase?: number }).type).toBe('log')
+    expect((option.xAxis as { logBase?: number }).logBase).toBe(2)
+    expect((option.yAxis as { type?: string }).type).toBe('value')
+    expect(series0(option).data).toEqual([
+      [1, 5],
+      [10, 0],
+    ])
+    expect((option.tooltip as { axisPointer?: { type?: string } }).axisPointer?.type).toBe('cross')
+  })
+
   it('defaults scale to linear when scale ref omitted', () => {
     const full = cfg()
     const { scale: _scale, ...rest } = full
@@ -339,8 +363,19 @@ describe('buildMixedAxes3DOptions', () => {
     )
     expect(option.yAxis3D).toMatchObject({ type: 'log' })
     expect(option.zAxis3D).toMatchObject({ type: 'log' })
+    expect(option.yAxis3D).toMatchObject({ logBase: 10 })
     expect(seriesList(option)).toEqual([])
     expect(option.visualMap).toBeTruthy()
+  })
+
+  it('logs mixed 3D y only when axes is y', () => {
+    const option = buildMixedAxes3DOptions(
+      mixed3dConfig({ scale: { type: 'log', axes: ['y'] } }),
+      'scatter3D'
+    )
+    expect(option.yAxis3D).toMatchObject({ type: 'log' })
+    expect(option.zAxis3D).toMatchObject({ type: 'value' })
+    expect(option.xAxis3D).toMatchObject({ type: 'category' })
   })
 
   it('omits itemStyle on scatter/bar when visualMap on', () => {

--- a/ui/src/composables/charts/shared/mixedMode.test.ts
+++ b/ui/src/composables/charts/shared/mixedMode.test.ts
@@ -171,6 +171,26 @@ describe('buildMixedAxes2DOptions', () => {
     expect((option.tooltip as { axisPointer?: { type?: string } }).axisPointer?.type).toBe('cross')
   })
 
+  it('falls back to the mixed index when log-X lookup is out of range', () => {
+    const option = buildMixedAxes2DOptions(
+      cfg({
+        scale: { type: 'log', axes: ['x'] },
+        chartData: makeMixedChartData({
+          xCategories: ['1'],
+          mixedTuples: [
+            [0, 5],
+            [9, 8],
+          ],
+        }),
+      }),
+      'line'
+    )
+    expect(series0(option).data).toEqual([
+      [1, 5],
+      [9, 8],
+    ])
+  })
+
   it('defaults scale to linear when scale ref omitted', () => {
     const full = cfg()
     const { scale: _scale, ...rest } = full

--- a/ui/src/composables/charts/shared/mixedMode.ts
+++ b/ui/src/composables/charts/shared/mixedMode.ts
@@ -1,12 +1,21 @@
 import type { EChartsOption } from 'echarts'
 import type { ScaleType } from '@/types'
 import { getDefaultThemeColor, getNextColorFor, formatChartNumber } from '@/lib/utils'
+import {
+  axisIsLog,
+  axisLogBase,
+  DEFAULT_LOG_AXES,
+  numericLogXValues,
+  parseScale,
+} from '@/lib/scale'
 import { type BaseChartConfig, getBaseOptions } from '../baseChartOptions'
 import {
   createAxisConfig,
   createDataZoomConfig,
   createLabelConfig,
+  createValueAxisConfig,
   createValueModeGridConfig,
+  createValueModeTooltip,
   createLineAxisPointer,
   createShadowAxisPointer,
   formatTooltipValue,
@@ -110,12 +119,20 @@ export function buildMixedAxes2DOptions(
   const yLabel = chartData.value.axisLabels?.y
   const baseOptions = getBaseOptions(config)
   const styling = getChartStyling(isDark.value)
+  const parsed = parseScale(scale?.value)
+  const xWant = axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.mixed2d)
+  const yWant = axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.mixed2d)
   const yScale = resolveLogScale(
-    scale?.value ?? 'linear',
+    yWant ? 'log' : 'linear',
     tuples.map(([, y]) => y)
   )
+  const xNums = numericLogXValues(xCategories, xWant)
 
-  const data = scaleMixedTuples(tuples, yScale)
+  const data = xNums
+    ? tuples.map(
+        ([xi, y]) => [xNums[xi] ?? xi, adjustForLogScaleLine(y, yScale)] as [number, number | null]
+      )
+    : scaleMixedTuples(tuples, yScale)
   const largeX = isLargeXAxis(xCategories)
   const useVisualMap = chartType === 'scatter' && visualMap?.value === true
   const smoothLines = chartType === 'line' && config.smooth?.value === true
@@ -169,28 +186,42 @@ export function buildMixedAxes2DOptions(
             ),
           }
 
-  const axisConfig = createAxisConfig(
-    styling,
-    xCategories,
-    yScale,
-    xLabel,
-    largeX,
-    chartType === 'scatter'
-  )
+  const axisConfig = xNums
+    ? createValueAxisConfig(styling, xLabel, yLabel, yScale, chartType === 'scatter', {
+        xScale: 'log',
+        xLogBase: axisLogBase(parsed, 'x'),
+        yLogBase: axisLogBase(parsed, 'y'),
+      })
+    : createAxisConfig(
+        styling,
+        xCategories,
+        yScale,
+        xLabel,
+        largeX,
+        chartType === 'scatter',
+        axisLogBase(parsed, 'y')
+      )
 
   return {
     ...baseOptions,
     legend: { show: false },
     grid: createValueModeGridConfig(largeX),
     visualMap: resolve2DScatterVisualMap(useVisualMap, colorValues, styling, 1),
-    tooltip: createMixedModeTooltip(isDark.value, xCategories, chartType, xLabel, yLabel),
+    tooltip: xNums
+      ? createValueModeTooltip(isDark.value, xLabel, yLabel, true)
+      : createMixedModeTooltip(isDark.value, xCategories, chartType, xLabel, yLabel),
     ...axisConfig,
-    dataZoom: largeX
-      ? createDataZoomConfig(xCategories, styling)
-      : [
+    dataZoom: xNums
+      ? [
           { type: 'inside', xAxisIndex: 0 },
           { type: 'inside', yAxisIndex: 0 },
-        ],
+        ]
+      : largeX
+        ? createDataZoomConfig(xCategories, styling)
+        : [
+            { type: 'inside', xAxisIndex: 0 },
+            { type: 'inside', yAxisIndex: 0 },
+          ],
     series: [series],
   } as EChartsOption
 }
@@ -215,8 +246,9 @@ export function buildMixedAxes3DOptions(
   const seriesData = render.lineSeries
   const pointCount = seriesData[0]?.data.length ?? 0
   const { yCount } = continuous3DGridCounts(pointCount)
-  const yScale = scale?.value ?? 'linear'
-  const valueType = yScale === 'log' ? ('log' as const) : ('value' as const)
+  const parsed = parseScale(scale?.value)
+  const yLog = axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.mixed3d)
+  const zLog = axisIsLog(parsed, 'z', DEFAULT_LOG_AXES.mixed3d)
   const grid3D = create3DGridConfig({
     styling,
     autoRotate: threeDRotate?.value ?? false,
@@ -286,12 +318,14 @@ export function buildMixedAxes3DOptions(
       ...axis3DName(axisLabels?.x, styling),
     },
     yAxis3D: {
-      type: valueType,
+      type: yLog ? ('log' as const) : ('value' as const),
+      ...(yLog ? { logBase: axisLogBase(parsed, 'y') } : {}),
       ...axisCommon,
       ...axis3DName(axisLabels?.y, styling),
     },
     zAxis3D: {
-      type: valueType,
+      type: zLog ? ('log' as const) : ('value' as const),
+      ...(zLog ? { logBase: axisLogBase(parsed, 'z') } : {}),
       ...axisCommon,
       ...axis3DName(axisLabels?.z, styling),
     },

--- a/ui/src/composables/charts/shared/mixedMode.ts
+++ b/ui/src/composables/charts/shared/mixedMode.ts
@@ -1,13 +1,7 @@
 import type { EChartsOption } from 'echarts'
 import type { ScaleType } from '@/types'
 import { getDefaultThemeColor, getNextColorFor, formatChartNumber } from '@/lib/utils'
-import {
-  axisIsLog,
-  axisLogBase,
-  DEFAULT_LOG_AXES,
-  numericLogXValues,
-  parseScale,
-} from '@/lib/scale'
+import { axisIsLog, axisLogBase, numericLogXValues, parseScale } from '@/lib/scale'
 import { type BaseChartConfig, getBaseOptions } from '../baseChartOptions'
 import {
   createAxisConfig,
@@ -22,6 +16,7 @@ import {
   getChartStyling,
   getTooltipTheme,
   isLargeXAxis,
+  INSIDE_XY_ZOOM,
   LARGE_DATA_THRESHOLD,
   scatterSeriesLargeOpts,
 } from './chartConfig'
@@ -120,8 +115,8 @@ export function buildMixedAxes2DOptions(
   const baseOptions = getBaseOptions(config)
   const styling = getChartStyling(isDark.value)
   const parsed = parseScale(scale?.value)
-  const xWant = axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.mixed2d)
-  const yWant = axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.mixed2d)
+  const xWant = axisIsLog(parsed, 'x', ['y'])
+  const yWant = axisIsLog(parsed, 'y', ['y'])
   const yScale = resolveLogScale(
     yWant ? 'log' : 'linear',
     tuples.map(([, y]) => y)
@@ -211,17 +206,7 @@ export function buildMixedAxes2DOptions(
       ? createValueModeTooltip(isDark.value, xLabel, yLabel, true)
       : createMixedModeTooltip(isDark.value, xCategories, chartType, xLabel, yLabel),
     ...axisConfig,
-    dataZoom: xNums
-      ? [
-          { type: 'inside', xAxisIndex: 0 },
-          { type: 'inside', yAxisIndex: 0 },
-        ]
-      : largeX
-        ? createDataZoomConfig(xCategories, styling)
-        : [
-            { type: 'inside', xAxisIndex: 0 },
-            { type: 'inside', yAxisIndex: 0 },
-          ],
+    dataZoom: xNums || !largeX ? INSIDE_XY_ZOOM : createDataZoomConfig(xCategories, styling),
     series: [series],
   } as EChartsOption
 }
@@ -247,8 +232,8 @@ export function buildMixedAxes3DOptions(
   const pointCount = seriesData[0]?.data.length ?? 0
   const { yCount } = continuous3DGridCounts(pointCount)
   const parsed = parseScale(scale?.value)
-  const yLog = axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.mixed3d)
-  const zLog = axisIsLog(parsed, 'z', DEFAULT_LOG_AXES.mixed3d)
+  const yLog = axisIsLog(parsed, 'y', ['y', 'z'])
+  const zLog = axisIsLog(parsed, 'z', ['y', 'z'])
   const grid3D = create3DGridConfig({
     styling,
     autoRotate: threeDRotate?.value ?? false,

--- a/ui/src/composables/charts/shared/valueMode.test.ts
+++ b/ui/src/composables/charts/shared/valueMode.test.ts
@@ -55,6 +55,14 @@ describe('scaleValueTuples', () => {
       [3, 4, 7],
     ])
   })
+
+  it('x-log drops non-positive x and leaves y intact', () => {
+    const tuples: [number, number, number?][] = [
+      [0, 0],
+      [2, -1],
+    ]
+    expect(scaleValueTuples(tuples, 'linear', 'log')).toEqual([[2, -1]])
+  })
 })
 
 function cfg(overrides: BaseConfigOverrides = {}) {
@@ -116,6 +124,28 @@ describe('buildValueAxes2DOptions', () => {
     expect(seriesOf(option).data).toEqual([])
   })
 
+  it('logs X independently and keeps non-positive y', () => {
+    const option = buildValueAxes2DOptions(
+      cfg({
+        chartData: makeValueChartData({
+          valueTuples: [
+            [10, 0],
+            [100, 8],
+          ],
+        }),
+        scale: { type: 'log', axes: ['x'], base: 2 },
+      }),
+      'line'
+    )
+    expect((option.xAxis as { type?: string; logBase?: number }).type).toBe('log')
+    expect((option.xAxis as { logBase?: number }).logBase).toBe(2)
+    expect((option.yAxis as { type?: string }).type).toBe('value')
+    expect(seriesOf(option).data).toEqual([
+      [10, 0],
+      [100, 8],
+    ])
+  })
+
   it('sorts when enabled and scales log y', () => {
     const option = buildValueAxes2DOptions(
       cfg({
@@ -132,9 +162,9 @@ describe('buildValueAxes2DOptions', () => {
       'line'
     )
     expect(seriesOf(option).data).toEqual([
-      [2, 20, undefined],
-      [3, 5, undefined],
-      [1, null, undefined],
+      [2, 20],
+      [3, 5],
+      [1, null],
     ])
   })
 

--- a/ui/src/composables/charts/shared/valueMode.ts
+++ b/ui/src/composables/charts/shared/valueMode.ts
@@ -1,6 +1,7 @@
 import type { EChartsOption } from 'echarts'
 import type { ScaleType, ChartType } from '@/types'
 import { getNextColorFor, VALUE_CHART_TYPES, formatChartNumber } from '@/lib/utils'
+import { axisIsLog, axisLogBase, DEFAULT_LOG_AXES, parseScale } from '@/lib/scale'
 import { type BaseChartConfig, getBaseOptions } from '../baseChartOptions'
 import {
   createValueModeGridConfig,
@@ -33,10 +34,19 @@ export function sortValueTuples(
 
 export function scaleValueTuples(
   tuples: [number, number, number?][],
-  scale: ScaleType
+  yScale: ScaleType,
+  xScale: ScaleType = 'linear'
 ): [number, number | null, number?][] {
-  if (scale !== 'log') return tuples
-  return tuples.map(([x, y, c]) => [x, adjustForLogScaleLine(y, scale), c])
+  const xLog = xScale === 'log'
+  const yLog = yScale === 'log'
+  if (!xLog && !yLog) return tuples
+  const out: [number, number | null, number?][] = []
+  for (const [x, y, c] of tuples) {
+    if (xLog && x <= 0) continue
+    const yAdj = adjustForLogScaleLine(y, yScale)
+    out.push(c !== undefined ? [x, yAdj, c] : [x, yAdj])
+  }
+  return out
 }
 
 const chartTypeForECharts = (chartType: ChartType): string =>
@@ -71,13 +81,20 @@ export function buildValueAxes2DOptions(
   const yLabel = chartData.value.axisLabels?.y
   const baseOptions = getBaseOptions(config)
   const styling = getChartStyling(isDark.value)
+  const parsed = parseScale(scale?.value)
+  const xWant = axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.value2d)
+  const yWant = axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.value2d)
+  const xScale = resolveLogScale(
+    xWant ? 'log' : 'linear',
+    tuples.map((t) => t[0])
+  )
   const yScale = resolveLogScale(
-    scale?.value ?? 'linear',
+    yWant ? 'log' : 'linear',
     tuples.map((t) => t[1])
   )
 
   const sorted = sortValueTuples(tuples, sort.value.enabled, sort.value.order)
-  const data = scaleValueTuples(sorted, yScale)
+  const data = scaleValueTuples(sorted, yScale, xScale)
   const largeX = isLargeXAxis(data.map((_, i) => String(i)))
 
   const useVisualMap = chartType === 'scatter' && config.visualMap?.value === true
@@ -125,7 +142,12 @@ export function buildValueAxes2DOptions(
       xLabel,
       yLabel,
       yScale,
-      chartType === 'line' || chartType === 'scatter'
+      chartType === 'line' || chartType === 'scatter',
+      {
+        xScale,
+        xLogBase: axisLogBase(parsed, 'x'),
+        yLogBase: axisLogBase(parsed, 'y'),
+      }
     ),
     dataZoom: [
       { type: 'inside', xAxisIndex: 0 },

--- a/ui/src/composables/charts/shared/valueMode.ts
+++ b/ui/src/composables/charts/shared/valueMode.ts
@@ -1,7 +1,7 @@
 import type { EChartsOption } from 'echarts'
 import type { ScaleType, ChartType } from '@/types'
 import { getNextColorFor, VALUE_CHART_TYPES, formatChartNumber } from '@/lib/utils'
-import { axisIsLog, axisLogBase, DEFAULT_LOG_AXES, parseScale } from '@/lib/scale'
+import { axisIsLog, axisLogBase, parseScale } from '@/lib/scale'
 import { type BaseChartConfig, getBaseOptions } from '../baseChartOptions'
 import {
   createValueModeGridConfig,
@@ -10,6 +10,7 @@ import {
   createValueModeTooltip,
   getChartStyling,
   isLargeXAxis,
+  INSIDE_XY_ZOOM,
   LARGE_DATA_THRESHOLD,
   scatterSeriesLargeOpts,
 } from './chartConfig'
@@ -82,8 +83,8 @@ export function buildValueAxes2DOptions(
   const baseOptions = getBaseOptions(config)
   const styling = getChartStyling(isDark.value)
   const parsed = parseScale(scale?.value)
-  const xWant = axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.value2d)
-  const yWant = axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.value2d)
+  const xWant = axisIsLog(parsed, 'x', ['y'])
+  const yWant = axisIsLog(parsed, 'y', ['y'])
   const xScale = resolveLogScale(
     xWant ? 'log' : 'linear',
     tuples.map((t) => t[0])
@@ -149,10 +150,7 @@ export function buildValueAxes2DOptions(
         yLogBase: axisLogBase(parsed, 'y'),
       }
     ),
-    dataZoom: [
-      { type: 'inside', xAxisIndex: 0 },
-      { type: 'inside', yAxisIndex: 0 },
-    ],
+    dataZoom: INSIDE_XY_ZOOM,
     series: [series],
   } as EChartsOption
 }

--- a/ui/src/composables/charts/use3DChartOptions.ts
+++ b/ui/src/composables/charts/use3DChartOptions.ts
@@ -19,7 +19,6 @@ import {
   makeContinuous3DParams,
   valuePoints3DToSeries,
   resolve3DZAxisType,
-  zAxisLogBase,
   type Continuous3DContext,
 } from './shared/3d'
 import { getChartStyling, getTooltipTheme } from './shared/chartConfig'
@@ -55,10 +54,10 @@ export function use3DChartOptions(config: BaseChartConfig, kind: Chart3DKind) {
     const defaultColor = getDefaultThemeColor()
     const axisCommon = makeAxis3DCommon(styling)
     const seriesData = kind === 'bar3D' ? render.barSeries : render.lineSeries
-    const zType = resolve3DZAxisType(scale?.value ?? 'linear', seriesData)
+    const zAxis = resolve3DZAxisType(scale?.value ?? 'linear', seriesData)
     const zAxis3DBase = {
-      type: zType,
-      ...(zType === 'log' ? { logBase: zAxisLogBase(scale?.value ?? 'linear') } : {}),
+      type: zAxis.type,
+      ...(zAxis.type === 'log' ? { logBase: zAxis.logBase } : {}),
       ...axisCommon,
     }
     if (render.mode === 'mixed') {

--- a/ui/src/composables/charts/use3DChartOptions.ts
+++ b/ui/src/composables/charts/use3DChartOptions.ts
@@ -19,6 +19,7 @@ import {
   makeContinuous3DParams,
   valuePoints3DToSeries,
   resolve3DZAxisType,
+  zAxisLogBase,
   type Continuous3DContext,
 } from './shared/3d'
 import { getChartStyling, getTooltipTheme } from './shared/chartConfig'
@@ -54,8 +55,10 @@ export function use3DChartOptions(config: BaseChartConfig, kind: Chart3DKind) {
     const defaultColor = getDefaultThemeColor()
     const axisCommon = makeAxis3DCommon(styling)
     const seriesData = kind === 'bar3D' ? render.barSeries : render.lineSeries
+    const zType = resolve3DZAxisType(scale?.value ?? 'linear', seriesData)
     const zAxis3DBase = {
-      type: resolve3DZAxisType(scale?.value ?? 'linear', seriesData),
+      type: zType,
+      ...(zType === 'log' ? { logBase: zAxisLogBase(scale?.value ?? 'linear') } : {}),
       ...axisCommon,
     }
     if (render.mode === 'mixed') {

--- a/ui/src/composables/charts/useBarChartOptions.test.ts
+++ b/ui/src/composables/charts/useBarChartOptions.test.ts
@@ -4,6 +4,7 @@ import type { ChartData } from '@/types'
 import type { BaseChartConfig } from './baseChartOptions'
 import { useBarChartOptions } from './useBarChartOptions'
 import { installDevicePixelRatio, makeMixedChartData, baseConfig } from '@/test-utils'
+import { LARGE_X_THRESHOLD, VALUE_MODE_GRID_TOP } from './shared/chartConfig'
 
 let restoreDpr = installDevicePixelRatio()
 afterAll(() => restoreDpr())
@@ -39,6 +40,47 @@ const makeStackedGroupedConfig = (
 })
 
 describe('useBarChartOptions — grouped mode', () => {
+  it('uses a compact pixel legend band, not the category % top', () => {
+    const { options } = useBarChartOptions(makeStackedGroupedConfig(false))
+    const grid = options.value.grid as {
+      top?: number | string
+      bottom?: number
+      containLabel?: boolean
+    }
+    expect(grid.top).toBe(48)
+    expect(grid.bottom).toBe(28)
+    expect(grid.containLabel).toBe(true)
+  })
+
+  it('grows the legend band when grouped series wrap', () => {
+    const yAxis = Array.from({ length: 16 }, (_, i) => `s${i}`)
+    const data = makeStackedGroupedChartData()
+    data.yAxis = yAxis
+    data.series = data.series.map((s) => ({ ...s, values: yAxis.map(() => 1) }))
+    const { options } = useBarChartOptions({
+      ...makeStackedGroupedConfig(false),
+      chartData: ref(data),
+    })
+    expect((options.value.grid as { top?: number }).top).toBe(48 + 16)
+  })
+
+  it('keeps the category slider band on large-X grouped bars with compact top', () => {
+    const data = makeStackedGroupedChartData()
+    data.series = Array.from({ length: LARGE_X_THRESHOLD + 1 }, (_, i) => ({
+      xAxis: `x${i}`,
+      values: [10, 30],
+      benchmarkId: '',
+    }))
+    const { options } = useBarChartOptions({
+      ...makeStackedGroupedConfig(false),
+      chartData: ref(data),
+    })
+    const grid = options.value.grid as { top?: number; bottom?: number; containLabel?: boolean }
+    expect(grid.top).toBe(48)
+    expect(grid.bottom).toBe(100)
+    expect(grid.containLabel).toBe(false)
+  })
+
   it('emits stacked bar series when stack is enabled', () => {
     const { options } = useBarChartOptions(makeStackedGroupedConfig(true))
     const series = options.value.series as { stack?: string }[]
@@ -180,7 +222,57 @@ const makeGroupedConfig = (horizontal: boolean): BaseChartConfig => ({
   horizontal: ref(horizontal),
 })
 
+describe('useBarChartOptions — simple vertical', () => {
+  it('skips the legend top band when there is no legend', () => {
+    const { options } = useBarChartOptions(makeSimpleConfig(false))
+    const grid = options.value.grid as {
+      top?: number | string
+      bottom?: number
+      containLabel?: boolean
+    }
+    expect(grid.top).toBe(VALUE_MODE_GRID_TOP)
+    expect(grid.bottom).toBe(28)
+    expect(grid.containLabel).toBe(true)
+  })
+
+  it('keeps the category slider band on large-X 1D bars with no legend top', () => {
+    const data = makeSimpleChartData()
+    data.series = Array.from({ length: LARGE_X_THRESHOLD + 1 }, (_, i) => ({
+      xAxis: `x${i}`,
+      values: [i],
+      benchmarkId: '',
+    }))
+    const { options } = useBarChartOptions({
+      ...makeSimpleConfig(false),
+      chartData: ref(data),
+    })
+    const grid = options.value.grid as { top?: number; bottom?: number; containLabel?: boolean }
+    expect(grid.top).toBe(VALUE_MODE_GRID_TOP)
+    expect(grid.bottom).toBe(100)
+    expect(grid.containLabel).toBe(false)
+  })
+})
+
 describe('useBarChartOptions — horizontal mode', () => {
+  it('uses the compact pixel legend band at the bottom', () => {
+    const { options } = useBarChartOptions(makeGroupedConfig(true))
+    const grid = options.value.grid as { bottom?: number | string; top?: number }
+    expect(grid.bottom).toBe(28)
+    expect(grid.top).toBe(8)
+  })
+
+  it('grows the bottom legend band when grouped series wrap', () => {
+    const yAxis = Array.from({ length: 16 }, (_, i) => `s${i}`)
+    const data = makeGroupedChartData()
+    data.yAxis = yAxis
+    data.series = data.series.map((s) => ({ ...s, values: yAxis.map(() => 1) }))
+    const { options } = useBarChartOptions({
+      ...makeGroupedConfig(true),
+      chartData: ref(data),
+    })
+    expect((options.value.grid as { bottom?: number }).bottom).toBe(44)
+  })
+
   it('renders horizontal 1D bars with value xAxis and category yAxis', () => {
     const { options } = useBarChartOptions(makeSimpleConfig(true))
     const opt = options.value
@@ -339,6 +431,36 @@ describe('useBarChartOptions — value mode and branches', () => {
     expect(
       (options.value.tooltip as { axisPointer?: { type?: string } }).axisPointer?.type
     ).not.toBe('cross')
+    const grid = options.value.grid as { top?: number | string; bottom?: number }
+    expect(grid.top).toBe(48)
+    expect(grid.bottom).toBe(28)
+  })
+
+  it('does not reserve the category slider band when numeric log-X has many steps', () => {
+    const chartData: ChartData = {
+      title: 'steps',
+      statType: 'v',
+      yAxis: ['a', 'b'],
+      zAxis: [],
+      series: Array.from({ length: LARGE_X_THRESHOLD + 1 }, (_, i) => ({
+        xAxis: String(i + 1),
+        values: [1, 2],
+        benchmarkId: '',
+      })),
+      points: [],
+      axisLabels: { x: 'step', y: 'run' },
+    }
+    const { options } = useBarChartOptions({
+      chartData: ref(chartData),
+      sort: ref({ enabled: false, order: 'asc' }),
+      showLabels: ref(false),
+      isDark: ref(false),
+      scale: ref({ type: 'log' as const, axes: ['x'] as ('x' | 'y' | 'z')[] }),
+    })
+    const grid = options.value.grid as { top?: number; bottom?: number; containLabel?: boolean }
+    expect(grid.top).toBe(48)
+    expect(grid.bottom).toBe(28)
+    expect(grid.containLabel).toBe(true)
   })
 
   it('log-X simple bars map missing values via ?? null', () => {
@@ -361,6 +483,7 @@ describe('useBarChartOptions — value mode and branches', () => {
     expect((options.value.series as { data: [number, number | null][] }[])[0]!.data).toEqual([
       [1, null],
     ])
+    expect((options.value.grid as { top?: number }).top).toBe(VALUE_MODE_GRID_TOP)
   })
 
   it('log-X grouped bars map missing y values and sort [x,y] pairs', () => {

--- a/ui/src/composables/charts/useBarChartOptions.test.ts
+++ b/ui/src/composables/charts/useBarChartOptions.test.ts
@@ -306,6 +306,71 @@ describe('useBarChartOptions — value mode and branches', () => {
     expect(series[0]!.data).toEqual([null, null, 5, null])
   })
 
+  it('coerces numeric category X to log without dropping y <= 0', () => {
+    const chartData: ChartData = {
+      title: 'steps',
+      statType: 'v',
+      yAxis: ['a', 'b'],
+      zAxis: [],
+      series: [
+        { xAxis: '1', values: [0, 4], benchmarkId: '' },
+        { xAxis: '10', values: [5, 8], benchmarkId: '' },
+      ],
+      points: [],
+      axisLabels: { x: 'step', y: 'run' },
+    }
+    const { options } = useBarChartOptions({
+      chartData: ref(chartData),
+      sort: ref({ enabled: false, order: 'asc' }),
+      showLabels: ref(false),
+      isDark: ref(false),
+      scale: ref({ type: 'log' as const, axes: ['x'] as ('x' | 'y' | 'z')[] }),
+    })
+    expect((options.value.xAxis as { type?: string }).type).toBe('log')
+    expect((options.value.yAxis as { type?: string }).type).toBe('value')
+    const series = options.value.series as { data: [number, number | null][] }[]
+    expect(series[0]!.data).toEqual([
+      [1, 0],
+      [10, 5],
+    ])
+    expect(
+      (options.value.tooltip as { trigger?: string; axisPointer?: { type?: string } }).trigger
+    ).toBe('axis')
+    expect(
+      (options.value.tooltip as { axisPointer?: { type?: string } }).axisPointer?.type
+    ).not.toBe('cross')
+  })
+
+  it('simple numeric log-X bars use cross tooltip', () => {
+    const chartData: ChartData = {
+      title: 'steps',
+      statType: 'v',
+      yAxis: [],
+      zAxis: [],
+      series: [
+        { xAxis: '1', values: [0], benchmarkId: '' },
+        { xAxis: '10', values: [5], benchmarkId: '' },
+      ],
+      points: [],
+      axisLabels: { x: 'step' },
+    }
+    const { options } = useBarChartOptions({
+      chartData: ref(chartData),
+      sort: ref({ enabled: false, order: 'asc' }),
+      showLabels: ref(false),
+      isDark: ref(false),
+      scale: ref({ type: 'log' as const, axes: ['x'] as ('x' | 'y' | 'z')[] }),
+    })
+    expect((options.value.xAxis as { type?: string }).type).toBe('log')
+    expect((options.value.series as { data: [number, number | null][] }[])[0]!.data).toEqual([
+      [1, 0],
+      [10, 5],
+    ])
+    expect((options.value.tooltip as { axisPointer?: { type?: string } }).axisPointer?.type).toBe(
+      'cross'
+    )
+  })
+
   it('adds horizontal dataZoom for large simple categories', () => {
     const many = Array.from({ length: 60 }, (_, i) => `c${i}`)
     const chartData: ChartData = {

--- a/ui/src/composables/charts/useBarChartOptions.test.ts
+++ b/ui/src/composables/charts/useBarChartOptions.test.ts
@@ -341,6 +341,81 @@ describe('useBarChartOptions — value mode and branches', () => {
     ).not.toBe('cross')
   })
 
+  it('log-X simple bars map missing values via ?? null', () => {
+    const chartData: ChartData = {
+      title: 'steps',
+      statType: 'v',
+      yAxis: [],
+      zAxis: [],
+      series: [{ xAxis: '1', values: [], benchmarkId: '' }],
+      points: [],
+      axisLabels: { x: 'step' },
+    }
+    const { options } = useBarChartOptions({
+      chartData: ref(chartData),
+      sort: ref({ enabled: false, order: 'asc' }),
+      showLabels: ref(false),
+      isDark: ref(false),
+      scale: ref({ type: 'log' as const, axes: ['x'] as ('x' | 'y')[] }),
+    })
+    expect((options.value.series as { data: [number, number | null][] }[])[0]!.data).toEqual([
+      [1, null],
+    ])
+  })
+
+  it('log-X grouped bars map missing y values and sort [x,y] pairs', () => {
+    const chartData: ChartData = {
+      title: 'steps',
+      statType: 'v',
+      yAxis: ['a', 'b'],
+      zAxis: [],
+      series: [{ xAxis: '10', values: [8], benchmarkId: '' }],
+      points: [],
+      axisLabels: { x: 'step', y: 'run' },
+    }
+    const { options } = useBarChartOptions({
+      chartData: ref(chartData),
+      sort: ref({ enabled: true, order: 'asc' }),
+      showLabels: ref(false),
+      isDark: ref(true),
+      scale: ref({ type: 'log' as const, axes: ['x'] as ('x' | 'y')[] }),
+    })
+    const series = options.value.series as { name: string; data: [number, number | null][] }[]
+    expect(series.map((s) => s.name)).toEqual(['b', 'a'])
+    expect(series[0]!.data).toEqual([[10, null]])
+    expect(series[1]!.data).toEqual([[10, 8]])
+    expect((options.value.tooltip as { axisPointer?: { type?: string } }).axisPointer?.type).toBe(
+      'line'
+    )
+  })
+
+  it('grouped log-X with one y series uses cross tooltip', () => {
+    const chartData: ChartData = {
+      title: 'steps',
+      statType: 'v',
+      yAxis: ['train'],
+      zAxis: [],
+      series: [
+        { xAxis: '1', values: [10], benchmarkId: '' },
+        { xAxis: '10', values: [5], benchmarkId: '' },
+      ],
+      points: [],
+      axisLabels: { x: 'step', y: 'split' },
+    }
+    const { options } = useBarChartOptions({
+      chartData: ref(chartData),
+      sort: ref({ enabled: false, order: 'asc' }),
+      showLabels: ref(false),
+      isDark: ref(false),
+      scale: ref({ type: 'log' as const, axes: ['x'] as ('x' | 'y')[] }),
+    })
+    expect((options.value.xAxis as { type?: string }).type).toBe('log')
+    expect((options.value.series as unknown[]).length).toBe(1)
+    expect((options.value.tooltip as { axisPointer?: { type?: string } }).axisPointer?.type).toBe(
+      'cross'
+    )
+  })
+
   it('simple numeric log-X bars use cross tooltip', () => {
     const chartData: ChartData = {
       title: 'steps',

--- a/ui/src/composables/charts/useBarChartOptions.test.ts
+++ b/ui/src/composables/charts/useBarChartOptions.test.ts
@@ -3,7 +3,12 @@ import { ref } from 'vue'
 import type { ChartData } from '@/types'
 import type { BaseChartConfig } from './baseChartOptions'
 import { useBarChartOptions } from './useBarChartOptions'
-import { installDevicePixelRatio, makeMixedChartData, baseConfig } from '@/test-utils'
+import {
+  installDevicePixelRatio,
+  makeMixedChartData,
+  makeNumericStepChartData,
+  baseConfig,
+} from '@/test-utils'
 import { LARGE_X_THRESHOLD, VALUE_MODE_GRID_TOP } from './shared/chartConfig'
 
 let restoreDpr = installDevicePixelRatio()
@@ -399,20 +404,16 @@ describe('useBarChartOptions — value mode and branches', () => {
   })
 
   it('coerces numeric category X to log without dropping y <= 0', () => {
-    const chartData: ChartData = {
-      title: 'steps',
-      statType: 'v',
-      yAxis: ['a', 'b'],
-      zAxis: [],
-      series: [
-        { xAxis: '1', values: [0, 4], benchmarkId: '' },
-        { xAxis: '10', values: [5, 8], benchmarkId: '' },
-      ],
-      points: [],
-      axisLabels: { x: 'step', y: 'run' },
-    }
     const { options } = useBarChartOptions({
-      chartData: ref(chartData),
+      chartData: ref(
+        makeNumericStepChartData(
+          ['a', 'b'],
+          [
+            ['1', [0, 4]],
+            ['10', [5, 8]],
+          ]
+        )
+      ),
       sort: ref({ enabled: false, order: 'asc' }),
       showLabels: ref(false),
       isDark: ref(false),

--- a/ui/src/composables/charts/useBarChartOptions.ts
+++ b/ui/src/composables/charts/useBarChartOptions.ts
@@ -7,6 +7,7 @@ import {
   createAxisConfig,
   createDataZoomConfig,
   createGridConfig,
+  createValueModeGridConfig,
   createHorizontalAxisConfig,
   createHorizontalDataZoomConfig,
   createLabelConfig,
@@ -15,7 +16,7 @@ import {
   createValueAxisConfig,
   createValueModeTooltip,
   getChartStyling,
-  horizontalLegendBottom,
+  legendBandPx,
   isLargeXAxis,
   makeLegendTitle,
   INSIDE_XY_ZOOM,
@@ -225,7 +226,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
       applyBackgroundToSeries([seriesItem], backgroundStyle)
       return {
         ...baseOptions,
-        grid: createGridConfig(1, largeX),
+        grid: createValueModeGridConfig(xNums ? false : largeX),
         tooltip: xNums
           ? createValueModeTooltip(isDark.value, xLabel, chartData.value.axisLabels?.y, true)
           : createTooltipConfig(false, isDark.value),
@@ -305,7 +306,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
         grid: {
           left: xLabel ? 70 : '3%',
           right: largeX ? 44 : 24,
-          bottom: hasMultipleSeries ? horizontalLegendBottom(transposedSeries.length) : '3%',
+          bottom: hasMultipleSeries ? legendBandPx(transposedSeries.length) : '3%',
           top: 8,
           containLabel: true,
         },
@@ -325,7 +326,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
     return {
       ...baseOptions,
       ...(showLegendTitle ? { title: makeLegendTitle(yLabel!, styling) } : {}),
-      grid: createGridConfig(transposedSeries.length, largeX),
+      grid: createGridConfig(transposedSeries.length, xNums ? false : largeX, showLegendTitle),
       tooltip: xNums
         ? hasMultipleSeries
           ? createTooltipConfig(hasXAxis(chartData), isDark.value, seriesTotals, 'line')

--- a/ui/src/composables/charts/useBarChartOptions.ts
+++ b/ui/src/composables/charts/useBarChartOptions.ts
@@ -171,13 +171,8 @@ export function useBarChartOptions(config: BaseChartConfig) {
       const seriesItem = {
         name: chartData.value.title,
         type: 'bar' as const,
-        data: xNums
-          ? asLogXPairs(
-              xNums,
-              series.map((s) => s.values[0] ?? null),
-              valueLog
-            )
-          : series.map((s) => barNullable(s.values[0] ?? null, valueLog)),
+        // xNums is null while horizontal (category X stays categorical).
+        data: series.map((s) => barNullable(s.values[0] ?? null, valueLog)),
         label: createLabelConfig(showLabels.value, styling, 'horizontal'),
         large: true,
         largeThreshold: LARGE_DATA_THRESHOLD,

--- a/ui/src/composables/charts/useBarChartOptions.ts
+++ b/ui/src/composables/charts/useBarChartOptions.ts
@@ -18,27 +18,16 @@ import {
   horizontalLegendBottom,
   isLargeXAxis,
   makeLegendTitle,
+  INSIDE_XY_ZOOM,
   LARGE_DATA_THRESHOLD,
 } from './shared/chartConfig'
 import { useSortedSeriesData, resolveLogScale, computeSeriesTotals } from './shared/common'
-import {
-  axisIsLog,
-  axisLogBase,
-  DEFAULT_LOG_AXES,
-  numericLogXValues,
-  parseScale,
-} from '@/lib/scale'
+import { asLogXPairs, axisIsLog, axisLogBase, numericLogXValues, parseScale } from '@/lib/scale'
 import { buildValueAxes2DOptions } from './shared/valueMode'
 import { buildMixedAxes2DOptions } from './shared/mixedMode'
 
 const barNullable = (val: number | null, yLog: boolean): number | null =>
   val === null ? null : yLog && val <= 0 ? null : val
-
-const asLogXPairs = (
-  xNums: number[],
-  values: (number | null)[],
-  yLog: boolean
-): [number, number | null][] => xNums.map((x, i) => [x, barNullable(values[i] ?? null, yLog)])
 
 // ECharts itemStyle.borderRadius: [TL, TR, BR, BL] (len 1–4; [8] = all corners).
 type BarItemStyle = { color?: string; borderRadius?: number[] }
@@ -147,7 +136,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
     // radar pass a config without it. The bar composable is the only consumer,
     // so we default at the call site.
     const parsed = parseScale(scale?.value)
-    const defaultAxes = isHorizontal ? DEFAULT_LOG_AXES.horizontalBar : DEFAULT_LOG_AXES.grouped2d
+    const defaultAxes = isHorizontal ? (['x'] as const) : (['y'] as const)
     const xWant = axisIsLog(parsed, 'x', defaultAxes)
     const yWant = axisIsLog(parsed, 'y', defaultAxes)
     const valueLogWant = isHorizontal ? xWant : yWant
@@ -170,10 +159,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
         ? createHorizontalAxisConfig(styling, xAxisData, yScale, xLabel, largeX, yLogBase)
         : createAxisConfig(styling, xAxisData, yScale, xLabel, largeX, false, yLogBase)
     const groupedDataZoom = xNums
-      ? [
-          { type: 'inside' as const, xAxisIndex: 0 },
-          { type: 'inside' as const, yAxisIndex: 0 },
-        ]
+      ? INSIDE_XY_ZOOM
       : largeX
         ? isHorizontal
           ? createHorizontalDataZoomConfig(styling)

--- a/ui/src/composables/charts/useBarChartOptions.ts
+++ b/ui/src/composables/charts/useBarChartOptions.ts
@@ -12,6 +12,8 @@ import {
   createLabelConfig,
   createLegendConfig,
   createTooltipConfig,
+  createValueAxisConfig,
+  createValueModeTooltip,
   getChartStyling,
   horizontalLegendBottom,
   isLargeXAxis,
@@ -19,11 +21,24 @@ import {
   LARGE_DATA_THRESHOLD,
 } from './shared/chartConfig'
 import { useSortedSeriesData, resolveLogScale, computeSeriesTotals } from './shared/common'
+import {
+  axisIsLog,
+  axisLogBase,
+  DEFAULT_LOG_AXES,
+  numericLogXValues,
+  parseScale,
+} from '@/lib/scale'
 import { buildValueAxes2DOptions } from './shared/valueMode'
 import { buildMixedAxes2DOptions } from './shared/mixedMode'
 
-const barNullable = (val: number | null, scale: string): number | null =>
-  val === null ? null : scale === 'log' && val <= 0 ? null : val
+const barNullable = (val: number | null, yLog: boolean): number | null =>
+  val === null ? null : yLog && val <= 0 ? null : val
+
+const asLogXPairs = (
+  xNums: number[],
+  values: (number | null)[],
+  yLog: boolean
+): [number, number | null][] => xNums.map((x, i) => [x, barNullable(values[i] ?? null, yLog)])
 
 // ECharts itemStyle.borderRadius: [TL, TR, BR, BL] (len 1–4; [8] = all corners).
 type BarItemStyle = { color?: string; borderRadius?: number[] }
@@ -131,19 +146,52 @@ export function useBarChartOptions(config: BaseChartConfig) {
     // `scale` is optional on BaseChartConfig (relaxed in Task 7) — pie/heatmap/
     // radar pass a config without it. The bar composable is the only consumer,
     // so we default at the call site.
+    const parsed = parseScale(scale?.value)
+    const defaultAxes = isHorizontal ? DEFAULT_LOG_AXES.horizontalBar : DEFAULT_LOG_AXES.grouped2d
+    const xWant = axisIsLog(parsed, 'x', defaultAxes)
+    const yWant = axisIsLog(parsed, 'y', defaultAxes)
+    const valueLogWant = isHorizontal ? xWant : yWant
     const yScale = resolveLogScale(
-      scale?.value ?? 'linear',
+      valueLogWant ? 'log' : 'linear',
       series.flatMap((s) => s.values)
     )
+    const valueLog = yScale === 'log'
+    const xNums = !isHorizontal ? numericLogXValues(xAxisData, xWant) : null
     const largeX = isLargeXAxis(xAxisData)
     const xLabel = chartData.value.axisLabels?.x
+    const yLogBase = axisLogBase(parsed, isHorizontal ? 'x' : 'y')
+    const groupedAxes = xNums
+      ? createValueAxisConfig(styling, xLabel, undefined, yScale, false, {
+          xScale: 'log',
+          xLogBase: axisLogBase(parsed, 'x'),
+          yLogBase,
+        })
+      : isHorizontal
+        ? createHorizontalAxisConfig(styling, xAxisData, yScale, xLabel, largeX, yLogBase)
+        : createAxisConfig(styling, xAxisData, yScale, xLabel, largeX, false, yLogBase)
+    const groupedDataZoom = xNums
+      ? [
+          { type: 'inside' as const, xAxisIndex: 0 },
+          { type: 'inside' as const, yAxisIndex: 0 },
+        ]
+      : largeX
+        ? isHorizontal
+          ? createHorizontalDataZoomConfig(styling)
+          : createDataZoomConfig(xAxisData, styling)
+        : undefined
     const useStack = stack?.value === true && yScale !== 'log'
 
     if (!hasYAxis && isHorizontal) {
       const seriesItem = {
         name: chartData.value.title,
         type: 'bar' as const,
-        data: series.map((s) => barNullable(s.values[0] ?? null, yScale)),
+        data: xNums
+          ? asLogXPairs(
+              xNums,
+              series.map((s) => s.values[0] ?? null),
+              valueLog
+            )
+          : series.map((s) => barNullable(s.values[0] ?? null, valueLog)),
         label: createLabelConfig(showLabels.value, styling, 'horizontal'),
         large: true,
         largeThreshold: LARGE_DATA_THRESHOLD,
@@ -164,8 +212,8 @@ export function useBarChartOptions(config: BaseChartConfig) {
         },
         tooltip: createTooltipConfig(false, isDark.value),
         legend: { show: false },
-        ...createHorizontalAxisConfig(styling, xAxisData, yScale, xLabel, largeX),
-        ...(largeX ? { dataZoom: createHorizontalDataZoomConfig(styling) } : {}),
+        ...groupedAxes,
+        ...(groupedDataZoom ? { dataZoom: groupedDataZoom } : {}),
         series: [seriesItem],
       } as EChartsOption
     }
@@ -178,7 +226,13 @@ export function useBarChartOptions(config: BaseChartConfig) {
         // object — a 100k-bar chart would otherwise allocate 100k label configs
         // on every recompute. `large` keeps the draw on one frame past the
         // threshold.
-        data: series.map((s) => barNullable(s.values[0] ?? null, yScale)),
+        data: xNums
+          ? asLogXPairs(
+              xNums,
+              series.map((s) => s.values[0] ?? null),
+              valueLog
+            )
+          : series.map((s) => barNullable(s.values[0] ?? null, valueLog)),
         label: createLabelConfig(showLabels.value, styling),
         large: true,
         largeThreshold: LARGE_DATA_THRESHOLD,
@@ -191,10 +245,12 @@ export function useBarChartOptions(config: BaseChartConfig) {
       return {
         ...baseOptions,
         grid: createGridConfig(1, largeX),
-        tooltip: createTooltipConfig(false, isDark.value),
+        tooltip: xNums
+          ? createValueModeTooltip(isDark.value, xLabel, chartData.value.axisLabels?.y, true)
+          : createTooltipConfig(false, isDark.value),
         legend: { show: false },
-        ...createAxisConfig(styling, xAxisData, yScale, xLabel, largeX),
-        ...(largeX ? { dataZoom: createDataZoomConfig(xAxisData, styling) } : {}),
+        ...groupedAxes,
+        ...(groupedDataZoom ? { dataZoom: groupedDataZoom } : {}),
         series: [seriesItem],
       } as EChartsOption
     }
@@ -204,7 +260,13 @@ export function useBarChartOptions(config: BaseChartConfig) {
     const transposedSeries = yAxisLabels.map((yAxisLabel, yIndex) => ({
       name: yAxisLabel,
       type: 'bar' as const,
-      data: series.map((s) => barNullable(s.values[yIndex] ?? null, yScale)),
+      data: xNums
+        ? asLogXPairs(
+            xNums,
+            series.map((s) => s.values[yIndex] ?? null),
+            valueLog
+          )
+        : series.map((s) => barNullable(s.values[yIndex] ?? null, valueLog)),
       label: createLabelConfig(
         showLabels.value,
         styling,
@@ -221,9 +283,13 @@ export function useBarChartOptions(config: BaseChartConfig) {
     // data items are now plain numbers (or null). Apply after sort so stacked
     // top-only radius tracks the outermost segment.
     if (sort.value.enabled && xAxisData.length === 1) {
+      const metricAt = (d: number | null | [number, number | null] | undefined): number => {
+        if (Array.isArray(d)) return d[1] ?? 0
+        return d ?? 0
+      }
       transposedSeries.sort((a, b) => {
-        const valA = a.data[0] ?? 0
-        const valB = b.data[0] ?? 0
+        const valA = metricAt(a.data[0])
+        const valB = metricAt(b.data[0])
         return sort.value.order === 'asc' ? valA - valB : valB - valA
       })
     }
@@ -269,8 +335,8 @@ export function useBarChartOptions(config: BaseChartConfig) {
           hasMultipleSeries,
           { bottom: 0 }
         ),
-        ...createHorizontalAxisConfig(styling, xAxisData, yScale, xLabel, largeX),
-        ...(largeX ? { dataZoom: createHorizontalDataZoomConfig(styling) } : {}),
+        ...groupedAxes,
+        ...(groupedDataZoom ? { dataZoom: groupedDataZoom } : {}),
         series: transposedSeries,
       } as EChartsOption
     }
@@ -279,15 +345,19 @@ export function useBarChartOptions(config: BaseChartConfig) {
       ...baseOptions,
       ...(showLegendTitle ? { title: makeLegendTitle(yLabel!, styling) } : {}),
       grid: createGridConfig(transposedSeries.length, largeX),
-      tooltip: createTooltipConfig(hasXAxis(chartData), isDark.value, seriesTotals),
+      tooltip: xNums
+        ? hasMultipleSeries
+          ? createTooltipConfig(hasXAxis(chartData), isDark.value, seriesTotals, 'line')
+          : createValueModeTooltip(isDark.value, xLabel, yLabel, true)
+        : createTooltipConfig(hasXAxis(chartData), isDark.value, seriesTotals),
       legend: createLegendConfig(
         transposedSeries.map((s) => ({ xAxis: s.name })),
         styling,
         hasMultipleSeries,
         showLegendTitle ? { top: 24 } : undefined
       ),
-      ...createAxisConfig(styling, xAxisData, yScale, xLabel, largeX),
-      ...(largeX ? { dataZoom: createDataZoomConfig(xAxisData, styling) } : {}),
+      ...groupedAxes,
+      ...(groupedDataZoom ? { dataZoom: groupedDataZoom } : {}),
       series: transposedSeries,
     } as EChartsOption
   })

--- a/ui/src/composables/charts/useCategorySeriesChartOptions.test.ts
+++ b/ui/src/composables/charts/useCategorySeriesChartOptions.test.ts
@@ -203,6 +203,36 @@ describe('useCategorySeriesChartOptions — mixed / value dispatch', () => {
 })
 
 describe('useCategorySeriesChartOptions — remaining branches', () => {
+  it('log-X maps missing simple and grouped values via ?? null', () => {
+    const simple = emptyChartData({
+      title: 'steps',
+      yAxis: [],
+      series: [{ xAxis: '1', values: [], benchmarkId: '' }],
+      axisLabels: { x: 'step' },
+    })
+    const { options } = useCategorySeriesChartOptions(
+      baseConfig({ chartData: simple, scale: { type: 'log', axes: ['x'] } }),
+      'line'
+    )
+    expect((options.value.series as { data: [number, number | null][] }[])[0]!.data).toEqual([
+      [1, null],
+    ])
+
+    const grouped = emptyChartData({
+      title: 'steps',
+      yAxis: ['a', 'b'],
+      series: [{ xAxis: '2', values: [10], benchmarkId: '' }],
+      axisLabels: { x: 'step', y: 'run' },
+    })
+    const { options: g } = useCategorySeriesChartOptions(
+      baseConfig({ chartData: grouped, scale: { type: 'log', axes: ['x'] } }),
+      'line'
+    )
+    const series = g.value.series as { data: [number, number | null][] }[]
+    expect(series[0]!.data).toEqual([[2, 10]])
+    expect(series[1]!.data).toEqual([[2, null]])
+  })
+
   it('smooth x-only lines and large grouped dataZoom', () => {
     const { options } = useCategorySeriesChartOptions(
       baseConfig({ chartData: xOnly(), smooth: true }),

--- a/ui/src/composables/charts/useCategorySeriesChartOptions.ts
+++ b/ui/src/composables/charts/useCategorySeriesChartOptions.ts
@@ -15,6 +15,7 @@ import {
   getChartStyling,
   isLargeXAxis,
   makeLegendTitle,
+  INSIDE_XY_ZOOM,
   LARGE_DATA_THRESHOLD,
   scatterSeriesLargeOpts,
 } from './shared/chartConfig'
@@ -24,13 +25,7 @@ import {
   resolveLogScale,
   computeSeriesTotals,
 } from './shared/common'
-import {
-  axisIsLog,
-  axisLogBase,
-  DEFAULT_LOG_AXES,
-  numericLogXValues,
-  parseScale,
-} from '@/lib/scale'
+import { asLogXPairs, axisIsLog, axisLogBase, numericLogXValues, parseScale } from '@/lib/scale'
 import { resolveSeriesSymbol } from './shared/seriesConfig'
 import { resolve2DScatterVisualMap } from './shared/visualMap'
 import { buildValueAxes2DOptions } from './shared/valueMode'
@@ -73,12 +68,6 @@ const groupedScatterColorValues = (seriesList: { data: SeriesPoint[] }[]): numbe
 const logYValue = (val: number | null, yLog: boolean): number | null =>
   adjustForLogScaleLine(val, yLog ? 'log' : 'linear')
 
-const asLogXPairs = (
-  xNums: number[],
-  values: (number | null)[],
-  yLog: boolean
-): [number, number | null][] => xNums.map((x, i) => [x, logYValue(values[i] ?? null, yLog)])
-
 export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: CategorySeriesKind) {
   const { chartData, sort, isDark, showLabels, scale, stack, visualMap } = config
   const sortedData = useSortedSeriesData(chartData, sort)
@@ -96,8 +85,8 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
     const baseOptions = getBaseOptions(config)
     const styling = getChartStyling(isDark.value)
     const parsed = parseScale(scale?.value)
-    const xWant = axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.grouped2d)
-    const yWant = axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.grouped2d)
+    const xWant = axisIsLog(parsed, 'x', ['y'])
+    const yWant = axisIsLog(parsed, 'y', ['y'])
     const yScale = resolveLogScale(
       yWant ? 'log' : 'linear',
       series.flatMap((s) => s.values)
@@ -116,10 +105,7 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
         })
       : createAxisConfig(styling, xAxisData, yScale, xLabel, largeX, true, yLogBase)
     const groupedDataZoom = coerceX
-      ? [
-          { type: 'inside' as const, xAxisIndex: 0 },
-          { type: 'inside' as const, yAxisIndex: 0 },
-        ]
+      ? INSIDE_XY_ZOOM
       : largeX
         ? createDataZoomConfig(xAxisData, styling)
         : undefined

--- a/ui/src/composables/charts/useCategorySeriesChartOptions.ts
+++ b/ui/src/composables/charts/useCategorySeriesChartOptions.ts
@@ -10,6 +10,8 @@ import {
   createLegendConfig,
   createPinnedAxisTooltip,
   createTooltipConfig,
+  createValueAxisConfig,
+  createValueModeTooltip,
   getChartStyling,
   isLargeXAxis,
   makeLegendTitle,
@@ -22,6 +24,13 @@ import {
   resolveLogScale,
   computeSeriesTotals,
 } from './shared/common'
+import {
+  axisIsLog,
+  axisLogBase,
+  DEFAULT_LOG_AXES,
+  numericLogXValues,
+  parseScale,
+} from '@/lib/scale'
 import { resolveSeriesSymbol } from './shared/seriesConfig'
 import { resolve2DScatterVisualMap } from './shared/visualMap'
 import { buildValueAxes2DOptions } from './shared/valueMode'
@@ -48,15 +57,27 @@ const SERIES_STYLE: Record<
   },
 }
 
-const groupedScatterColorValues = (seriesList: { data: (number | null)[] }[]): number[] => {
+type SeriesPoint = number | null | [number, number | null]
+
+const groupedScatterColorValues = (seriesList: { data: SeriesPoint[] }[]): number[] => {
   const vals: number[] = []
   for (const s of seriesList) {
     for (const v of s.data) {
-      if (v != null && isFinite(v)) vals.push(v)
+      const n = Array.isArray(v) ? v[1] : v
+      if (n != null && isFinite(n)) vals.push(n)
     }
   }
   return vals
 }
+
+const logYValue = (val: number | null, yLog: boolean): number | null =>
+  adjustForLogScaleLine(val, yLog ? 'log' : 'linear')
+
+const asLogXPairs = (
+  xNums: number[],
+  values: (number | null)[],
+  yLog: boolean
+): [number, number | null][] => xNums.map((x, i) => [x, logYValue(values[i] ?? null, yLog)])
 
 export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: CategorySeriesKind) {
   const { chartData, sort, isDark, showLabels, scale, stack, visualMap } = config
@@ -74,12 +95,34 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
     const { series, xAxisData, hasYAxis } = sortedData.value
     const baseOptions = getBaseOptions(config)
     const styling = getChartStyling(isDark.value)
+    const parsed = parseScale(scale?.value)
+    const xWant = axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.grouped2d)
+    const yWant = axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.grouped2d)
     const yScale = resolveLogScale(
-      scale?.value ?? 'linear',
+      yWant ? 'log' : 'linear',
       series.flatMap((s) => s.values)
     )
+    const yLog = yScale === 'log'
+    const xNums = numericLogXValues(xAxisData, xWant)
+    const coerceX = xNums !== null
     const largeX = isLargeXAxis(xAxisData)
     const xLabel = chartData.value.axisLabels?.x
+    const yLogBase = axisLogBase(parsed, 'y')
+    const groupedAxes = coerceX
+      ? createValueAxisConfig(styling, xLabel, undefined, yScale, true, {
+          xScale: 'log',
+          xLogBase: axisLogBase(parsed, 'x'),
+          yLogBase,
+        })
+      : createAxisConfig(styling, xAxisData, yScale, xLabel, largeX, true, yLogBase)
+    const groupedDataZoom = coerceX
+      ? [
+          { type: 'inside' as const, xAxisIndex: 0 },
+          { type: 'inside' as const, yAxisIndex: 0 },
+        ]
+      : largeX
+        ? createDataZoomConfig(xAxisData, styling)
+        : undefined
     const seriesExtras = resolveSeriesSymbol(
       largeX ? style.largeSymbol : style.defaultSymbol,
       config.symbol?.value,
@@ -93,7 +136,13 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
       const singleSeries = {
         name: chartData.value.title,
         type: kind,
-        data: series.map((s) => adjustForLogScaleLine(s.values[0] ?? null, yScale)),
+        data: xNums
+          ? asLogXPairs(
+              xNums,
+              series.map((s) => s.values[0] ?? null),
+              yLog
+            )
+          : series.map((s) => logYValue(s.values[0] ?? null, yLog)),
         label: createLabelConfig(showLabels.value, styling),
         ...(kind === 'scatter'
           ? scatterSeriesLargeOpts(useVisualMap)
@@ -106,9 +155,11 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
       return {
         ...baseOptions,
         grid: createGridConfig(1, largeX),
-        tooltip: createPinnedAxisTooltip(isDark.value),
-        ...createAxisConfig(styling, xAxisData, yScale, xLabel, largeX, true),
-        ...(largeX ? { dataZoom: createDataZoomConfig(xAxisData, styling) } : {}),
+        tooltip: coerceX
+          ? createValueModeTooltip(isDark.value, xLabel, chartData.value.axisLabels?.y, true)
+          : createPinnedAxisTooltip(isDark.value),
+        ...groupedAxes,
+        ...(groupedDataZoom ? { dataZoom: groupedDataZoom } : {}),
         legend: { show: false },
         visualMap: resolve2DScatterVisualMap(
           useVisualMap,
@@ -124,7 +175,13 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
     const transposedSeries = yAxisLabels.map((yAxisLabel, yIndex) => ({
       name: yAxisLabel,
       type: kind,
-      data: series.map((s) => adjustForLogScaleLine(s.values[yIndex] ?? null, yScale)),
+      data: xNums
+        ? asLogXPairs(
+            xNums,
+            series.map((s) => s.values[yIndex] ?? null),
+            yLog
+          )
+        : series.map((s) => logYValue(s.values[yIndex] ?? null, yLog)),
       label: createLabelConfig(showLabels.value, styling),
       ...(kind === 'scatter'
         ? scatterSeriesLargeOpts(useVisualMap)
@@ -151,9 +208,13 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
         styling,
         1
       ),
-      tooltip: createTooltipConfig(showXBreakdown, isDark.value, seriesTotals),
-      ...createAxisConfig(styling, xAxisData, yScale, xLabel, largeX, true),
-      ...(largeX ? { dataZoom: createDataZoomConfig(xAxisData, styling) } : {}),
+      tooltip: coerceX
+        ? transposedSeries.length <= 1
+          ? createValueModeTooltip(isDark.value, xLabel, yLabel, true)
+          : createTooltipConfig(showXBreakdown, isDark.value, seriesTotals, 'line')
+        : createTooltipConfig(showXBreakdown, isDark.value, seriesTotals),
+      ...groupedAxes,
+      ...(groupedDataZoom ? { dataZoom: groupedDataZoom } : {}),
       legend: createLegendConfig(
         transposedSeries.map((s) => ({ xAxis: s.name })),
         styling,

--- a/ui/src/composables/charts/useCategorySeriesChartOptions.ts
+++ b/ui/src/composables/charts/useCategorySeriesChartOptions.ts
@@ -6,6 +6,7 @@ import {
   createAxisConfig,
   createDataZoomConfig,
   createGridConfig,
+  createValueModeGridConfig,
   createLabelConfig,
   createLegendConfig,
   createPinnedAxisTooltip,
@@ -140,7 +141,7 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
       }
       return {
         ...baseOptions,
-        grid: createGridConfig(1, largeX),
+        grid: createValueModeGridConfig(coerceX ? false : largeX),
         tooltip: coerceX
           ? createValueModeTooltip(isDark.value, xLabel, chartData.value.axisLabels?.y, true)
           : createPinnedAxisTooltip(isDark.value),
@@ -187,7 +188,7 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
     return {
       ...baseOptions,
       ...(yLabel ? { title: makeLegendTitle(yLabel, styling) } : {}),
-      grid: createGridConfig(transposedSeries.length, largeX),
+      grid: createGridConfig(transposedSeries.length, coerceX ? false : largeX, !!yLabel),
       visualMap: resolve2DScatterVisualMap(
         useVisualMap,
         groupedScatterColorValues(transposedSeries),

--- a/ui/src/composables/charts/useLineChartOptions.test.ts
+++ b/ui/src/composables/charts/useLineChartOptions.test.ts
@@ -3,7 +3,11 @@ import { ref } from 'vue'
 import type { ChartData, ScaleInput } from '@/types'
 import type { BaseChartConfig } from './baseChartOptions'
 import { useLineChartOptions } from './useLineChartOptions'
-import { installDevicePixelRatio } from '@/test-utils'
+import {
+  installDevicePixelRatio,
+  makeNumericStepChartData,
+  makeNumericStepConfig,
+} from '@/test-utils'
 import { LARGE_X_THRESHOLD, VALUE_MODE_GRID_TOP } from './shared/chartConfig'
 
 let restoreDpr = installDevicePixelRatio()
@@ -83,36 +87,6 @@ const makeGroupedConfig = (opts: { smooth?: boolean; stack?: boolean } = {}): Ba
   scale: ref<ScaleInput>('linear'),
   smooth: ref(opts.smooth ?? false),
   stack: ref(opts.stack ?? false),
-})
-
-const makeNumericStepChartData = (
-  yAxis: string[] = ['train', 'val'],
-  points: [string, number[]][] = [
-    ['1', [10, 8]],
-    ['2', [0, 9]],
-    ['4', [12, 6]],
-  ]
-): ChartData => ({
-  title: 'loss vs step',
-  statType: 'grouped',
-  yAxis,
-  zAxis: [],
-  series: points.map(([xAxis, values]) => ({ xAxis, values, benchmarkId: xAxis })),
-  points: [],
-  axisLabels: { x: 'step', y: 'split' },
-})
-
-const makeNumericStepConfig = (
-  scale: ScaleInput,
-  data: ChartData = makeNumericStepChartData()
-) => ({
-  chartData: ref(data),
-  sort: ref({ enabled: false, order: 'asc' as const }),
-  showLabels: ref(false),
-  isDark: ref(false),
-  scale: ref(scale),
-  smooth: ref(false),
-  stack: ref(false),
 })
 
 const axisOf = (options: { xAxis?: unknown; yAxis?: unknown }) => ({

--- a/ui/src/composables/charts/useLineChartOptions.test.ts
+++ b/ui/src/composables/charts/useLineChartOptions.test.ts
@@ -4,6 +4,7 @@ import type { ChartData, ScaleInput } from '@/types'
 import type { BaseChartConfig } from './baseChartOptions'
 import { useLineChartOptions } from './useLineChartOptions'
 import { installDevicePixelRatio } from '@/test-utils'
+import { LARGE_X_THRESHOLD, VALUE_MODE_GRID_TOP } from './shared/chartConfig'
 
 let restoreDpr = installDevicePixelRatio()
 afterAll(() => restoreDpr())
@@ -126,7 +127,131 @@ const tooltipOf = (options: { tooltip?: unknown }) =>
     formatter?: (params: unknown) => string
   }
 
+describe('useLineChartOptions — simple 1D', () => {
+  it('skips the legend top band when there is no legend', () => {
+    const { options } = useLineChartOptions({
+      chartData: ref({
+        title: 'items',
+        statType: 'counts',
+        yAxis: [],
+        zAxis: [],
+        series: [
+          { xAxis: 'A', values: [10], benchmarkId: 'a' },
+          { xAxis: 'B', values: [20], benchmarkId: 'b' },
+        ],
+        points: [],
+        axisLabels: { x: 'category' },
+      }),
+      sort: ref({ enabled: false, order: 'asc' as const }),
+      showLabels: ref(false),
+      isDark: ref(false),
+      scale: ref<ScaleInput>('linear'),
+      smooth: ref(false),
+      stack: ref(false),
+    })
+    const grid = options.value.grid as {
+      top?: number | string
+      bottom?: number
+      containLabel?: boolean
+    }
+    expect((options.value.legend as { show?: boolean }).show).toBe(false)
+    expect(grid.top).toBe(VALUE_MODE_GRID_TOP)
+    expect(grid.bottom).toBe(28)
+    expect(grid.containLabel).toBe(true)
+  })
+
+  it('keeps the category slider band on large-X 1D lines with no legend top', () => {
+    const { options } = useLineChartOptions({
+      chartData: ref({
+        title: 'items',
+        statType: 'counts',
+        yAxis: [],
+        zAxis: [],
+        series: Array.from({ length: LARGE_X_THRESHOLD + 1 }, (_, i) => ({
+          xAxis: `x${i}`,
+          values: [i],
+          benchmarkId: `x${i}`,
+        })),
+        points: [],
+        axisLabels: { x: 'category' },
+      }),
+      sort: ref({ enabled: false, order: 'asc' as const }),
+      showLabels: ref(false),
+      isDark: ref(false),
+      scale: ref<ScaleInput>('linear'),
+      smooth: ref(false),
+      stack: ref(false),
+    })
+    const grid = options.value.grid as { top?: number; bottom?: number; containLabel?: boolean }
+    expect(grid.top).toBe(VALUE_MODE_GRID_TOP)
+    expect(grid.bottom).toBe(100)
+    expect(grid.containLabel).toBe(false)
+  })
+
+  it('uses no-legend top on numeric log-X 1D lines', () => {
+    const { options } = useLineChartOptions(
+      makeNumericStepConfig(
+        { type: 'log', axes: ['x'] },
+        {
+          title: 'steps',
+          statType: 'grouped',
+          yAxis: [],
+          zAxis: [],
+          series: [
+            { xAxis: '1', values: [10], benchmarkId: '1' },
+            { xAxis: '2', values: [0], benchmarkId: '2' },
+          ],
+          points: [],
+          axisLabels: { x: 'step' },
+        }
+      )
+    )
+    expect((options.value.grid as { top?: number }).top).toBe(VALUE_MODE_GRID_TOP)
+  })
+})
+
 describe('useLineChartOptions — grouped mode', () => {
+  it('uses a compact pixel legend band, not the category % top', () => {
+    const { options } = useLineChartOptions(makeGroupedConfig())
+    const grid = options.value.grid as {
+      top?: number | string
+      bottom?: number
+      containLabel?: boolean
+    }
+    expect(grid.top).toBe(48)
+    expect(grid.bottom).toBe(28)
+    expect(grid.containLabel).toBe(true)
+  })
+
+  it('grows the legend band when grouped series wrap', () => {
+    const yAxis = Array.from({ length: 16 }, (_, i) => `s${i}`)
+    const data = makeGroupedChartData()
+    data.yAxis = yAxis
+    data.series = data.series.map((s) => ({ ...s, values: yAxis.map(() => 1) }))
+    const { options } = useLineChartOptions({
+      ...makeGroupedConfig(),
+      chartData: ref(data),
+    })
+    expect((options.value.grid as { top?: number }).top).toBe(48 + 16)
+  })
+
+  it('keeps the category slider band on large-X grouped lines with compact top', () => {
+    const data = makeGroupedChartData()
+    data.series = Array.from({ length: LARGE_X_THRESHOLD + 1 }, (_, i) => ({
+      xAxis: `x${i}`,
+      values: [10, 8],
+      benchmarkId: `x${i}`,
+    }))
+    const { options } = useLineChartOptions({
+      ...makeGroupedConfig(),
+      chartData: ref(data),
+    })
+    const grid = options.value.grid as { top?: number; bottom?: number; containLabel?: boolean }
+    expect(grid.top).toBe(48)
+    expect(grid.bottom).toBe(100)
+    expect(grid.containLabel).toBe(false)
+  })
+
   it('emits stacked area line series when stack is enabled', () => {
     const { options } = useLineChartOptions(makeGroupedConfig({ stack: true }))
     const series = options.value.series as { stack?: string; areaStyle?: Record<string, never> }[]
@@ -244,6 +369,35 @@ describe('useLineChartOptions — per-axis log scale', () => {
     expect(xAxis.type).toBe('category')
     expect(xAxis.data).toEqual(['Jan', 'Feb'])
     expect(yAxis.type).toBe('value')
+  })
+
+  it('uses a compact pixel legend band on numeric log-X, not the category % top', () => {
+    const { options } = useLineChartOptions(makeNumericStepConfig({ type: 'log', axes: ['x'] }))
+    const grid = options.value.grid as {
+      top?: number | string
+      bottom?: number
+      containLabel?: boolean
+    }
+    expect(grid.top).toBe(48)
+    expect(grid.bottom).toBe(28)
+    expect(grid.containLabel).toBe(true)
+  })
+
+  it('does not reserve the category slider band when numeric log-X has many steps', () => {
+    const many = Array.from({ length: LARGE_X_THRESHOLD + 1 }, (_, i) => [
+      String(i + 1),
+      [10, 8],
+    ]) as [string, number[]][]
+    const { options } = useLineChartOptions(
+      makeNumericStepConfig(
+        { type: 'log', axes: ['x'] },
+        makeNumericStepChartData(['train', 'val'], many)
+      )
+    )
+    const grid = options.value.grid as { top?: number; bottom?: number; containLabel?: boolean }
+    expect(grid.top).toBe(48)
+    expect(grid.bottom).toBe(28)
+    expect(grid.containLabel).toBe(true)
   })
 
   it('grouped log-X with 2+ y series uses axis tooltip not cross', () => {

--- a/ui/src/composables/charts/useLineChartOptions.test.ts
+++ b/ui/src/composables/charts/useLineChartOptions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterAll } from 'vitest'
 import { ref } from 'vue'
-import type { ChartData } from '@/types'
+import type { ChartData, ScaleInput } from '@/types'
 import type { BaseChartConfig } from './baseChartOptions'
 import { useLineChartOptions } from './useLineChartOptions'
 import { installDevicePixelRatio } from '@/test-utils'
@@ -79,10 +79,52 @@ const makeGroupedConfig = (opts: { smooth?: boolean; stack?: boolean } = {}): Ba
   sort: ref({ enabled: false, order: 'asc' }),
   showLabels: ref(false),
   isDark: ref(false),
-  scale: ref<'linear' | 'log'>('linear'),
+  scale: ref<ScaleInput>('linear'),
   smooth: ref(opts.smooth ?? false),
   stack: ref(opts.stack ?? false),
 })
+
+const makeNumericStepChartData = (
+  yAxis: string[] = ['train', 'val'],
+  points: [string, number[]][] = [
+    ['1', [10, 8]],
+    ['2', [0, 9]],
+    ['4', [12, 6]],
+  ]
+): ChartData => ({
+  title: 'loss vs step',
+  statType: 'grouped',
+  yAxis,
+  zAxis: [],
+  series: points.map(([xAxis, values]) => ({ xAxis, values, benchmarkId: xAxis })),
+  points: [],
+  axisLabels: { x: 'step', y: 'split' },
+})
+
+const makeNumericStepConfig = (
+  scale: ScaleInput,
+  data: ChartData = makeNumericStepChartData()
+) => ({
+  chartData: ref(data),
+  sort: ref({ enabled: false, order: 'asc' as const }),
+  showLabels: ref(false),
+  isDark: ref(false),
+  scale: ref(scale),
+  smooth: ref(false),
+  stack: ref(false),
+})
+
+const axisOf = (options: { xAxis?: unknown; yAxis?: unknown }) => ({
+  xAxis: options.xAxis as { type?: string; logBase?: number; data?: string[] },
+  yAxis: options.yAxis as { type?: string; logBase?: number },
+})
+
+const tooltipOf = (options: { tooltip?: unknown }) =>
+  options.tooltip as {
+    trigger?: string
+    axisPointer?: { type?: string; snap?: boolean }
+    formatter?: (params: unknown) => string
+  }
 
 describe('useLineChartOptions — grouped mode', () => {
   it('emits stacked area line series when stack is enabled', () => {
@@ -143,6 +185,128 @@ describe('useLineChartOptions — axes value mode', () => {
     const { options } = useLineChartOptions(makeSmoothValueConfig())
     const s = (options.value.series as { smooth?: boolean }[])[0]!
     expect(s.smooth).toBe(true)
+  })
+})
+
+describe('useLineChartOptions — per-axis log scale', () => {
+  it('string log logs the default value axis only', () => {
+    const { options } = useLineChartOptions(makeNumericStepConfig('log'))
+    const { xAxis, yAxis } = axisOf(options.value)
+    expect(xAxis.type).toBe('category')
+    expect(yAxis.type).toBe('log')
+    expect(yAxis.logBase).toBe(10)
+  })
+
+  it('object axes x on numeric-step grouped lines sets log X and value Y with legend', () => {
+    const { options } = useLineChartOptions(makeNumericStepConfig({ type: 'log', axes: ['x'] }))
+    const { xAxis, yAxis } = axisOf(options.value)
+    expect(xAxis.type).toBe('log')
+    expect(yAxis.type).toBe('value')
+    const legend = options.value.legend as { show?: boolean; data?: string[] }
+    expect(legend.show).not.toBe(false)
+    expect(legend.data).toEqual(['train', 'val'])
+    const series = options.value.series as { name: string; data: [number, number | null][] }[]
+    expect(series).toHaveLength(2)
+    expect(series[0]!.data[0]).toEqual([1, 10])
+  })
+
+  it('base 2 sets xAxis.logBase to 2', () => {
+    const { options } = useLineChartOptions(
+      makeNumericStepConfig({ type: 'log', axes: ['x'], base: 2 })
+    )
+    expect(axisOf(options.value).xAxis.logBase).toBe(2)
+  })
+
+  it('X-log does not drop y <= 0', () => {
+    const { options } = useLineChartOptions(makeNumericStepConfig({ type: 'log', axes: ['x'] }))
+    const series = options.value.series as { data: [number, number | null][] }[]
+    expect(series[0]!.data).toEqual([
+      [1, 10],
+      [2, 0],
+      [4, 12],
+    ])
+  })
+
+  it('Y-log still nulls y <= 0', () => {
+    const { options } = useLineChartOptions(makeNumericStepConfig({ type: 'log', axes: ['y'] }))
+    const series = options.value.series as { data: (number | null)[] }[]
+    expect(series[0]!.data).toEqual([10, null, 12])
+    expect(axisOf(options.value).xAxis.type).toBe('category')
+    expect(axisOf(options.value).yAxis.type).toBe('log')
+  })
+
+  it('non-numeric category X stays category when axes includes x', () => {
+    const { options } = useLineChartOptions({
+      ...makeGroupedConfig(),
+      scale: ref<ScaleInput>({ type: 'log', axes: ['x'] }),
+    })
+    const { xAxis, yAxis } = axisOf(options.value)
+    expect(xAxis.type).toBe('category')
+    expect(xAxis.data).toEqual(['Jan', 'Feb'])
+    expect(yAxis.type).toBe('value')
+  })
+
+  it('grouped log-X with 2+ y series uses axis tooltip not cross', () => {
+    const { options } = useLineChartOptions(makeNumericStepConfig({ type: 'log', axes: ['x'] }))
+    const tooltip = tooltipOf(options.value)
+    expect(tooltip.trigger).toBe('axis')
+    expect(tooltip.axisPointer?.type).not.toBe('cross')
+    expect(tooltip.axisPointer?.type).toBe('line')
+    expect(tooltip.axisPointer?.snap).toBe(true)
+    const html = tooltip.formatter?.([
+      { name: '1', seriesName: 'train', value: [1, 10], marker: 'a', color: '#a00' },
+      { name: '1', seriesName: 'val', value: [1, 8], marker: 'b', color: '#00a' },
+    ])
+    expect(html).toContain('train')
+    expect(html).toContain('val')
+    expect(html).toContain('10')
+    expect(html).toContain('8')
+  })
+
+  it('same coerce-X path with one series uses cross', () => {
+    const { options } = useLineChartOptions(
+      makeNumericStepConfig(
+        { type: 'log', axes: ['x'] },
+        makeNumericStepChartData(
+          ['train'],
+          [
+            ['1', [10]],
+            ['2', [0]],
+            ['4', [12]],
+          ]
+        )
+      )
+    )
+    const tooltip = tooltipOf(options.value)
+    expect(tooltip.axisPointer?.type).toBe('cross')
+    expect(tooltip.trigger).toBe('item')
+  })
+
+  it('x-only numeric log-X uses cross and [x, y] pairs', () => {
+    const { options } = useLineChartOptions(
+      makeNumericStepConfig(
+        { type: 'log', axes: ['x'] },
+        {
+          title: 'steps',
+          statType: 'grouped',
+          yAxis: [],
+          zAxis: [],
+          series: [
+            { xAxis: '1', values: [10], benchmarkId: '1' },
+            { xAxis: '2', values: [0], benchmarkId: '2' },
+          ],
+          points: [],
+          axisLabels: { x: 'step' },
+        }
+      )
+    )
+    expect(axisOf(options.value).xAxis.type).toBe('log')
+    const series = options.value.series as { data: [number, number | null][] }[]
+    expect(series[0]!.data).toEqual([
+      [1, 10],
+      [2, 0],
+    ])
+    expect(tooltipOf(options.value).axisPointer?.type).toBe('cross')
   })
 })
 

--- a/ui/src/composables/useActiveChartShape.ts
+++ b/ui/src/composables/useActiveChartShape.ts
@@ -4,7 +4,7 @@ import type {
   BarConfig,
   LineConfig,
   ScatterConfig,
-  ScaleType,
+  ScaleInput,
   Sort,
   StatConfig,
 } from '../types'
@@ -36,10 +36,10 @@ export function useActiveChartShape() {
     () => (activeConfig.value as BarConfig | LineConfig | undefined)?.stack ?? false
   )
 
-  const scale = computed<ScaleType>(() =>
+  const scale = computed<ScaleInput>(() =>
     stack.value
       ? 'linear'
-      : ((activeConfig.value as { scale?: ScaleType } | undefined)?.scale ?? 'linear')
+      : ((activeConfig.value as { scale?: ScaleInput } | undefined)?.scale ?? 'linear')
   )
 
   const threeDRotate = computed<boolean>(

--- a/ui/src/composables/useChartOptions.ts
+++ b/ui/src/composables/useChartOptions.ts
@@ -1,5 +1,5 @@
 import { computed, type Ref } from 'vue'
-import type { Axis, BarBackground, ChartData, Sort, ChartType, ScaleType } from '../types'
+import type { Axis, BarBackground, ChartData, Sort, ChartType, ScaleInput } from '../types'
 import type { EChartsOption } from 'echarts'
 import { useBarChartOptions } from './charts/useBarChartOptions'
 import { useLineChartOptions } from './charts/useLineChartOptions'
@@ -21,7 +21,7 @@ export function useChartOptions(
   showLabels: Ref<boolean>,
   isDark: Ref<boolean>,
   chartType: Ref<ChartType>,
-  scale: Ref<ScaleType>,
+  scale: Ref<ScaleInput>,
   stack: Ref<boolean>,
   threeDRotate: Ref<boolean>,
   visibleZ: Ref<Record<string, boolean>>,

--- a/ui/src/composables/useChartPipeline.test.ts
+++ b/ui/src/composables/useChartPipeline.test.ts
@@ -2,7 +2,16 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { effectScope, reactive, ref, type Ref } from 'vue'
 import type { WorkerResponse, ReadyMessage, ChartMessage } from '../workers/transform.worker'
-import type { DataPoint, AxisLabels, Sort, ScaleType, ScaleInput, ChartData, Axis } from '../types'
+import type {
+  DataPoint,
+  AxisLabels,
+  Sort,
+  ScaleType,
+  ScaleInput,
+  ScaleSpec,
+  ChartData,
+  Axis,
+} from '../types'
 import { dp, noSort, VALUE_AXES, MIXED_AXES } from '@/test-utils'
 import { TrackedMockWorker } from '../workers/__test-utils__/workerHarness'
 
@@ -151,7 +160,7 @@ describe('useChartPipeline — object scale clone', () => {
   it('posts a plain cloneable object scale from a Vue reactive Proxy', async () => {
     scope.stop()
     TrackedMockWorker.reset()
-    const objectScale = reactive<ScaleInput>({ type: 'log', axes: ['x'] })
+    const objectScale = reactive<ScaleSpec>({ type: 'log', axes: ['x'] })
     const objectScaleRef = ref<ScaleInput>(objectScale)
     // Vue reactive Proxies cannot be structured-cloned (the original bug).
     expect(() => structuredClone(objectScaleRef.value)).toThrow()
@@ -186,7 +195,7 @@ describe('useChartPipeline — object scale clone', () => {
   it('copies optional log bases and still posts string scale as a string', async () => {
     scope.stop()
     TrackedMockWorker.reset()
-    const objectScale = reactive<ScaleInput>({
+    const objectScale = reactive<ScaleSpec>({
       type: 'log',
       axes: ['x', 'y'],
       base: 2,
@@ -244,6 +253,32 @@ describe('useChartPipeline — object scale clone', () => {
     const stringCompute = worker.postMessage.mock.calls.find((c) => c[0].type === 'compute')
     expect(stringCompute![0].scale).toBe('log')
     expect(() => structuredClone(stringCompute![0])).not.toThrow()
+  })
+
+  it('omits type and axes when the object scale does not set them', async () => {
+    scope.stop()
+    TrackedMockWorker.reset()
+    const objectScale = reactive<ScaleSpec>({ base: 2 })
+    scope = effectScope()
+    result = scope.run(() =>
+      useChartPipeline(
+        rawData,
+        arrangement,
+        ref(defaultLabels),
+        activeGroupId,
+        sort,
+        showLabels,
+        ref(objectScale),
+        threeD
+      )
+    )!
+    await vi.advanceTimersByTimeAsync(50)
+    worker = TrackedMockWorker.latest()
+    replyReady(1)
+
+    const computeCall = worker.postMessage.mock.calls.find((c) => c[0].type === 'compute')
+    expect(computeCall![0].scale).toEqual({ base: 2 })
+    expect(() => structuredClone(computeCall![0])).not.toThrow()
   })
 })
 

--- a/ui/src/composables/useChartPipeline.test.ts
+++ b/ui/src/composables/useChartPipeline.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { effectScope, reactive, ref, type Ref } from 'vue'
 import type { WorkerResponse, ReadyMessage, ChartMessage } from '../workers/transform.worker'
-import type { DataPoint, AxisLabels, Sort, ScaleType, ChartData, Axis } from '../types'
+import type { DataPoint, AxisLabels, Sort, ScaleType, ScaleInput, ChartData, Axis } from '../types'
 import { dp, noSort, VALUE_AXES, MIXED_AXES } from '@/test-utils'
 import { TrackedMockWorker } from '../workers/__test-utils__/workerHarness'
 
@@ -144,6 +144,106 @@ describe('useChartPipeline — setArrangement', () => {
     expect(setCall).toBeDefined()
     const initCall = worker.postMessage.mock.calls.find((c) => c[0].type === 'init')
     expect(initCall).toBeUndefined()
+  })
+})
+
+describe('useChartPipeline — object scale clone', () => {
+  it('posts a plain cloneable object scale from a Vue reactive Proxy', async () => {
+    scope.stop()
+    TrackedMockWorker.reset()
+    const objectScale = reactive<ScaleInput>({ type: 'log', axes: ['x'] })
+    const objectScaleRef = ref<ScaleInput>(objectScale)
+    // Vue reactive Proxies cannot be structured-cloned (the original bug).
+    expect(() => structuredClone(objectScaleRef.value)).toThrow()
+
+    scope = effectScope()
+    result = scope.run(() =>
+      useChartPipeline(
+        rawData,
+        arrangement,
+        ref(defaultLabels),
+        activeGroupId,
+        sort,
+        showLabels,
+        objectScaleRef,
+        threeD
+      )
+    )!
+    await vi.advanceTimersByTimeAsync(50)
+    worker = TrackedMockWorker.latest()
+    replyReady(1)
+
+    const computeCall = worker.postMessage.mock.calls.find((c) => c[0].type === 'compute')
+    expect(computeCall).toBeDefined()
+    const posted = computeCall![0] as { scale: ScaleInput }
+    expect(posted.scale).toEqual({ type: 'log', axes: ['x'] })
+    expect(Object.getPrototypeOf(posted.scale)).toBe(Object.prototype)
+    expect(Array.isArray((posted.scale as { axes?: unknown }).axes)).toBe(true)
+    expect(posted.scale).not.toBe(objectScale)
+    expect(() => structuredClone(posted)).not.toThrow()
+  })
+
+  it('copies optional log bases and still posts string scale as a string', async () => {
+    scope.stop()
+    TrackedMockWorker.reset()
+    const objectScale = reactive<ScaleInput>({
+      type: 'log',
+      axes: ['x', 'y'],
+      base: 2,
+      baseX: 4,
+      baseY: 8,
+      baseZ: 16,
+    })
+    scope = effectScope()
+    result = scope.run(() =>
+      useChartPipeline(
+        rawData,
+        arrangement,
+        ref(defaultLabels),
+        activeGroupId,
+        sort,
+        showLabels,
+        ref(objectScale),
+        threeD
+      )
+    )!
+    await vi.advanceTimersByTimeAsync(50)
+    worker = TrackedMockWorker.latest()
+    replyReady(1)
+
+    const computeCall = worker.postMessage.mock.calls.find((c) => c[0].type === 'compute')
+    const posted = computeCall![0] as { scale: ScaleInput }
+    expect(posted.scale).toEqual({
+      type: 'log',
+      axes: ['x', 'y'],
+      base: 2,
+      baseX: 4,
+      baseY: 8,
+      baseZ: 16,
+    })
+    expect(() => structuredClone(posted.scale)).not.toThrow()
+
+    scope.stop()
+    TrackedMockWorker.reset()
+    scope = effectScope()
+    result = scope.run(() =>
+      useChartPipeline(
+        rawData,
+        arrangement,
+        ref(defaultLabels),
+        activeGroupId,
+        sort,
+        showLabels,
+        ref('log' as ScaleType),
+        threeD
+      )
+    )!
+    await vi.advanceTimersByTimeAsync(50)
+    worker = TrackedMockWorker.latest()
+    replyReady(1)
+    const stringCompute = worker.postMessage.mock.calls.find((c) => c[0].type === 'compute')
+    expect(stringCompute![0].scale).toBe('log')
+    expect(() => structuredClone(stringCompute![0])).not.toThrow()
   })
 })
 

--- a/ui/src/composables/useChartPipeline.ts
+++ b/ui/src/composables/useChartPipeline.ts
@@ -1,5 +1,14 @@
 import { ref, watch, unref, toRaw, markRaw, onScopeDispose, type MaybeRef, type Ref } from 'vue'
-import type { AxisLabels, DataPoint, ChartData, Sort, ScaleInput, Axis, ChartType } from '../types'
+import type {
+  AxisLabels,
+  DataPoint,
+  ChartData,
+  Sort,
+  ScaleInput,
+  ScaleSpec,
+  Axis,
+  ChartType,
+} from '../types'
 import TransformWorker from '../workers/transform.worker.ts?worker&inline'
 import type { WorkerResponse } from '../workers/transform.worker'
 import { listChartSignatures } from '../lib/transform'
@@ -110,6 +119,22 @@ export function useChartPipeline(
   // settings store) — so spread it into a fresh object before posting.
   const currentSort = (): Sort => ({ enabled: sort.value.enabled, order: sort.value.order })
 
+  // Same for scale: string `linear`/`log` clones natively, but object scale
+  // `{ type, axes, base? }` from the reactive dataset/settings store is a Proxy.
+  // Nested `axes` stays a Proxy after toRaw, so copy it into a new array.
+  const currentScale = (): ScaleInput => {
+    const s = scale.value
+    if (typeof s !== 'object' || s == null) return s
+    const out: ScaleSpec = {}
+    if (s.type !== undefined) out.type = s.type
+    if (s.axes !== undefined) out.axes = [...s.axes]
+    if (s.base !== undefined) out.base = s.base
+    if (s.baseX !== undefined) out.baseX = s.baseX
+    if (s.baseY !== undefined) out.baseY = s.baseY
+    if (s.baseZ !== undefined) out.baseZ = s.baseZ
+    return out
+  }
+
   const pumpQueue = () => {
     if (draining) return
     const signature = queue.shift()
@@ -123,7 +148,7 @@ export function useChartPipeline(
       groupName: currentGroupName(),
       sort: currentSort(),
       showLabels: showLabels.value,
-      scale: scale.value,
+      scale: currentScale(),
       threeD: threeD.value,
     })
   }

--- a/ui/src/composables/useChartPipeline.ts
+++ b/ui/src/composables/useChartPipeline.ts
@@ -1,5 +1,5 @@
 import { ref, watch, unref, toRaw, markRaw, onScopeDispose, type MaybeRef, type Ref } from 'vue'
-import type { AxisLabels, DataPoint, ChartData, Sort, ScaleType, Axis, ChartType } from '../types'
+import type { AxisLabels, DataPoint, ChartData, Sort, ScaleInput, Axis, ChartType } from '../types'
 import TransformWorker from '../workers/transform.worker.ts?worker&inline'
 import type { WorkerResponse } from '../workers/transform.worker'
 import { listChartSignatures } from '../lib/transform'
@@ -54,7 +54,7 @@ export function useChartPipeline(
   activeGroupId: Ref<number>,
   sort: Ref<Sort>,
   showLabels: Ref<boolean>,
-  scale: Ref<ScaleType>,
+  scale: Ref<ScaleInput>,
   threeD: Ref<boolean>,
   axes?: MaybeRef<Axis[] | undefined>,
   chartType?: MaybeRef<ChartType>,

--- a/ui/src/composables/useUrlRouter.ts
+++ b/ui/src/composables/useUrlRouter.ts
@@ -274,7 +274,9 @@ export function useUrlRouter() {
       else if (cfg.showLabels === false) params[`${ct}.l`] = 'false'
       if (cfg.type === 'bar' || cfg.type === 'line' || cfg.type === 'scatter') {
         const cartesian = cfg as BarConfig | LineConfig | ScatterConfig
-        if (cartesian.scale && cartesian.scale !== 'linear') params[`${ct}.sc`] = cartesian.scale
+        if (typeof cartesian.scale === 'string' && cartesian.scale !== 'linear') {
+          params[`${ct}.sc`] = cartesian.scale
+        }
         if (cartesian.threeD === true) params[`${ct}.3d`] = 'true'
         if (cartesian.threeDRotate === true) params[`${ct}.3d-rt`] = 'true'
         if (cartesian.threeDVisualMap === true) params[`${ct}.3d-vm`] = 'true'

--- a/ui/src/lib/builders/types.ts
+++ b/ui/src/lib/builders/types.ts
@@ -3,7 +3,7 @@ import type {
   DataPoint,
   AxisLabels,
   Sort,
-  ScaleType,
+  ScaleInput,
   Stat,
   Axis,
   ChartType,
@@ -16,7 +16,7 @@ export interface BuildContext {
   labels?: AxisLabels
   sort: Sort
   showLabels: boolean
-  scale: ScaleType
+  scale: ScaleInput
   canonical?: CanonicalAxisOrders
   threeD: boolean
   preserveRows: boolean

--- a/ui/src/lib/scale.test.ts
+++ b/ui/src/lib/scale.test.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import {
-  DEFAULT_LOG_AXES,
   DEFAULT_LOG_BASE,
+  asLogXPairs,
   axisIsLog,
   axisLogBase,
   numericLogXValues,
   parseScale,
-  scaleTabValue,
   validLogBase,
 } from './scale'
 
@@ -35,9 +34,9 @@ describe('parseScale', () => {
     expect(axisIsLog(parsed, 'x', ['x'])).toBe(false)
   })
 
-  it('omitted type with axes implies log', () => {
+  it('omitted type stays linear even with axes', () => {
     const parsed = parseScale({ axes: ['x'] })
-    expect(parsed.type).toBe('log')
+    expect(parsed.type).toBe('linear')
     expect(parsed.axes).toEqual(['x'])
   })
 
@@ -67,34 +66,34 @@ describe('parseScale', () => {
 describe('axisIsLog', () => {
   it('string log uses the chart default value axis only', () => {
     const parsed = parseScale('log')
-    expect(axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.grouped2d)).toBe(true)
-    expect(axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.grouped2d)).toBe(false)
-    expect(axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.horizontalBar)).toBe(true)
-    expect(axisIsLog(parsed, 'z', DEFAULT_LOG_AXES.grouped3d)).toBe(true)
-    expect(axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.continuous3d)).toBe(true)
-    expect(axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.continuous3d)).toBe(true)
-    expect(axisIsLog(parsed, 'z', DEFAULT_LOG_AXES.continuous3d)).toBe(true)
+    expect(axisIsLog(parsed, 'y', ['y'])).toBe(true)
+    expect(axisIsLog(parsed, 'x', ['y'])).toBe(false)
+    expect(axisIsLog(parsed, 'x', ['x'])).toBe(true)
+    expect(axisIsLog(parsed, 'z', ['z'])).toBe(true)
+    expect(axisIsLog(parsed, 'x', ['x', 'y', 'z'])).toBe(true)
+    expect(axisIsLog(parsed, 'y', ['x', 'y', 'z'])).toBe(true)
+    expect(axisIsLog(parsed, 'z', ['x', 'y', 'z'])).toBe(true)
   })
 
   it('explicit axes override the default', () => {
     const parsed = parseScale({ type: 'log', axes: ['x'] })
-    expect(axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.grouped2d)).toBe(true)
-    expect(axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.grouped2d)).toBe(false)
+    expect(axisIsLog(parsed, 'x', ['y'])).toBe(true)
+    expect(axisIsLog(parsed, 'y', ['y'])).toBe(false)
   })
 
   it('explicit empty axes logs nothing', () => {
     const parsed = parseScale({ type: 'log', axes: [] })
-    expect(axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.grouped2d)).toBe(false)
+    expect(axisIsLog(parsed, 'y', ['y'])).toBe(false)
   })
 })
 
-describe('scaleTabValue / validLogBase / numericLogXValues', () => {
-  it('maps object scale to the Linear / Logarithmic tab', () => {
-    expect(scaleTabValue(undefined)).toBe('linear')
-    expect(scaleTabValue('log')).toBe('log')
-    expect(scaleTabValue({ type: 'log', axes: ['x'] })).toBe('log')
-    expect(scaleTabValue({ axes: ['x'] })).toBe('log')
-    expect(scaleTabValue({ type: 'linear' })).toBe('linear')
+describe('validLogBase / numericLogXValues / asLogXPairs', () => {
+  it('maps object scale type for the Linear / Logarithmic tab', () => {
+    expect(parseScale(undefined).type).toBe('linear')
+    expect(parseScale('log').type).toBe('log')
+    expect(parseScale({ type: 'log', axes: ['x'] }).type).toBe('log')
+    expect(parseScale({ axes: ['x'] }).type).toBe('linear')
+    expect(parseScale({ type: 'linear' }).type).toBe('linear')
   })
 
   it('rejects invalid log bases', () => {
@@ -112,5 +111,17 @@ describe('scaleTabValue / validLogBase / numericLogXValues', () => {
     expect(numericLogXValues(['-1', '2'], true)).toBeNull()
     expect(numericLogXValues(['1', '2'], false)).toBeNull()
     expect(numericLogXValues([], true)).toBeNull()
+  })
+
+  it('pairs log-X numbers with Y and nulls non-positive Y when Y is log', () => {
+    expect(asLogXPairs([1, 10], [2, 4], false)).toEqual([
+      [1, 2],
+      [10, 4],
+    ])
+    expect(asLogXPairs([1, 10], [0, 4], true)).toEqual([
+      [1, null],
+      [10, 4],
+    ])
+    expect(asLogXPairs([1], [null], true)).toEqual([[1, null]])
   })
 })

--- a/ui/src/lib/scale.test.ts
+++ b/ui/src/lib/scale.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_LOG_AXES,
+  DEFAULT_LOG_BASE,
+  axisIsLog,
+  axisLogBase,
+  numericLogXValues,
+  parseScale,
+  scaleTabValue,
+  validLogBase,
+} from './scale'
+
+describe('parseScale', () => {
+  it('treats omitted, null, and linear as linear with default base', () => {
+    expect(parseScale(undefined)).toEqual({ type: 'linear', axes: null, base: DEFAULT_LOG_BASE })
+    expect(parseScale(null)).toEqual({ type: 'linear', axes: null, base: DEFAULT_LOG_BASE })
+    expect(parseScale('linear')).toEqual({ type: 'linear', axes: null, base: DEFAULT_LOG_BASE })
+  })
+
+  it('parses the log string as log with omitted axes', () => {
+    expect(parseScale('log')).toEqual({ type: 'log', axes: null, base: DEFAULT_LOG_BASE })
+  })
+
+  it('ignores non-object non-string input', () => {
+    expect(parseScale(1 as never)).toEqual({ type: 'linear', axes: null, base: DEFAULT_LOG_BASE })
+  })
+
+  it('object type log without axes uses chart defaults later', () => {
+    expect(parseScale({ type: 'log' })).toMatchObject({ type: 'log', axes: null, base: 10 })
+  })
+
+  it('object type linear never logs even with axes', () => {
+    const parsed = parseScale({ type: 'linear', axes: ['x'] })
+    expect(parsed.type).toBe('linear')
+    expect(axisIsLog(parsed, 'x', ['x'])).toBe(false)
+  })
+
+  it('omitted type with axes implies log', () => {
+    const parsed = parseScale({ axes: ['x'] })
+    expect(parsed.type).toBe('log')
+    expect(parsed.axes).toEqual(['x'])
+  })
+
+  it('unknown type without axes is linear', () => {
+    expect(parseScale({ type: 'foo' as never })).toMatchObject({ type: 'linear' })
+  })
+
+  it('filters invalid axes and keeps explicit empty', () => {
+    expect(parseScale({ type: 'log', axes: ['q' as never, 'x', 1 as never] }).axes).toEqual(['x'])
+    expect(parseScale({ type: 'log', axes: ['q' as never] }).axes).toEqual([])
+    expect(parseScale({ type: 'log', axes: 'x' as never }).axes).toBeNull()
+  })
+
+  it('defaults invalid base to 10 and keeps per-axis overrides', () => {
+    expect(parseScale({ type: 'log', base: 0 }).base).toBe(10)
+    expect(parseScale({ type: 'log', base: 1 }).base).toBe(10)
+    expect(parseScale({ type: 'log', base: -2 }).base).toBe(10)
+    expect(parseScale({ type: 'log', base: Number.NaN }).base).toBe(10)
+    expect(parseScale({ type: 'log', base: 2 }).base).toBe(2)
+    const parsed = parseScale({ type: 'log', base: 2, baseX: 4, baseY: 1, baseZ: 8 })
+    expect(axisLogBase(parsed, 'x')).toBe(4)
+    expect(axisLogBase(parsed, 'y')).toBe(2)
+    expect(axisLogBase(parsed, 'z')).toBe(8)
+  })
+})
+
+describe('axisIsLog', () => {
+  it('string log uses the chart default value axis only', () => {
+    const parsed = parseScale('log')
+    expect(axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.grouped2d)).toBe(true)
+    expect(axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.grouped2d)).toBe(false)
+    expect(axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.horizontalBar)).toBe(true)
+    expect(axisIsLog(parsed, 'z', DEFAULT_LOG_AXES.grouped3d)).toBe(true)
+    expect(axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.continuous3d)).toBe(true)
+    expect(axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.continuous3d)).toBe(true)
+    expect(axisIsLog(parsed, 'z', DEFAULT_LOG_AXES.continuous3d)).toBe(true)
+  })
+
+  it('explicit axes override the default', () => {
+    const parsed = parseScale({ type: 'log', axes: ['x'] })
+    expect(axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.grouped2d)).toBe(true)
+    expect(axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.grouped2d)).toBe(false)
+  })
+
+  it('explicit empty axes logs nothing', () => {
+    const parsed = parseScale({ type: 'log', axes: [] })
+    expect(axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.grouped2d)).toBe(false)
+  })
+})
+
+describe('scaleTabValue / validLogBase / numericLogXValues', () => {
+  it('maps object scale to the Linear / Logarithmic tab', () => {
+    expect(scaleTabValue(undefined)).toBe('linear')
+    expect(scaleTabValue('log')).toBe('log')
+    expect(scaleTabValue({ type: 'log', axes: ['x'] })).toBe('log')
+    expect(scaleTabValue({ axes: ['x'] })).toBe('log')
+    expect(scaleTabValue({ type: 'linear' })).toBe('linear')
+  })
+
+  it('rejects invalid log bases', () => {
+    expect(validLogBase(10)).toBe(10)
+    expect(validLogBase(2)).toBe(2)
+    expect(validLogBase(0)).toBeUndefined()
+    expect(validLogBase(1)).toBeUndefined()
+    expect(validLogBase('10')).toBeUndefined()
+  })
+
+  it('coerces numeric-step labels only when x is log and every label is > 0', () => {
+    expect(numericLogXValues(['1', '2', '10'], true)).toEqual([1, 2, 10])
+    expect(numericLogXValues(['1', 'Jan'], true)).toBeNull()
+    expect(numericLogXValues(['0', '1'], true)).toBeNull()
+    expect(numericLogXValues(['-1', '2'], true)).toBeNull()
+    expect(numericLogXValues(['1', '2'], false)).toBeNull()
+    expect(numericLogXValues([], true)).toBeNull()
+  })
+})

--- a/ui/src/lib/scale.ts
+++ b/ui/src/lib/scale.ts
@@ -1,0 +1,107 @@
+import type { ScaleAxis, ScaleInput, ScaleType } from '@/types'
+
+export const DEFAULT_LOG_BASE = 10
+
+export const DEFAULT_LOG_AXES = {
+  grouped2d: ['y'] as const satisfies readonly ScaleAxis[],
+  horizontalBar: ['x'] as const satisfies readonly ScaleAxis[],
+  value2d: ['y'] as const satisfies readonly ScaleAxis[],
+  mixed2d: ['y'] as const satisfies readonly ScaleAxis[],
+  grouped3d: ['z'] as const satisfies readonly ScaleAxis[],
+  value3d: ['z'] as const satisfies readonly ScaleAxis[],
+  mixed3d: ['y', 'z'] as const satisfies readonly ScaleAxis[],
+  continuous3d: ['x', 'y', 'z'] as const satisfies readonly ScaleAxis[],
+}
+
+const SCALE_AXES: ReadonlySet<string> = new Set(['x', 'y', 'z'])
+
+export type ParsedScale = {
+  type: ScaleType
+  /** Explicit axes; `null` means omitted → use the chart's default value axis. */
+  axes: ScaleAxis[] | null
+  base: number
+  baseX?: number
+  baseY?: number
+  baseZ?: number
+}
+
+const isScaleAxis = (value: unknown): value is ScaleAxis =>
+  typeof value === 'string' && SCALE_AXES.has(value)
+
+/** ECharts logBase must be finite and not 0 or 1. */
+export function validLogBase(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined
+  if (value <= 0 || value === 1) return undefined
+  return value
+}
+
+function parseAxes(axes: unknown): ScaleAxis[] | null {
+  if (!Array.isArray(axes)) return null
+  return axes.filter(isScaleAxis)
+}
+
+/** Normalize Dataset `scale` (string or object) without applying chart defaults. */
+export function parseScale(input: ScaleInput | undefined | null): ParsedScale {
+  if (input == null || input === 'linear') {
+    return { type: 'linear', axes: null, base: DEFAULT_LOG_BASE }
+  }
+  if (input === 'log') {
+    return { type: 'log', axes: null, base: DEFAULT_LOG_BASE }
+  }
+  if (typeof input !== 'object') {
+    return { type: 'linear', axes: null, base: DEFAULT_LOG_BASE }
+  }
+
+  const axes = parseAxes(input.axes)
+  const type: ScaleType =
+    input.type === 'log' || input.type === 'linear'
+      ? input.type
+      : axes !== null && axes.length > 0
+        ? 'log'
+        : 'linear'
+
+  return {
+    type,
+    axes,
+    base: validLogBase(input.base) ?? DEFAULT_LOG_BASE,
+    baseX: validLogBase(input.baseX),
+    baseY: validLogBase(input.baseY),
+    baseZ: validLogBase(input.baseZ),
+  }
+}
+
+export function axisIsLog(
+  parsed: ParsedScale,
+  axis: ScaleAxis,
+  defaultAxes: readonly ScaleAxis[]
+): boolean {
+  if (parsed.type !== 'log') return false
+  const axes = parsed.axes ?? defaultAxes
+  return axes.includes(axis)
+}
+
+export function axisLogBase(parsed: ParsedScale, axis: ScaleAxis): number {
+  const override = axis === 'x' ? parsed.baseX : axis === 'y' ? parsed.baseY : parsed.baseZ
+  return override ?? parsed.base
+}
+
+/** Linear / Logarithmic tab value. Object scale is display-only; the toggle still writes a string. */
+export function scaleTabValue(scale: ScaleInput | undefined | null): ScaleType {
+  return parseScale(scale).type
+}
+
+/**
+ * When X is log and every category label is a finite number > 0, return those
+ * numbers so callers can coerce the category axis to a value/log axis.
+ * Non-numeric or non-positive labels: stay category (ignore X in axes).
+ */
+export function numericLogXValues(labels: string[], xLog: boolean): number[] | null {
+  if (!xLog || labels.length === 0) return null
+  const nums: number[] = []
+  for (const label of labels) {
+    const n = Number(label)
+    if (!Number.isFinite(n) || n <= 0) return null
+    nums.push(n)
+  }
+  return nums
+}

--- a/ui/src/lib/scale.ts
+++ b/ui/src/lib/scale.ts
@@ -2,17 +2,6 @@ import type { ScaleAxis, ScaleInput, ScaleType } from '@/types'
 
 export const DEFAULT_LOG_BASE = 10
 
-export const DEFAULT_LOG_AXES = {
-  grouped2d: ['y'] as const satisfies readonly ScaleAxis[],
-  horizontalBar: ['x'] as const satisfies readonly ScaleAxis[],
-  value2d: ['y'] as const satisfies readonly ScaleAxis[],
-  mixed2d: ['y'] as const satisfies readonly ScaleAxis[],
-  grouped3d: ['z'] as const satisfies readonly ScaleAxis[],
-  value3d: ['z'] as const satisfies readonly ScaleAxis[],
-  mixed3d: ['y', 'z'] as const satisfies readonly ScaleAxis[],
-  continuous3d: ['x', 'y', 'z'] as const satisfies readonly ScaleAxis[],
-}
-
 const SCALE_AXES: ReadonlySet<string> = new Set(['x', 'y', 'z'])
 
 export type ParsedScale = {
@@ -42,27 +31,13 @@ function parseAxes(axes: unknown): ScaleAxis[] | null {
 
 /** Normalize Dataset `scale` (string or object) without applying chart defaults. */
 export function parseScale(input: ScaleInput | undefined | null): ParsedScale {
-  if (input == null || input === 'linear') {
-    return { type: 'linear', axes: null, base: DEFAULT_LOG_BASE }
+  if (input == null || typeof input !== 'object') {
+    return { type: input === 'log' ? 'log' : 'linear', axes: null, base: DEFAULT_LOG_BASE }
   }
-  if (input === 'log') {
-    return { type: 'log', axes: null, base: DEFAULT_LOG_BASE }
-  }
-  if (typeof input !== 'object') {
-    return { type: 'linear', axes: null, base: DEFAULT_LOG_BASE }
-  }
-
-  const axes = parseAxes(input.axes)
-  const type: ScaleType =
-    input.type === 'log' || input.type === 'linear'
-      ? input.type
-      : axes !== null && axes.length > 0
-        ? 'log'
-        : 'linear'
 
   return {
-    type,
-    axes,
+    type: input.type === 'log' ? 'log' : 'linear',
+    axes: parseAxes(input.axes),
     base: validLogBase(input.base) ?? DEFAULT_LOG_BASE,
     baseX: validLogBase(input.baseX),
     baseY: validLogBase(input.baseY),
@@ -85,11 +60,6 @@ export function axisLogBase(parsed: ParsedScale, axis: ScaleAxis): number {
   return override ?? parsed.base
 }
 
-/** Linear / Logarithmic tab value. Object scale is display-only; the toggle still writes a string. */
-export function scaleTabValue(scale: ScaleInput | undefined | null): ScaleType {
-  return parseScale(scale).type
-}
-
 /**
  * When X is log and every category label is a finite number > 0, return those
  * numbers so callers can coerce the category axis to a value/log axis.
@@ -104,4 +74,16 @@ export function numericLogXValues(labels: string[], xLog: boolean): number[] | n
     nums.push(n)
   }
   return nums
+}
+
+/** Pair numeric log-X categories with Y, nulling non-positive Y when Y is log. */
+export function asLogXPairs(
+  xNums: number[],
+  values: (number | null)[],
+  yLog: boolean
+): [number, number | null][] {
+  return xNums.map((x, i) => {
+    const y = values[i] ?? null
+    return [x, y === null || (yLog && y <= 0) ? null : y]
+  })
 }

--- a/ui/src/lib/transform.test.ts
+++ b/ui/src/lib/transform.test.ts
@@ -802,18 +802,18 @@ describe('identity / labels / projection helpers', () => {
     expect(valuePoints3DToSeries([], 't')[0]!.data).toEqual([])
   })
 
-  it('buildValueMode3DRender log filter and showLabels', () => {
+  it('buildValueMode3DRender showLabels uses metric when present', () => {
     const render = buildValueMode3DRender(
       [
         [1, 2, 3, 9],
         [0, 2, 3],
       ],
       't',
-      true,
-      'log'
+      true
     )
-    expect(render.barSeries[0]!.data).toHaveLength(1)
+    expect(render.barSeries[0]!.data).toHaveLength(2)
     expect(render.cellTotals['0']).toBe(9)
+    expect(render.cellTotals['1']).toBe(3)
 
     const noMetric = buildValueMode3DRender([[1, 2, 3]], 't', true)
     expect(noMetric.cellTotals['0']).toBe(3)
@@ -850,7 +850,7 @@ describe('buildValueModeChart remaining branches', () => {
     expect(chart.valueTuples).toEqual([[2, 3, 4]])
   })
 
-  it('x-log keeps non-positive y and drops non-positive x', () => {
+  it('x-log keeps non-positive y; x<=0 stays in tuples for scaleValueTuples', () => {
     const chart = buildValueModeChart(
       [
         { xAxis: '0', yAxis: '5', stats: [] },
@@ -864,7 +864,10 @@ describe('buildValueModeChart remaining branches', () => {
       'xy',
       { scale: { type: 'log', axes: ['x'] } }
     )
-    expect(chart.valueTuples).toEqual([[2, 0]])
+    expect(chart.valueTuples).toEqual([
+      [0, 5],
+      [2, 0],
+    ])
   })
 
   it('threeD false keeps 2D even when target has z', () => {
@@ -1047,9 +1050,8 @@ describe('remaining transform branch edges', () => {
     ).toEqual(['A'])
   })
 
-  it('buildValueMode3DRender empty filtered withMetric and labelVal nullish', () => {
-    // all filtered out under log → filtered[0] undefined → withMetric false via ?? 0
-    const empty = buildValueMode3DRender([[0, 0, 0]], 't', true, 'log')
+  it('buildValueMode3DRender empty points and labelVal nullish', () => {
+    const empty = buildValueMode3DRender([], 't', true)
     expect(empty.barSeries[0]!.data).toEqual([])
 
     // point without metric; p[2] used; explicit undefined 4th

--- a/ui/src/lib/transform.test.ts
+++ b/ui/src/lib/transform.test.ts
@@ -681,6 +681,13 @@ describe('buildValueModeChart — 3-col swap-driven 3D', () => {
     expect(chart.valuePoints3D).toBeUndefined()
     expect(chart.render3D).toBeUndefined()
   })
+
+  it('x-only log on continuous 3D keeps non-positive y/z', () => {
+    const chart = buildValueModeChart([vdp3('1', '0', '-1')], valueAxes3, 'xyz', 'xyz', {
+      scale: { type: 'log', axes: ['x'] },
+    })
+    expect(chart.valuePoints3D).toEqual([[1, 0, -1]])
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -841,6 +848,23 @@ describe('buildValueModeChart remaining branches', () => {
       { scale: 'log' }
     )
     expect(chart.valueTuples).toEqual([[2, 3, 4]])
+  })
+
+  it('x-log keeps non-positive y and drops non-positive x', () => {
+    const chart = buildValueModeChart(
+      [
+        { xAxis: '0', yAxis: '5', stats: [] },
+        { xAxis: '2', yAxis: '0', stats: [] },
+      ],
+      [
+        { key: 'x', type: 'value' },
+        { key: 'y', type: 'value' },
+      ],
+      'xy',
+      'xy',
+      { scale: { type: 'log', axes: ['x'] } }
+    )
+    expect(chart.valueTuples).toEqual([[2, 0]])
   })
 
   it('threeD false keeps 2D even when target has z', () => {

--- a/ui/src/lib/transform.ts
+++ b/ui/src/lib/transform.ts
@@ -16,7 +16,7 @@ import type {
   Series3DData,
   ScaleInput,
 } from '../types'
-import { axisIsLog, DEFAULT_LOG_AXES, parseScale } from './scale'
+import { axisIsLog, parseScale } from './scale'
 import {
   arrangementHasChartZ,
   sourceFieldForChartAxis,
@@ -242,22 +242,13 @@ export function valuePoints3DToSeries(points: ValuePoint3D[], title: string): Se
 export function buildValueMode3DRender(
   points: ValuePoint3D[],
   title: string,
-  showLabels = false,
-  scale: ScaleInput = 'linear'
+  showLabels = false
 ): Render3D {
-  const parsed = parseScale(scale)
-  const xLog = axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.continuous3d)
-  const yLog = axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.continuous3d)
-  const zLog = axisIsLog(parsed, 'z', DEFAULT_LOG_AXES.continuous3d)
-  const filtered =
-    xLog || yLog || zLog
-      ? points.filter(([x, y, z]) => (!xLog || x > 0) && (!yLog || y > 0) && (!zLog || z > 0))
-      : points
-  const withMetric = (filtered[0]?.length ?? 0) >= 4
-  const seriesData = valuePoints3DToSeries(filtered, title)[0]!.data
+  const withMetric = (points[0]?.length ?? 0) >= 4
+  const seriesData = valuePoints3DToSeries(points, title)[0]!.data
   const cellTotals: Record<string, number> = {}
   if (showLabels) {
-    filtered.forEach((p, i) => {
+    points.forEach((p, i) => {
       const labelVal = withMetric && p[3] !== undefined ? p[3] : p[2]
       cellTotals[String(i)] = labelVal as number
     })
@@ -288,11 +279,11 @@ export function buildValueModeChart(
   const target = targetString ?? identity
   const scale = opts?.scale ?? 'linear'
   const parsed = parseScale(scale)
-  const xLog3d = axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.continuous3d)
-  const yLog3d = axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.continuous3d)
-  const zLog3d = axisIsLog(parsed, 'z', DEFAULT_LOG_AXES.continuous3d)
-  const xLog2d = axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.value2d)
-  const yLog2d = axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.value2d)
+  const xyz = ['x', 'y', 'z'] as const
+  const xLog3d = axisIsLog(parsed, 'x', xyz)
+  const yLog3d = axisIsLog(parsed, 'y', xyz)
+  const zLog3d = axisIsLog(parsed, 'z', xyz)
+  const yLog2d = axisIsLog(parsed, 'y', ['y'])
   const baseLabels = axisLabelsFromAxes(axes)
   const labels = { ...swapAxisLabels(identity, target, baseLabels)! }
   const use3D = (opts?.threeD ?? true) && arrangementHasChartZ(target)
@@ -321,7 +312,7 @@ export function buildValueModeChart(
       const cx = coords.xAxis
       const cy = coords.yAxis
       if (cx === undefined || cy === undefined) continue
-      if ((xLog2d && cx <= 0) || (yLog2d && cy <= 0)) continue
+      if (yLog2d && cy <= 0) continue
 
       let colorDim: number | undefined
       const metricRaw = row.metric
@@ -357,7 +348,7 @@ export function buildValueModeChart(
   }
 
   if (use3D && valuePoints3D.length) {
-    chart.render3D = buildValueMode3DRender(valuePoints3D, title, opts?.showLabels ?? false, scale)
+    chart.render3D = buildValueMode3DRender(valuePoints3D, title, opts?.showLabels ?? false)
   }
 
   return chart
@@ -380,8 +371,8 @@ export function buildMixedModeChart(
   const zLabel = labels.z ?? 'z'
   const use3D = mixedModeHasZ(axes)
   const parsed = parseScale(scale)
-  const yLog = axisIsLog(parsed, 'y', use3D ? DEFAULT_LOG_AXES.mixed3d : DEFAULT_LOG_AXES.mixed2d)
-  const zLog = axisIsLog(parsed, 'z', DEFAULT_LOG_AXES.mixed3d)
+  const yLog = axisIsLog(parsed, 'y', use3D ? ['y', 'z'] : ['y'])
+  const zLog = axisIsLog(parsed, 'z', ['y', 'z'])
   const title = use3D ? `${xLabel} · ${yLabel} · ${zLabel}` : `${xLabel} vs ${yLabel}`
 
   const xCategories: string[] = []
@@ -551,7 +542,7 @@ export function build3DRender(
   // A log z-axis can't plot 0/negative values. bar3D's full 0-filled grid would
   // be invalid, so under log we drop non-positive cells and make bar sparse too
   // (same intent as the 2D log path nulling values <= 0).
-  const zLog = axisIsLog(parseScale(scale), 'z', DEFAULT_LOG_AXES.grouped3d)
+  const zLog = axisIsLog(parseScale(scale), 'z', ['z'])
 
   const barSeries: Series3DData[] = []
   const lineSeries: Series3DData[] = []
@@ -644,7 +635,7 @@ export function buildValue3DRender(
     }
   }
 
-  const zLog = axisIsLog(parseScale(scale), 'z', DEFAULT_LOG_AXES.value3d)
+  const zLog = axisIsLog(parseScale(scale), 'z', ['z'])
   if (zLog) for (const [k, v] of cells) if (v <= 0) cells.delete(k)
 
   const barData = zLog ? sparseFromCells(cells) : gridFromCells(cells, xIndex, yIndex)

--- a/ui/src/lib/transform.ts
+++ b/ui/src/lib/transform.ts
@@ -14,8 +14,9 @@ import type {
   SortOrder,
   Render3D,
   Series3DData,
-  ScaleType,
+  ScaleInput,
 } from '../types'
+import { axisIsLog, DEFAULT_LOG_AXES, parseScale } from './scale'
 import {
   arrangementHasChartZ,
   sourceFieldForChartAxis,
@@ -153,7 +154,7 @@ export function buildChartForSignature(
   labels: AxisLabels | undefined,
   sort: Sort,
   showLabels = false,
-  scale: ScaleType = 'linear',
+  scale: ScaleInput = 'linear',
   canonical?: CanonicalAxisOrders,
   threeD = false,
   preserveRows = false
@@ -242,9 +243,16 @@ export function buildValueMode3DRender(
   points: ValuePoint3D[],
   title: string,
   showLabels = false,
-  scale: ScaleType = 'linear'
+  scale: ScaleInput = 'linear'
 ): Render3D {
-  const filtered = scale === 'log' ? points.filter(([x, y, z]) => x > 0 && y > 0 && z > 0) : points
+  const parsed = parseScale(scale)
+  const xLog = axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.continuous3d)
+  const yLog = axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.continuous3d)
+  const zLog = axisIsLog(parsed, 'z', DEFAULT_LOG_AXES.continuous3d)
+  const filtered =
+    xLog || yLog || zLog
+      ? points.filter(([x, y, z]) => (!xLog || x > 0) && (!yLog || y > 0) && (!zLog || z > 0))
+      : points
   const withMetric = (filtered[0]?.length ?? 0) >= 4
   const seriesData = valuePoints3DToSeries(filtered, title)[0]!.data
   const cellTotals: Record<string, number> = {}
@@ -274,11 +282,17 @@ export function buildValueModeChart(
   axes: Axis[],
   identityString?: string,
   targetString?: string,
-  opts?: { scale?: ScaleType; showLabels?: boolean; threeD?: boolean }
+  opts?: { scale?: ScaleInput; showLabels?: boolean; threeD?: boolean }
 ): ChartData {
   const identity = identityString ?? identityStringFromAxes(axes)
   const target = targetString ?? identity
   const scale = opts?.scale ?? 'linear'
+  const parsed = parseScale(scale)
+  const xLog3d = axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.continuous3d)
+  const yLog3d = axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.continuous3d)
+  const zLog3d = axisIsLog(parsed, 'z', DEFAULT_LOG_AXES.continuous3d)
+  const xLog2d = axisIsLog(parsed, 'x', DEFAULT_LOG_AXES.value2d)
+  const yLog2d = axisIsLog(parsed, 'y', DEFAULT_LOG_AXES.value2d)
   const baseLabels = axisLabelsFromAxes(axes)
   const labels = { ...swapAxisLabels(identity, target, baseLabels)! }
   const use3D = (opts?.threeD ?? true) && arrangementHasChartZ(target)
@@ -295,7 +309,7 @@ export function buildValueModeChart(
       const cy = coords.yAxis
       const cz = coords.zAxis
       if (cx === undefined || cy === undefined || cz === undefined) continue
-      if (scale === 'log' && (cx <= 0 || cy <= 0 || cz <= 0)) continue
+      if ((xLog3d && cx <= 0) || (yLog3d && cy <= 0) || (zLog3d && cz <= 0)) continue
       const metricRaw = row.metric
       const metricNum = metricRaw !== undefined && metricRaw !== '' ? Number(metricRaw) : undefined
       if (metricNum !== undefined && isFinite(metricNum)) {
@@ -307,7 +321,7 @@ export function buildValueModeChart(
       const cx = coords.xAxis
       const cy = coords.yAxis
       if (cx === undefined || cy === undefined) continue
-      if (scale === 'log' && cy <= 0) continue
+      if ((xLog2d && cx <= 0) || (yLog2d && cy <= 0)) continue
 
       let colorDim: number | undefined
       const metricRaw = row.metric
@@ -357,7 +371,7 @@ export const mixedModeHasZ = (axes: Axis[]): boolean =>
 export function buildMixedModeChart(
   data: DataPoint[],
   axes: Axis[],
-  opts?: { scale?: ScaleType; showLabels?: boolean }
+  opts?: { scale?: ScaleInput; showLabels?: boolean }
 ): ChartData {
   const scale = opts?.scale ?? 'linear'
   const labels = axisLabelsFromAxes(axes)
@@ -365,6 +379,9 @@ export function buildMixedModeChart(
   const yLabel = labels.y ?? 'y'
   const zLabel = labels.z ?? 'z'
   const use3D = mixedModeHasZ(axes)
+  const parsed = parseScale(scale)
+  const yLog = axisIsLog(parsed, 'y', use3D ? DEFAULT_LOG_AXES.mixed3d : DEFAULT_LOG_AXES.mixed2d)
+  const zLog = axisIsLog(parsed, 'z', DEFAULT_LOG_AXES.mixed3d)
   const title = use3D ? `${xLabel} · ${yLabel} · ${zLabel}` : `${xLabel} vs ${yLabel}`
 
   const xCategories: string[] = []
@@ -388,10 +405,10 @@ export function buildMixedModeChart(
     if (use3D) {
       const z = Number(row.zAxis)
       if (!isFinite(z)) continue
-      if (scale === 'log' && (y <= 0 || z <= 0)) continue
+      if ((yLog && y <= 0) || (zLog && z <= 0)) continue
       points3D.push({ value: [xi, y, z] })
     } else {
-      if (scale === 'log' && y <= 0) continue
+      if (yLog && y <= 0) continue
       mixedTuples.push([xi, y])
     }
   }
@@ -508,7 +525,7 @@ export function build3DRender(
   zAxisAll: string[],
   sort: Sort,
   showLabels = false,
-  scale: ScaleType = 'linear',
+  scale: ScaleInput = 'linear',
   canonical?: CanonicalAxisOrders,
   preserveRows = false
 ): Render3D {
@@ -534,24 +551,24 @@ export function build3DRender(
   // A log z-axis can't plot 0/negative values. bar3D's full 0-filled grid would
   // be invalid, so under log we drop non-positive cells and make bar sparse too
   // (same intent as the 2D log path nulling values <= 0).
-  const isLog = scale === 'log'
+  const zLog = axisIsLog(parseScale(scale), 'z', DEFAULT_LOG_AXES.grouped3d)
 
   const barSeries: Series3DData[] = []
   const lineSeries: Series3DData[] = []
   for (const z of zValues) {
     if (preserveRows) {
       const sparse = sparseFromPoints(points, z, xIndex, yIndex)
-      const filtered = isLog ? sparse.filter((d) => (d.value[2] as number) > 0) : sparse
+      const filtered = zLog ? sparse.filter((d) => (d.value[2] as number) > 0) : sparse
       barSeries.push({ name: z, data: filtered })
       lineSeries.push({ name: z, data: filtered })
       continue
     }
 
     const cells = cellsFor(points, z, xIndex, yIndex)
-    if (isLog) for (const [k, v] of cells) if (v <= 0) cells.delete(k)
+    if (zLog) for (const [k, v] of cells) if (v <= 0) cells.delete(k)
     barSeries.push({
       name: z,
-      data: isLog ? sparseFromCells(cells) : gridFromCells(cells, xIndex, yIndex),
+      data: zLog ? sparseFromCells(cells) : gridFromCells(cells, xIndex, yIndex),
     })
     lineSeries.push({ name: z, data: sparseFromCells(cells) })
   }
@@ -592,7 +609,7 @@ export function buildValue3DRender(
   chart: ChartData,
   sort: Sort,
   showLabels = false,
-  scale: ScaleType = 'linear',
+  scale: ScaleInput = 'linear',
   canonical?: CanonicalAxisOrders
 ): Render3D {
   let xValues = chart.series.map((s) => s.xAxis).filter((x) => x.trim() !== '')
@@ -627,10 +644,10 @@ export function buildValue3DRender(
     }
   }
 
-  const isLog = scale === 'log'
-  if (isLog) for (const [k, v] of cells) if (v <= 0) cells.delete(k)
+  const zLog = axisIsLog(parseScale(scale), 'z', DEFAULT_LOG_AXES.value3d)
+  if (zLog) for (const [k, v] of cells) if (v <= 0) cells.delete(k)
 
-  const barData = isLog ? sparseFromCells(cells) : gridFromCells(cells, xIndex, yIndex)
+  const barData = zLog ? sparseFromCells(cells) : gridFromCells(cells, xIndex, yIndex)
   const lineData = sparseFromCells(cells)
   const seriesName = chart.title
 

--- a/ui/src/test-utils/chartFixtures.ts
+++ b/ui/src/test-utils/chartFixtures.ts
@@ -74,6 +74,38 @@ export function makeValueChartData(overrides: ChartDataOverrides = {}): ChartDat
   })
 }
 
+export function makeNumericStepChartData(
+  yAxis: string[] = ['train', 'val'],
+  points: [string, number[]][] = [
+    ['1', [10, 8]],
+    ['2', [0, 9]],
+    ['4', [12, 6]],
+  ]
+): ChartData {
+  return emptyChartData({
+    title: 'loss vs step',
+    statType: 'grouped',
+    yAxis,
+    series: points.map(([xAxis, values]) => ({ xAxis, values, benchmarkId: xAxis })),
+    axisLabels: { x: 'step', y: 'split' },
+  })
+}
+
+export function makeNumericStepConfig(
+  scale: ScaleInput,
+  data: ChartData = makeNumericStepChartData()
+): BaseChartConfig {
+  return {
+    chartData: ref(data),
+    sort: ref({ enabled: false, order: 'asc' as const }),
+    showLabels: ref(false),
+    isDark: ref(false),
+    scale: ref(scale),
+    smooth: ref(false),
+    stack: ref(false),
+  }
+}
+
 export function makePieChartData(overrides: ChartDataOverrides = {}): ChartData {
   return emptyChartData({
     title: 'share',

--- a/ui/src/test-utils/chartFixtures.ts
+++ b/ui/src/test-utils/chartFixtures.ts
@@ -1,5 +1,5 @@
 import { ref, type Ref } from 'vue'
-import type { ChartData, ChartType, Render3D, ScaleType, Sort } from '@/types'
+import type { ChartData, ChartType, Render3D, ScaleInput, ScaleType, Sort } from '@/types'
 import type { BaseChartConfig } from '@/composables/charts/baseChartOptions'
 
 const noSort: Sort = { enabled: false, order: 'asc' }
@@ -165,7 +165,7 @@ export type BaseConfigOverrides = {
   sort?: Sort | Ref<Sort>
   showLabels?: boolean | Ref<boolean>
   isDark?: boolean | Ref<boolean>
-  scale?: ScaleType | Ref<ScaleType>
+  scale?: ScaleInput | Ref<ScaleInput>
   stack?: boolean | Ref<boolean>
   threeDRotate?: boolean | Ref<boolean>
   threeD?: boolean | Ref<boolean>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -44,6 +44,20 @@ export const ALL_CHART_TYPES: ChartType[] = [
 export type ScaleType = 'linear' | 'log'
 export const SCALE_TYPES: ScaleType[] = ['linear', 'log']
 
+export type ScaleAxis = 'x' | 'y' | 'z'
+
+/** Dataset JSON `scale` object (hand-written or future CLI). */
+export type ScaleSpec = {
+  type?: ScaleType
+  axes?: ScaleAxis[]
+  base?: number
+  baseX?: number
+  baseY?: number
+  baseZ?: number
+}
+
+export type ScaleInput = ScaleType | ScaleSpec
+
 export type Stat = {
   type: string
   value?: number
@@ -102,7 +116,7 @@ export type BarConfig = {
   type: 'bar'
   swap?: string
   sort?: Sort
-  scale?: ScaleType
+  scale?: ScaleInput
   stack?: boolean
   showLabels?: boolean
   horizontal?: boolean
@@ -120,7 +134,7 @@ export type LineConfig = {
   type: 'line'
   swap?: string
   sort?: Sort
-  scale?: ScaleType
+  scale?: ScaleInput
   stack?: boolean
   showLabels?: boolean
   symbol?: string
@@ -136,7 +150,7 @@ export type ScatterConfig = {
   type: 'scatter'
   swap?: string
   sort?: Sort
-  scale?: ScaleType
+  scale?: ScaleInput
   showLabels?: boolean
   symbol?: string
   symbolSize?: number

--- a/ui/src/workers/transform.worker.ts
+++ b/ui/src/workers/transform.worker.ts
@@ -34,7 +34,7 @@ import {
 } from '../lib/transform'
 import { isValueChartType, isValueMode, isMixedMode } from '../lib/utils'
 import { translateAxisKey } from '../lib/swap'
-import type { DataPoint, AxisLabels, Sort, ChartData, ScaleType, Axis, ChartType } from '../types'
+import type { DataPoint, AxisLabels, Sort, ChartData, ScaleInput, Axis, ChartType } from '../types'
 
 export type InitMessage = {
   type: 'init'
@@ -61,7 +61,7 @@ export type ComputeMessage = {
   groupName: string
   sort: Sort
   showLabels: boolean
-  scale: ScaleType
+  scale: ScaleInput
   threeD: boolean
 }
 export type WorkerRequest = InitMessage | SetArrangementMessage | ComputeMessage


### PR DESCRIPTION
## Summary
- Chart UI reads string or object `scale` and applies ECharts `type: 'log'` + `logBase` per axis.
- Numeric category labels coerce X to a value/log axis; non-numeric labels stay category.
- Value-X tooltips: 1 series → cross; 2+ series → axis + snap, not cross.
- ScaleControl is still Linear / Logarithmic only (hover is #416).

Closes #415
Relates to #412

## Test Plan
- [x] `pnpm exec vitest run src/lib/scale.test.ts src/composables/charts/useLineChartOptions.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added independent logarithmic scaling for X, Y, and Z axes, including configurable log bases.
  * Improved handling of numeric values, missing data, and non-positive values on log-scaled axes.
  * Enhanced 2D and 3D chart tooltips, legends, zooming, and axis layouts.
  * Improved mixed, bar, line, category, and value chart behavior with log scales.

* **Bug Fixes**
  * Corrected chart totals, tooltip values, and data mapping for paired X/Y data.
  * Improved fallback behavior when logarithmic scaling cannot be applied.

* **Tests**
  * Expanded automated coverage across chart types, scaling, layouts, tooltips, and 3D axes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->