### PR TITLE
feat(api): accept per-axis scale object on REST

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -684,6 +684,28 @@ components:
       properties:
         enabled: { type: boolean }
         order: { type: string, enum: [asc, desc] }
+    # LogBase is > 0 and not 1 (logarithm base). exclusiveMinimum: 0 is not
+    # enough on its own because 1 is still valid.
+    LogBase:
+      type: number
+      exclusiveMinimum: 0
+      not: { const: 1 }
+    Scale:
+      oneOf:
+        - type: string
+          enum: [linear, log]
+        - type: object
+          additionalProperties: false
+          required: [type]
+          properties:
+            type: { type: string, enum: [linear, log] }
+            axes:
+              type: array
+              items: { type: string, enum: [x, y, z] }
+            base: { $ref: '#/components/schemas/LogBase' }
+            baseX: { $ref: '#/components/schemas/LogBase' }
+            baseY: { $ref: '#/components/schemas/LogBase' }
+            baseZ: { $ref: '#/components/schemas/LogBase' }
     StatisticsConfig:
       type: object
       additionalProperties: false
@@ -724,7 +746,7 @@ components:
         type: { const: bar }
         swap: { type: string }
         sort: { $ref: '#/components/schemas/Sort' }
-        scale: { type: string, enum: [linear, log] }
+        scale: { $ref: '#/components/schemas/Scale' }
         stack: { type: boolean }
         showLabels: { type: boolean }
         borderRadius:
@@ -763,7 +785,7 @@ components:
         type: { const: line }
         swap: { type: string }
         sort: { $ref: '#/components/schemas/Sort' }
-        scale: { type: string, enum: [linear, log] }
+        scale: { $ref: '#/components/schemas/Scale' }
         stack: { type: boolean }
         showLabels: { type: boolean }
         symbol:
@@ -782,7 +804,7 @@ components:
         type: { const: scatter }
         swap: { type: string }
         sort: { $ref: '#/components/schemas/Sort' }
-        scale: { type: string, enum: [linear, log] }
+        scale: { $ref: '#/components/schemas/Scale' }
         showLabels: { type: boolean }
         symbol:
           $ref: '#/components/schemas/SeriesSymbol'

--- a/api/openapi_test.go
+++ b/api/openapi_test.go
@@ -624,9 +624,6 @@ func validateNumericBounds(schema map[string]any, value any, location string) er
 	if max, ok := numericValue(schema["maximum"]); ok && number > max {
 		return fmt.Errorf("%s = %v is greater than maximum %v", location, number, max)
 	}
-	if exclMax, ok := numericValue(schema["exclusiveMaximum"]); ok && number >= exclMax {
-		return fmt.Errorf("%s = %v is not less than exclusiveMaximum %v", location, number, exclMax)
-	}
 	return nil
 }
 

--- a/api/openapi_test.go
+++ b/api/openapi_test.go
@@ -204,6 +204,59 @@ func (s *OpenAPISuite) TestUIContractRejectsRemoteInputAndReturnsHTML() {
 	s.NotNil(successContent["text/html"])
 }
 
+// TestScaleSchemaAcceptsStringAndObject covers the hybrid Scale wire: a
+// linear|log string or a per-axis object. base=1, unknown keys, and unknown
+// axes must fail schema validation (exclusiveMinimum: 0 is not enough).
+func (s *OpenAPISuite) TestScaleSchemaAcceptsStringAndObject() {
+	contract := readContract(s.T())
+	schemas := mustMap(s.T(), mustMap(s.T(), contract["components"], "components")["schemas"], "components.schemas")
+	scaleSchema := schemas["Scale"]
+	s.Require().NotNil(scaleSchema, "components.schemas.Scale")
+
+	valid := []any{
+		"linear",
+		"log",
+		map[string]any{"type": "linear"},
+		map[string]any{"type": "log", "axes": []any{"x"}},
+		map[string]any{"type": "log", "axes": []any{"x", "y", "z"}, "base": 10, "baseX": 2, "baseY": 5, "baseZ": 8},
+	}
+	for _, value := range valid {
+		s.NoError(validateSchema(contract, scaleSchema, value, "Scale"), fmt.Sprint(value))
+	}
+
+	invalid := []any{
+		"square",
+		true,
+		1,
+		map[string]any{"axes": []any{"x"}},
+		map[string]any{"type": "log", "base": 1},
+		map[string]any{"type": "log", "baseX": 1},
+		map[string]any{"type": "log", "baseY": 1},
+		map[string]any{"type": "log", "baseZ": 1},
+		map[string]any{"type": "log", "base": 0},
+		map[string]any{"type": "log", "base": -2},
+		map[string]any{"type": "log", "foo": 1},
+		map[string]any{"type": "log", "axes": []any{"q"}},
+		map[string]any{"type": "log", "axes": "x"},
+		map[string]any{"type": "log", "base": "10"},
+	}
+	for _, value := range invalid {
+		s.Error(validateSchema(contract, scaleSchema, value, "Scale"), fmt.Sprint(value))
+	}
+
+	for _, schemaName := range []string{"BarChartConfig", "LineChartConfig", "ScatterChartConfig"} {
+		s.Run(schemaName, func() {
+			schema := schemas[schemaName]
+			chartType := strings.TrimSuffix(strings.ToLower(schemaName), "chartconfig")
+			s.NoError(validateSchema(contract, schema, map[string]any{"type": chartType, "scale": "log"}, schemaName))
+			s.NoError(validateSchema(contract, schema, map[string]any{"type": chartType, "scale": map[string]any{"type": "log", "axes": []any{"x"}}}, schemaName))
+			s.Error(validateSchema(contract, schema, map[string]any{"type": chartType, "scale": map[string]any{"type": "log", "base": 1}}, schemaName))
+			s.Error(validateSchema(contract, schema, map[string]any{"type": chartType, "scale": map[string]any{"type": "log", "foo": 1}}, schemaName))
+			s.Error(validateSchema(contract, schema, map[string]any{"type": chartType, "scale": map[string]any{"type": "log", "axes": []any{"q"}}}, schemaName))
+		})
+	}
+}
+
 func (s *OpenAPISuite) TestLineAndScatterSymbolsMatchServerValidation() {
 	contract := readContract(s.T())
 	schemas := mustMap(s.T(), mustMap(s.T(), contract["components"], "components")["schemas"], "components.schemas")
@@ -409,7 +462,7 @@ func validateSchema(root map[string]any, rawSchema, value any, location string) 
 		return err
 	}
 	schema := mustMapValue(dereferenced, location+" schema")
-	if constant, exists := schema["const"]; exists && !reflect.DeepEqual(constant, value) {
+	if constant, exists := schema["const"]; exists && !jsonValuesEqual(constant, value) {
 		return fmt.Errorf("%s = %#v, want constant %#v", location, value, constant)
 	}
 	if enum, exists := schema["enum"]; exists {
@@ -547,6 +600,11 @@ func validateSchema(root map[string]any, rawSchema, value any, location string) 
 			return err
 		}
 	}
+	if notSchema, exists := schema["not"]; exists {
+		if err := validateSchema(root, notSchema, value, location); err == nil {
+			return fmt.Errorf("%s matches not schema", location)
+		}
+	}
 	return nil
 }
 
@@ -560,10 +618,27 @@ func validateNumericBounds(schema map[string]any, value any, location string) er
 	if min, ok := numericValue(schema["minimum"]); ok && number < min {
 		return fmt.Errorf("%s = %v is less than minimum %v", location, number, min)
 	}
+	if exclMin, ok := numericValue(schema["exclusiveMinimum"]); ok && number <= exclMin {
+		return fmt.Errorf("%s = %v is not greater than exclusiveMinimum %v", location, number, exclMin)
+	}
 	if max, ok := numericValue(schema["maximum"]); ok && number > max {
 		return fmt.Errorf("%s = %v is greater than maximum %v", location, number, max)
 	}
+	if exclMax, ok := numericValue(schema["exclusiveMaximum"]); ok && number >= exclMax {
+		return fmt.Errorf("%s = %v is not less than exclusiveMaximum %v", location, number, exclMax)
+	}
 	return nil
+}
+
+// jsonValuesEqual is DeepEqual plus numeric equality so YAML ints and JSON
+// float64s compare as the same JSON number (needed for not: { const: 1 }).
+func jsonValuesEqual(a, b any) bool {
+	if reflect.DeepEqual(a, b) {
+		return true
+	}
+	an, aok := numericValue(a)
+	bn, bok := numericValue(b)
+	return aok && bok && an == bn
 }
 
 func numericValue(value any) (float64, bool) {

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -797,83 +797,54 @@ func validateChartConfigValues(raw json.RawMessage, path string) *apiValidationE
 	return nil
 }
 
-// validateScaleValue accepts the REST Scale wire: "linear"|"log" or an object
-// {type, axes?, base?, baseX?, baseY?, baseZ?}. Unknown keys, unknown axes,
-// and log bases of 1 or <= 0 are request errors (CLI bag parse warns-and-defaults).
+// validateScaleValue accepts the REST Scale wire: "linear"|"log" or an object.
+// shared.Scale.UnmarshalJSON already rejects unknown keys and bad types; REST
+// still requires type and rejects unknown axes and log bases of 1 or <= 0
+// (CLI bag parse warns-and-defaults).
 func validateScaleValue(raw json.RawMessage, path string) *apiValidationError {
+	var scale shared.Scale
+	if err := json.Unmarshal(raw, &scale); err != nil {
+		validationErr := bodyValidationError(path, "invalid_json", err.Error())
+		return &validationErr
+	}
+
 	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) > 0 && trimmed[0] == '"' {
-		var scale string
-		if err := json.Unmarshal(raw, &scale); err != nil || (scale != "linear" && scale != "log") {
-			validationErr := bodyValidationError(path, "invalid_enum", "scale must be linear or log")
-			return &validationErr
-		}
+	if len(trimmed) == 0 || trimmed[0] != '{' {
 		return nil
 	}
+
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &fields); err != nil {
 		validationErr := bodyValidationError(path, "invalid_type", "scale must be a string or object")
 		return &validationErr
 	}
-	if validationErr := rejectNullObjectValues(fields, path); validationErr != nil {
-		return validationErr
-	}
-
-	allowed := map[string]struct{}{
-		"type": {}, "axes": {}, "base": {}, "baseX": {}, "baseY": {}, "baseZ": {},
-	}
-	keys := make([]string, 0, len(fields))
-	for key := range fields {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	for _, key := range keys {
-		if _, ok := allowed[key]; !ok {
-			validationErr := bodyValidationError(path+"/"+key, "unknown_field", "unknown request field "+key)
-			return &validationErr
-		}
-	}
-
-	typeRaw, ok := fields["type"]
-	if !ok {
+	if _, ok := fields["type"]; !ok {
 		validationErr := bodyValidationError(path+"/type", "required", "scale.type is required")
 		return &validationErr
 	}
-	var scaleType string
-	if err := json.Unmarshal(typeRaw, &scaleType); err != nil || (scaleType != "linear" && scaleType != "log") {
-		validationErr := bodyValidationError(path+"/type", "invalid_enum", "scale.type must be linear or log")
-		return &validationErr
+	if validationErr := validateScaleAxes(scale.Axes, path+"/axes"); validationErr != nil {
+		return validationErr
 	}
-
-	if axesRaw, ok := fields["axes"]; ok {
-		if validationErr := validateScaleAxes(axesRaw, path+"/axes"); validationErr != nil {
+	for _, item := range []struct {
+		key   string
+		value *float64
+	}{
+		{"base", scale.Base},
+		{"baseX", scale.BaseX},
+		{"baseY", scale.BaseY},
+		{"baseZ", scale.BaseZ},
+	} {
+		if validationErr := validateLogBase(item.value, path+"/"+item.key); validationErr != nil {
 			return validationErr
-		}
-	}
-	for _, key := range []string{"base", "baseX", "baseY", "baseZ"} {
-		if baseRaw, ok := fields[key]; ok {
-			if validationErr := validateLogBase(baseRaw, path+"/"+key); validationErr != nil {
-				return validationErr
-			}
 		}
 	}
 	return nil
 }
 
-func validateScaleAxes(raw json.RawMessage, path string) *apiValidationError {
-	var items []json.RawMessage
-	if err := json.Unmarshal(raw, &items); err != nil {
-		validationErr := bodyValidationError(path, "invalid_type", "scale.axes must be an array of axis names")
-		return &validationErr
-	}
-	for i, item := range items {
-		var axis string
-		itemPath := fmt.Sprintf("%s/%d", path, i)
-		if err := json.Unmarshal(item, &axis); err != nil {
-			validationErr := bodyValidationError(itemPath, "invalid_type", "scale.axes items must be strings")
-			return &validationErr
-		}
+func validateScaleAxes(axes []string, path string) *apiValidationError {
+	for i, axis := range axes {
 		if axis != "x" && axis != "y" && axis != "z" {
+			itemPath := fmt.Sprintf("%s/%d", path, i)
 			validationErr := bodyValidationError(itemPath, "invalid_enum", "scale.axes items must be x, y, or z")
 			return &validationErr
 		}
@@ -881,22 +852,15 @@ func validateScaleAxes(raw json.RawMessage, path string) *apiValidationError {
 	return nil
 }
 
-func validateLogBase(raw json.RawMessage, path string) *apiValidationError {
-	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 || trimmed[0] == '"' {
-		validationErr := bodyValidationError(path, "invalid_type", path+" must be a number")
-		return &validationErr
+func validateLogBase(n *float64, path string) *apiValidationError {
+	if n == nil {
+		return nil
 	}
-	var n float64
-	if err := json.Unmarshal(raw, &n); err != nil {
-		validationErr := bodyValidationError(path, "invalid_type", path+" must be a number")
-		return &validationErr
-	}
-	if n <= 0 {
+	if *n <= 0 {
 		validationErr := bodyValidationError(path, "exclusive_minimum", path+" must be greater than 0")
 		return &validationErr
 	}
-	if n == 1 {
+	if *n == 1 {
 		validationErr := bodyValidationError(path, "invalid_value", path+" must not be 1")
 		return &validationErr
 	}

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -814,10 +814,8 @@ func validateScaleValue(raw json.RawMessage, path string) *apiValidationError {
 	}
 
 	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &fields); err != nil {
-		validationErr := bodyValidationError(path, "invalid_type", "scale must be a string or object")
-		return &validationErr
-	}
+	// Scale.UnmarshalJSON already accepted this as an object.
+	_ = json.Unmarshal(raw, &fields)
 	if _, ok := fields["type"]; !ok {
 		validationErr := bodyValidationError(path+"/type", "required", "scale.type is required")
 		return &validationErr

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -722,10 +722,8 @@ func validateChartConfigValues(raw json.RawMessage, path string) *apiValidationE
 		return validationErr
 	}
 	if scaleRaw, ok := values["scale"]; ok {
-		var scale string
-		if err := json.Unmarshal(scaleRaw, &scale); err != nil || (scale != "linear" && scale != "log") {
-			validationErr := bodyValidationError(path+"/scale", "invalid_enum", "scale must be linear or log")
-			return &validationErr
+		if validationErr := validateScaleValue(scaleRaw, path+"/scale"); validationErr != nil {
+			return validationErr
 		}
 	}
 	if symbolRaw, ok := values["symbol"]; ok {
@@ -795,6 +793,112 @@ func validateChartConfigValues(raw json.RawMessage, path string) *apiValidationE
 		if validationErr := validateStatMath(stat.Math, path+"/stat/math"); validationErr != nil {
 			return validationErr
 		}
+	}
+	return nil
+}
+
+// validateScaleValue accepts the REST Scale wire: "linear"|"log" or an object
+// {type, axes?, base?, baseX?, baseY?, baseZ?}. Unknown keys, unknown axes,
+// and log bases of 1 or <= 0 are request errors (CLI bag parse warns-and-defaults).
+func validateScaleValue(raw json.RawMessage, path string) *apiValidationError {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) > 0 && trimmed[0] == '"' {
+		var scale string
+		if err := json.Unmarshal(raw, &scale); err != nil || (scale != "linear" && scale != "log") {
+			validationErr := bodyValidationError(path, "invalid_enum", "scale must be linear or log")
+			return &validationErr
+		}
+		return nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		validationErr := bodyValidationError(path, "invalid_type", "scale must be a string or object")
+		return &validationErr
+	}
+	if validationErr := rejectNullObjectValues(fields, path); validationErr != nil {
+		return validationErr
+	}
+
+	allowed := map[string]struct{}{
+		"type": {}, "axes": {}, "base": {}, "baseX": {}, "baseY": {}, "baseZ": {},
+	}
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if _, ok := allowed[key]; !ok {
+			validationErr := bodyValidationError(path+"/"+key, "unknown_field", "unknown request field "+key)
+			return &validationErr
+		}
+	}
+
+	typeRaw, ok := fields["type"]
+	if !ok {
+		validationErr := bodyValidationError(path+"/type", "required", "scale.type is required")
+		return &validationErr
+	}
+	var scaleType string
+	if err := json.Unmarshal(typeRaw, &scaleType); err != nil || (scaleType != "linear" && scaleType != "log") {
+		validationErr := bodyValidationError(path+"/type", "invalid_enum", "scale.type must be linear or log")
+		return &validationErr
+	}
+
+	if axesRaw, ok := fields["axes"]; ok {
+		if validationErr := validateScaleAxes(axesRaw, path+"/axes"); validationErr != nil {
+			return validationErr
+		}
+	}
+	for _, key := range []string{"base", "baseX", "baseY", "baseZ"} {
+		if baseRaw, ok := fields[key]; ok {
+			if validationErr := validateLogBase(baseRaw, path+"/"+key); validationErr != nil {
+				return validationErr
+			}
+		}
+	}
+	return nil
+}
+
+func validateScaleAxes(raw json.RawMessage, path string) *apiValidationError {
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		validationErr := bodyValidationError(path, "invalid_type", "scale.axes must be an array of axis names")
+		return &validationErr
+	}
+	for i, item := range items {
+		var axis string
+		itemPath := fmt.Sprintf("%s/%d", path, i)
+		if err := json.Unmarshal(item, &axis); err != nil {
+			validationErr := bodyValidationError(itemPath, "invalid_type", "scale.axes items must be strings")
+			return &validationErr
+		}
+		if axis != "x" && axis != "y" && axis != "z" {
+			validationErr := bodyValidationError(itemPath, "invalid_enum", "scale.axes items must be x, y, or z")
+			return &validationErr
+		}
+	}
+	return nil
+}
+
+func validateLogBase(raw json.RawMessage, path string) *apiValidationError {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] == '"' {
+		validationErr := bodyValidationError(path, "invalid_type", path+" must be a number")
+		return &validationErr
+	}
+	var n float64
+	if err := json.Unmarshal(raw, &n); err != nil {
+		validationErr := bodyValidationError(path, "invalid_type", path+" must be a number")
+		return &validationErr
+	}
+	if n <= 0 {
+		validationErr := bodyValidationError(path, "exclusive_minimum", path+" must be greater than 0")
+		return &validationErr
+	}
+	if n == 1 {
+		validationErr := bodyValidationError(path, "invalid_value", path+" must not be 1")
+		return &validationErr
 	}
 	return nil
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1667,6 +1667,24 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 
 		s.Nil(validateChartConfigValues(json.RawMessage(`{"scale":"log"}`), "/config"))
 		s.Nil(validateChartConfigValues(json.RawMessage(`{"scale":{"type":"log","axes":["x"]}}`), "/config"))
+		s.Nil(validateChartConfigValues(json.RawMessage(`{"scale":{"type":"log","base":2}}`), "/config"))
+
+		for _, test := range []struct {
+			name string
+			raw  string
+			path string
+			code string
+		}{
+			{name: "scale missing type", raw: `{"scale":{}}`, path: "/config/scale/type", code: "required"},
+			{name: "scale base 0", raw: `{"scale":{"type":"log","base":0}}`, path: "/config/scale/base", code: "exclusive_minimum"},
+		} {
+			s.Run(test.name, func() {
+				err := validateChartConfigValues(json.RawMessage(test.raw), "/config")
+				s.Require().NotNil(err, test.raw)
+				s.Equal(test.path, err.Path)
+				s.Equal(test.code, err.Code)
+			})
+		}
 
 		for _, raw := range []string{
 			`{`,

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -677,6 +677,10 @@ func (s *ServeSuite) TestConvertEndpointValidatesStructuredOptions() {
 		{name: "unselected config", body: `{"input":"x,y\na,1\n","charts":{"types":["bar"],"configs":[{"type":"line"}]}}`},
 		{name: "unknown config field", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","bogus":true}]}}`},
 		{name: "invalid scale", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","scale":"square"}]}}`},
+		{name: "scale unknown key", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","scale":{"type":"log","foo":1}}]}}`},
+		{name: "scale unknown axis", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","scale":{"type":"log","axes":["q"]}}]}}`},
+		{name: "scale base 1", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","scale":{"type":"log","base":1}}]}}`},
+		{name: "scale wrong type", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","scale":true}]}}`},
 		{name: "invalid symbol size", body: `{"input":"x,y\na,1\n","charts":{"types":["line"],"configs":[{"type":"line","symbolSize":0}]}}`},
 		{name: "sort not object", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","sort":true}]}}`},
 		{name: "sort missing enabled", body: `{"input":"x,y\na,1\n","charts":{"configs":[{"type":"bar","sort":{"order":"asc"}}]}}`},
@@ -796,6 +800,29 @@ func (s *ServeSuite) TestUIEndpointBarBackgroundRoundTrip() {
 	s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
 }
 
+// responseScale extracts settings[0].scale from a Dataset JSON response.
+func (s *ServeSuite) responseScale(recorder *httptest.ResponseRecorder) any {
+	s.T().Helper()
+	var dataset struct {
+		Settings []map[string]any `json:"settings"`
+	}
+	s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &dataset))
+	s.Require().Len(dataset.Settings, 1)
+	return dataset.Settings[0]["scale"]
+}
+
+// settingScale marshals settings[0] and returns its scale value.
+func (s *ServeSuite) settingScale(datasets []shared.Dataset) any {
+	s.T().Helper()
+	s.Require().Len(datasets, 1)
+	s.Require().Len(datasets[0].Settings, 1)
+	raw, err := json.Marshal(datasets[0].Settings[0])
+	s.Require().NoError(err)
+	var config map[string]any
+	s.Require().NoError(json.Unmarshal(raw, &config))
+	return config["scale"]
+}
+
 // settingBackground marshals settings[0] and returns its background object.
 func (s *ServeSuite) settingBackground(datasets []shared.Dataset) map[string]any {
 	s.Require().Len(datasets, 1)
@@ -836,6 +863,117 @@ func (s *ServeSuite) TestConvertEndpointRejectsInvalidBackground() {
 		s.Run(test.name, func() {
 			recorder := s.apiRequest(handler, "/", test.body, "application/json", "application/json")
 			s.Equal(http.StatusUnprocessableEntity, recorder.Code, recorder.Body.String())
+			var problem struct {
+				Errors []apiValidationError `json:"errors"`
+			}
+			s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &problem))
+			s.NotEmpty(problem.Errors)
+		})
+	}
+}
+
+// TestConvertEndpointScaleRoundTrip covers POST /: "scale":"log" stays a
+// string on Dataset settings, and a per-axis object persists as an object.
+func (s *ServeSuite) TestConvertEndpointScaleRoundTrip() {
+	handler := newRESTHandler()
+
+	s.Run("string log persists as string", func() {
+		body := `{"input":"region,value\nwest,12\n","parser":"csv","charts":{"types":["bar"],"configs":[{"type":"bar","scale":"log"}]}}`
+		recorder := s.apiRequest(handler, "/", body, "application/json", "application/json")
+		s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+		s.Equal("log", s.responseScale(recorder))
+	})
+
+	s.Run("object log axes persists as object", func() {
+		body := `{"input":"region,value\nwest,12\n","parser":"csv","charts":{"types":["bar"],"configs":[{"type":"bar","scale":{"type":"log","axes":["x"]}}]}}`
+		recorder := s.apiRequest(handler, "/", body, "application/json", "application/json")
+		s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+		object, ok := s.responseScale(recorder).(map[string]any)
+		s.Require().True(ok, "expected a scale object on settings, got %#v", s.responseScale(recorder))
+		s.Equal("log", object["type"])
+		s.Equal([]any{"x"}, object["axes"])
+	})
+}
+
+// TestUIEndpointScaleRoundTrip covers POST /ui: scale round-trips onto the
+// materialised Dataset settings inspected by the injected generator.
+func (s *ServeSuite) TestUIEndpointScaleRoundTrip() {
+	s.Run("string log persists as string", func() {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handleUIWithGenerator(w, r, func(datasets []shared.Dataset, charts []string) (string, error) {
+				s.Equal("log", s.settingScale(datasets))
+				return "<html>ok</html>", nil
+			})
+		})
+		body := `{"datasets":` + validDatasetJSON + `,"charts":{"types":["bar"],"configs":[{"type":"bar","scale":"log"}]}}`
+		recorder := s.apiRequest(handler, "/ui", body, "application/json", "text/html")
+		s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+	})
+
+	s.Run("object log axes persists as object", func() {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handleUIWithGenerator(w, r, func(datasets []shared.Dataset, charts []string) (string, error) {
+				object, ok := s.settingScale(datasets).(map[string]any)
+				s.Require().True(ok, "expected a scale object on settings")
+				s.Equal("log", object["type"])
+				s.Equal([]any{"x"}, object["axes"])
+				return "<html>ok</html>", nil
+			})
+		})
+		body := `{"datasets":` + validDatasetJSON + `,"charts":{"types":["bar"],"configs":[{"type":"bar","scale":{"type":"log","axes":["x"]}}]}}`
+		recorder := s.apiRequest(handler, "/ui", body, "application/json", "text/html")
+		s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+	})
+}
+
+// TestConvertEndpointRejectsInvalidScale confirms invalid scale values are
+// request errors (422), never 500s. CLI bags warn-and-default these.
+func (s *ServeSuite) TestConvertEndpointRejectsInvalidScale() {
+	handler := newRESTHandler()
+	for _, test := range []struct {
+		name string
+		body string
+	}{
+		{name: "base 1", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","scale":{"type":"log","base":1}}]}}`},
+		{name: "baseX 1", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","scale":{"type":"log","baseX":1}}]}}`},
+		{name: "unknown key", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","scale":{"type":"log","foo":1}}]}}`},
+		{name: "unknown axis", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","scale":{"type":"log","axes":["q"]}}]}}`},
+		{name: "wrong type", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","scale":true}]}}`},
+		{name: "axes not array", body: `{"input":"region,value\nwest,12\n","charts":{"configs":[{"type":"bar","scale":{"type":"log","axes":"x"}}]}}`},
+	} {
+		s.Run(test.name, func() {
+			recorder := s.apiRequest(handler, "/", test.body, "application/json", "application/json")
+			s.Equal(http.StatusUnprocessableEntity, recorder.Code, recorder.Body.String())
+			s.NotEqual(http.StatusInternalServerError, recorder.Code, recorder.Body.String())
+			var problem struct {
+				Errors []apiValidationError `json:"errors"`
+			}
+			s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &problem))
+			s.NotEmpty(problem.Errors)
+		})
+	}
+}
+
+// TestUIEndpointRejectsInvalidScale is the POST /ui counterpart of
+// TestConvertEndpointRejectsInvalidScale.
+func (s *ServeSuite) TestUIEndpointRejectsInvalidScale() {
+	handler := newRESTHandler()
+	for _, test := range []struct {
+		name  string
+		scale string
+	}{
+		{name: "base 1", scale: `{"type":"log","base":1}`},
+		{name: "unknown key", scale: `{"type":"log","foo":1}`},
+		{name: "unknown axis", scale: `{"type":"log","axes":["q"]}`},
+		{name: "wrong type", scale: `true`},
+	} {
+		s.Run(test.name, func() {
+			body := `{"datasets":` + validDatasetJSON + `,"charts":{"types":["bar"],"configs":[{"type":"bar","scale":` + test.scale + `}]}}`
+			recorder := s.apiRequest(handler, "/ui", body, "application/json", "text/html")
+			s.Equal(http.StatusUnprocessableEntity, recorder.Code, recorder.Body.String())
+			s.NotEqual(http.StatusInternalServerError, recorder.Code, recorder.Body.String())
+			s.Equal("application/problem+json", recorder.Header().Get("Content-Type"))
+			s.Equal(float64(http.StatusUnprocessableEntity), s.problemStatus(recorder))
 			var problem struct {
 				Errors []apiValidationError `json:"errors"`
 			}
@@ -1527,9 +1665,16 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 		s.Require().NotNil(validationErr)
 		s.Equal("/config/showLabels", validationErr.Path)
 
+		s.Nil(validateChartConfigValues(json.RawMessage(`{"scale":"log"}`), "/config"))
+		s.Nil(validateChartConfigValues(json.RawMessage(`{"scale":{"type":"log","axes":["x"]}}`), "/config"))
+
 		for _, raw := range []string{
 			`{`,
 			`{"scale":null}`,
+			`{"scale":true}`,
+			`{"scale":{"type":"log","base":1}}`,
+			`{"scale":{"type":"log","foo":1}}`,
+			`{"scale":{"type":"log","axes":["q"]}}`,
 			`{"symbol":1}`,
 			`{"symbol":"not-a-symbol"}`,
 			`{"sort":true}`,


### PR DESCRIPTION
## Summary
- OpenAPI `Scale` is `oneOf` string enum and object (`type`, `axes`, `base`/`baseX`/`baseY`/`baseZ`).
- `POST /` and `POST /ui` persist both shapes on Dataset JSON.
- Invalid keys, types, `base=1`, and unknown axes return 422, not 500.

Stacked on #413 (`feat/413-parse-scale-bag`).

Closes #414
Relates to #412

## Test Plan
- [x] `go test -count=1 ./cmd/ ./api/`
