### PR TITLE
feat(ui): add read-only log-scale info hover

### DIFF
--- a/ui/src/components/SelectionTabs.vue
+++ b/ui/src/components/SelectionTabs.vue
@@ -6,6 +6,7 @@ interface Option {
   value: string | number
   label: string
   icon?: Component
+  class?: string
 }
 
 const props = defineProps<{
@@ -32,10 +33,11 @@ const onUpdate = (value: string | number) => {
         :key="option.value"
         :value="option.value"
         :disabled="props.disabled"
-        class="flex-1"
+        :class="['flex-1', option.class]"
       >
         <component :is="option.icon" v-if="option.icon" class="h-4 w-4" />
         <span class="ml-2">{{ option.label }}</span>
+        <slot name="suffix" :option="option" />
       </TabsTrigger>
     </TabsList>
   </Tabs>

--- a/ui/src/components/SelectionTabs.vue
+++ b/ui/src/components/SelectionTabs.vue
@@ -6,7 +6,6 @@ interface Option {
   value: string | number
   label: string
   icon?: Component
-  class?: string
 }
 
 const props = defineProps<{
@@ -33,7 +32,7 @@ const onUpdate = (value: string | number) => {
         :key="option.value"
         :value="option.value"
         :disabled="props.disabled"
-        :class="['flex-1', option.class]"
+        class="flex-1"
       >
         <component :is="option.icon" v-if="option.icon" class="h-4 w-4" />
         <span class="ml-2">{{ option.label }}</span>

--- a/ui/src/components/SettingsPanel.integration.test.ts
+++ b/ui/src/components/SettingsPanel.integration.test.ts
@@ -7,7 +7,7 @@ const { controlStub } = vi.hoisted(() => {
   const controlStub = (name: string) => ({
     default: {
       name,
-      props: ['modelValue', 'disabled'],
+      props: ['modelValue', 'disabled', 'defaultAxes'],
       emits: ['update:modelValue'],
       template: `<div data-testid="${name}" :data-disabled="String(!!disabled)" :data-value="modelValue" />`,
     },
@@ -259,6 +259,24 @@ describe('SettingsPanel', () => {
     expect(scale.exists()).toBe(true)
     expect(scale.props('disabled')).toBe(true)
     expect(scale.props('modelValue')).toBe('linear')
+  })
+
+  it('passes raw object scale and default log axes to ScaleControl', () => {
+    holder.barConfig = {
+      ...holder.barConfig,
+      scale: { type: 'log', axes: ['x'], base: 10 },
+    }
+    barConfigRef.value = holder.barConfig
+    holder.settings = [holder.barConfig]
+    const w = mount(SettingsPanel)
+    const scale = w.findComponent({ name: 'ScaleControl' })
+    expect(scale.props('modelValue')).toEqual({ type: 'log', axes: ['x'], base: 10 })
+    expect(scale.props('defaultAxes')).toEqual(['y'])
+
+    holder.barConfig = { ...holder.barConfig, horizontal: true }
+    barConfigRef.value = holder.barConfig
+    const horizontal = mount(SettingsPanel)
+    expect(horizontal.findComponent({ name: 'ScaleControl' }).props('defaultAxes')).toEqual(['x'])
   })
 
   it('handles field updates including swap side effects', async () => {

--- a/ui/src/components/SettingsPanel.vue
+++ b/ui/src/components/SettingsPanel.vue
@@ -24,7 +24,6 @@ import {
   type SettingFieldValueMap,
 } from '../composables/settings/fieldRegistry'
 import type { ChartType, ScaleInput } from '../types'
-import { parseScale } from '../lib/scale'
 
 // Generic, schema-less settings panel: walks `Object.keys(activeConfig)` via
 // `getRenderableFields` and renders the registered control for each key. The
@@ -59,7 +58,7 @@ const {
   chartMode,
 } = useDataPoint()
 
-const { hasZOnChart, hasThreeDOption, threeD, stack } = useActiveChartShape()
+const { hasZOnChart, hasThreeDOption, threeD, stack, horizontal } = useActiveChartShape()
 
 const CHART_ICONS: Record<ChartType, Component> = {
   bar: BarChart3,
@@ -150,7 +149,7 @@ const valueFor = (key: SettingFieldKey) => {
   if (!activeConfig.value) return undefined
   if (key === 'scale') {
     if (stack.value) return 'linear'
-    return parseScale((activeConfig.value as { scale?: ScaleInput }).scale).type
+    return (activeConfig.value as { scale?: ScaleInput }).scale
   }
   return (activeConfig.value as Partial<SettingFieldValueMap>)[key]
 }
@@ -186,6 +185,7 @@ const onUpdate = (key: SettingFieldKey, value: unknown) => {
           :is="field.component"
           :model-value="valueFor(field.key)"
           :disabled="disabledFor(field.key)"
+          v-bind="field.key === 'scale' ? { defaultAxes: horizontal ? ['x'] : ['y'] } : {}"
           :id="field.id"
           :label="field.label"
           :description="field.description"
@@ -201,6 +201,7 @@ const onUpdate = (key: SettingFieldKey, value: unknown) => {
             :is="field.component"
             :model-value="valueFor(field.key)"
             :disabled="disabledFor(field.key)"
+
             :id="field.id"
             :label="field.label"
             :description="field.description"

--- a/ui/src/components/SettingsPanel.vue
+++ b/ui/src/components/SettingsPanel.vue
@@ -201,7 +201,6 @@ const onUpdate = (key: SettingFieldKey, value: unknown) => {
             :is="field.component"
             :model-value="valueFor(field.key)"
             :disabled="disabledFor(field.key)"
-
             :id="field.id"
             :label="field.label"
             :description="field.description"

--- a/ui/src/components/settings/ScaleControl.vue
+++ b/ui/src/components/settings/ScaleControl.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { BarChart3, Info, TrendingUp } from 'lucide-vue-next'
-import { Separator } from '../ui'
+import { Popover, PopoverContent, PopoverTrigger, Separator } from '../ui'
 import SelectionTabs from '../SelectionTabs.vue'
 import type { ScaleAxis, ScaleInput, ScaleType } from '@/types'
 import { scaleLogInfoText } from '@/lib/scale'
@@ -29,34 +29,57 @@ const scaleOptions = [
   { value: 'log', label: 'Logarithmic', icon: TrendingUp },
 ]
 
+const infoOpen = ref(false)
+
 const onUpdate = (val: string | number) => {
   if (props.disabled) return
   emit('update:modelValue', val as ScaleType)
+}
+
+const setInfoOpen = (open: boolean) => {
+  infoOpen.value = open
 }
 </script>
 
 <template>
   <div class="space-y-3" :class="{ 'opacity-60': props.disabled }">
     <p class="text-sm font-medium">Data Scale</p>
-    <div class="flex items-center gap-2">
-      <SelectionTabs
-        class="min-w-0 flex-1"
-        :model-value="value"
-        :options="scaleOptions"
-        :disabled="props.disabled"
-        @update:model-value="onUpdate"
-      />
-      <button
-        v-if="logInfo"
-        type="button"
-        data-testid="scale-log-info"
-        class="inline-flex shrink-0 text-muted-foreground hover:text-foreground"
-        :title="logInfo"
-        :aria-label="logInfo"
-      >
-        <Info class="h-4 w-4" aria-hidden="true" />
-      </button>
-    </div>
+    <SelectionTabs
+      class="min-w-0 w-full"
+      :model-value="value"
+      :options="scaleOptions"
+      :disabled="props.disabled"
+      @update:model-value="onUpdate"
+    >
+      <template #suffix="{ option }">
+        <span
+          v-if="option.value === 'log' && logInfo"
+          data-testid="scale-log-info"
+          class="ml-1 inline-flex text-muted-foreground hover:text-foreground"
+          :aria-label="logInfo"
+          :aria-expanded="infoOpen"
+          role="button"
+          tabindex="0"
+          @mouseenter="setInfoOpen(true)"
+          @mouseleave="setInfoOpen(false)"
+          @focus="setInfoOpen(true)"
+          @blur="setInfoOpen(false)"
+          @click.stop
+          @pointerdown.stop
+        >
+          <Popover :open="infoOpen">
+            <PopoverTrigger as-child>
+              <span class="inline-flex">
+                <Info class="h-4 w-4" aria-hidden="true" />
+              </span>
+            </PopoverTrigger>
+            <PopoverContent class="w-auto max-w-xs p-3 text-sm" align="end">
+              {{ logInfo }}
+            </PopoverContent>
+          </Popover>
+        </span>
+      </template>
+    </SelectionTabs>
   </div>
   <Separator />
 </template>

--- a/ui/src/components/settings/ScaleControl.vue
+++ b/ui/src/components/settings/ScaleControl.vue
@@ -1,20 +1,28 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { BarChart3, TrendingUp } from 'lucide-vue-next'
+import { BarChart3, Info, TrendingUp } from 'lucide-vue-next'
 import { Separator } from '../ui'
 import SelectionTabs from '../SelectionTabs.vue'
-import type { ScaleType } from '@/types'
+import type { ScaleAxis, ScaleInput, ScaleType } from '@/types'
+import { scaleLogInfoText } from '@/lib/scale'
 
-const props = defineProps<{
-  modelValue: ScaleType | undefined
-  disabled?: boolean
-}>()
+const props = withDefaults(
+  defineProps<{
+    modelValue: ScaleInput | undefined
+    disabled?: boolean
+    defaultAxes?: readonly ScaleAxis[]
+  }>(),
+  {
+    defaultAxes: () => ['y'],
+  }
+)
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: ScaleType): void
 }>()
 
-const value = computed<ScaleType>(() => props.modelValue ?? 'linear')
+const logInfo = computed(() => scaleLogInfoText(props.modelValue, props.defaultAxes))
+const value = computed<ScaleType>(() => (logInfo.value ? 'log' : 'linear'))
 
 const scaleOptions = [
   { value: 'linear', label: 'Linear', icon: BarChart3 },
@@ -30,12 +38,25 @@ const onUpdate = (val: string | number) => {
 <template>
   <div class="space-y-3" :class="{ 'opacity-60': props.disabled }">
     <p class="text-sm font-medium">Data Scale</p>
-    <SelectionTabs
-      :model-value="value"
-      :options="scaleOptions"
-      :disabled="props.disabled"
-      @update:model-value="onUpdate"
-    />
+    <div class="flex items-center gap-2">
+      <SelectionTabs
+        class="min-w-0 flex-1"
+        :model-value="value"
+        :options="scaleOptions"
+        :disabled="props.disabled"
+        @update:model-value="onUpdate"
+      />
+      <button
+        v-if="logInfo"
+        type="button"
+        data-testid="scale-log-info"
+        class="inline-flex shrink-0 text-muted-foreground hover:text-foreground"
+        :title="logInfo"
+        :aria-label="logInfo"
+      >
+        <Info class="h-4 w-4" aria-hidden="true" />
+      </button>
+    </div>
   </div>
   <Separator />
 </template>

--- a/ui/src/components/settings/ScaleControl.vue
+++ b/ui/src/components/settings/ScaleControl.vue
@@ -35,10 +35,6 @@ const onUpdate = (val: string | number) => {
   if (props.disabled) return
   emit('update:modelValue', val as ScaleType)
 }
-
-const setInfoOpen = (open: boolean) => {
-  infoOpen.value = open
-}
 </script>
 
 <template>
@@ -60,10 +56,10 @@ const setInfoOpen = (open: boolean) => {
           :aria-expanded="infoOpen"
           role="button"
           tabindex="0"
-          @mouseenter="setInfoOpen(true)"
-          @mouseleave="setInfoOpen(false)"
-          @focus="setInfoOpen(true)"
-          @blur="setInfoOpen(false)"
+          @mouseenter="infoOpen = true"
+          @mouseleave="infoOpen = false"
+          @focus="infoOpen = true"
+          @blur="infoOpen = false"
           @click.stop
           @pointerdown.stop
         >

--- a/ui/src/components/settings/controls.integration.test.ts
+++ b/ui/src/components/settings/controls.integration.test.ts
@@ -13,6 +13,31 @@ vi.mock('../ui', () => {
     })
   return {
     Separator: passthrough('Separator'),
+    Popover: defineComponent({
+      name: 'Popover',
+      props: ['open'],
+      setup(_, { slots }) {
+        return () => slots.default?.()
+      },
+    }),
+    PopoverTrigger: defineComponent({
+      name: 'PopoverTrigger',
+      inheritAttrs: false,
+      setup(_, { slots, attrs }) {
+        return () =>
+          h(
+            'button',
+            { type: 'button', ...attrs, 'data-stub': 'PopoverTrigger' },
+            slots.default?.()
+          )
+      },
+    }),
+    PopoverContent: defineComponent({
+      name: 'PopoverContent',
+      setup(_, { slots, attrs }) {
+        return () => h('div', { 'data-stub': 'PopoverContent', ...attrs }, slots.default?.())
+      },
+    }),
     Label: defineComponent({
       name: 'Label',
       props: ['for'],
@@ -40,7 +65,7 @@ vi.mock('../SelectionTabs.vue', () => ({
     name: 'SelectionTabs',
     props: ['modelValue', 'options', 'disabled'],
     emits: ['update:modelValue'],
-    setup(p, { emit }) {
+    setup(p, { emit, slots }) {
       return () =>
         h(
           'div',
@@ -53,7 +78,7 @@ vi.mock('../SelectionTabs.vue', () => ({
                 disabled: p.disabled,
                 onClick: () => emit('update:modelValue', o.value),
               },
-              o.label
+              [o.label, slots.suffix?.({ option: o })]
             )
           )
         )
@@ -203,30 +228,53 @@ describe('settings controls', () => {
     expect(emitVals.length).toBe(before)
   })
 
-  it('ScaleControl shows log info hover only when scale is log', () => {
+  it('ScaleControl shows log info popover on the Logarithmic tab only when scale is log', () => {
     const linear = mount(ScaleControl, { props: { modelValue: 'linear' } })
     expect(linear.find('[data-testid="scale-log-info"]').exists()).toBe(false)
+    expect(linear.find('[data-stub="PopoverContent"]').exists()).toBe(false)
     expect(linear.findAll('input')).toHaveLength(0)
 
     const log = mount(ScaleControl, { props: { modelValue: 'log' } })
     const info = log.get('[data-testid="scale-log-info"]')
-    expect(info.attributes('title')).toBe('Y log (base 10)')
+    expect(info.attributes('title')).toBeUndefined()
     expect(info.attributes('aria-label')).toBe('Y log (base 10)')
+    expect(log.get('[data-stub="PopoverContent"]').text()).toBe('Y log (base 10)')
     expect(log.findAll('input')).toHaveLength(0)
+
+    expect(log.get('[data-value="log"]').element.contains(info.element)).toBe(true)
 
     const horizontal = mount(ScaleControl, {
       props: { modelValue: 'log', defaultAxes: ['x'] },
     })
-    expect(horizontal.get('[data-testid="scale-log-info"]').attributes('title')).toBe(
-      'X log (base 10)'
-    )
+    expect(horizontal.get('[data-stub="PopoverContent"]').text()).toBe('X log (base 10)')
 
     const objectLog = mount(ScaleControl, {
       props: { modelValue: { type: 'log', axes: ['x'], base: 10 } },
     })
-    expect(objectLog.get('[data-testid="scale-log-info"]').attributes('title')).toBe(
-      'X log (base 10) · Y linear'
-    )
+    expect(objectLog.get('[data-stub="PopoverContent"]').text()).toBe('X log (base 10) · Y linear')
+  })
+
+  it('ScaleControl opens log info on hover and closes on leave', async () => {
+    const emitVals: ScaleType[] = []
+    const log = mount(ScaleControl, {
+      props: {
+        modelValue: 'log',
+        'onUpdate:modelValue': (v: ScaleType) => emitVals.push(v),
+      },
+    })
+    const info = log.get('[data-testid="scale-log-info"]')
+    expect(info.attributes('aria-expanded')).toBe('false')
+    await info.trigger('mouseenter')
+    expect(info.attributes('aria-expanded')).toBe('true')
+    await info.trigger('mouseleave')
+    expect(info.attributes('aria-expanded')).toBe('false')
+    await info.trigger('focus')
+    expect(info.attributes('aria-expanded')).toBe('true')
+    await info.trigger('blur')
+    expect(info.attributes('aria-expanded')).toBe('false')
+    await info.trigger('click')
+    await info.trigger('pointerdown')
+    expect(emitVals).toEqual([])
   })
 
   it('ScaleControl Logarithmic click still writes string log for object scale', async () => {

--- a/ui/src/components/settings/controls.integration.test.ts
+++ b/ui/src/components/settings/controls.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { computed, defineComponent, h, ref } from 'vue'
 import { mount } from '@vue/test-utils'
-import type { Sort, ScaleType } from '@/types'
+import type { ScaleInput, Sort, ScaleType } from '@/types'
 
 vi.mock('../ui', () => {
   const passthrough = (name: string) =>
@@ -201,6 +201,46 @@ describe('settings controls', () => {
     const tabs = disabled.findComponent({ name: 'SelectionTabs' })
     await tabs.vm.$emit('update:modelValue', 'log')
     expect(emitVals.length).toBe(before)
+  })
+
+  it('ScaleControl shows log info hover only when scale is log', () => {
+    const linear = mount(ScaleControl, { props: { modelValue: 'linear' } })
+    expect(linear.find('[data-testid="scale-log-info"]').exists()).toBe(false)
+    expect(linear.findAll('input')).toHaveLength(0)
+
+    const log = mount(ScaleControl, { props: { modelValue: 'log' } })
+    const info = log.get('[data-testid="scale-log-info"]')
+    expect(info.attributes('title')).toBe('Y log (base 10)')
+    expect(info.attributes('aria-label')).toBe('Y log (base 10)')
+    expect(log.findAll('input')).toHaveLength(0)
+
+    const horizontal = mount(ScaleControl, {
+      props: { modelValue: 'log', defaultAxes: ['x'] },
+    })
+    expect(horizontal.get('[data-testid="scale-log-info"]').attributes('title')).toBe(
+      'X log (base 10)'
+    )
+
+    const objectLog = mount(ScaleControl, {
+      props: { modelValue: { type: 'log', axes: ['x'], base: 10 } },
+    })
+    expect(objectLog.get('[data-testid="scale-log-info"]').attributes('title')).toBe(
+      'X log (base 10) · Y linear'
+    )
+  })
+
+  it('ScaleControl Logarithmic click still writes string log for object scale', async () => {
+    const emitVals: ScaleType[] = []
+    const w = mount(ScaleControl, {
+      props: {
+        modelValue: { type: 'log', axes: ['x'], baseX: 5, baseY: 10 } satisfies ScaleInput,
+        'onUpdate:modelValue': (v: ScaleType) => emitVals.push(v),
+      },
+    })
+    expect(w.find('[data-testid="selection-tabs"]').exists()).toBe(true)
+    await w.get('[data-value="log"]').trigger('click')
+    expect(emitVals).toEqual(['log'])
+    expect(w.findAll('input')).toHaveLength(0)
   })
 
   it.each([

--- a/ui/src/components/simple.integration.test.ts
+++ b/ui/src/components/simple.integration.test.ts
@@ -65,12 +65,12 @@ vi.mock('./ui', () => {
     TabsList: passthrough('TabsList'),
     TabsTrigger: defineComponent({
       name: 'TabsTrigger',
-      props: ['value', 'disabled', 'class'],
+      props: ['value', 'disabled'],
       setup(props, { slots }) {
         return () =>
           h(
             'button',
-            { 'data-value': String(props.value), disabled: props.disabled, class: props.class },
+            { 'data-value': String(props.value), disabled: props.disabled },
             slots.default?.()
           )
       },
@@ -276,20 +276,6 @@ describe('SettingHeader / SettingsToggle / SelectionTabs', () => {
     })
     await disabled.get('[data-tabs]').trigger('click')
     expect(onDisabledUpdate).not.toHaveBeenCalled()
-  })
-
-  it('SelectionTabs applies optional option class on the trigger', () => {
-    const w = mount(SelectionTabs, {
-      props: {
-        modelValue: 'a',
-        options: [
-          { value: 'a', label: 'A' },
-          { value: 'b', label: 'B', class: 'pr-7' },
-        ],
-      },
-    })
-    expect(w.get('[data-value="b"]').classes()).toContain('pr-7')
-    expect(w.get('[data-value="a"]').classes()).not.toContain('pr-7')
   })
 
   it('SelectionTabs renders suffix slot after the option label', () => {

--- a/ui/src/components/simple.integration.test.ts
+++ b/ui/src/components/simple.integration.test.ts
@@ -65,12 +65,12 @@ vi.mock('./ui', () => {
     TabsList: passthrough('TabsList'),
     TabsTrigger: defineComponent({
       name: 'TabsTrigger',
-      props: ['value', 'disabled'],
+      props: ['value', 'disabled', 'class'],
       setup(props, { slots }) {
         return () =>
           h(
             'button',
-            { 'data-value': String(props.value), disabled: props.disabled },
+            { 'data-value': String(props.value), disabled: props.disabled, class: props.class },
             slots.default?.()
           )
       },
@@ -276,6 +276,40 @@ describe('SettingHeader / SettingsToggle / SelectionTabs', () => {
     })
     await disabled.get('[data-tabs]').trigger('click')
     expect(onDisabledUpdate).not.toHaveBeenCalled()
+  })
+
+  it('SelectionTabs applies optional option class on the trigger', () => {
+    const w = mount(SelectionTabs, {
+      props: {
+        modelValue: 'a',
+        options: [
+          { value: 'a', label: 'A' },
+          { value: 'b', label: 'B', class: 'pr-7' },
+        ],
+      },
+    })
+    expect(w.get('[data-value="b"]').classes()).toContain('pr-7')
+    expect(w.get('[data-value="a"]').classes()).not.toContain('pr-7')
+  })
+
+  it('SelectionTabs renders suffix slot after the option label', () => {
+    const w = mount(SelectionTabs, {
+      props: {
+        modelValue: 'a',
+        options: [
+          { value: 'a', label: 'A' },
+          { value: 'b', label: 'B' },
+        ],
+      },
+      slots: {
+        suffix: ({ option }: { option: { value: string | number } }) =>
+          h('span', { 'data-testid': `suffix-${option.value}` }, 'after'),
+      },
+    })
+    const logTab = w.get('[data-value="b"]')
+    expect(logTab.text()).toContain('B')
+    expect(logTab.get('[data-testid="suffix-b"]').text()).toBe('after')
+    expect(w.get('[data-value="a"]').find('[data-testid="suffix-a"]').exists()).toBe(true)
   })
 })
 

--- a/ui/src/composables/useSettingsStore.test.ts
+++ b/ui/src/composables/useSettingsStore.test.ts
@@ -389,6 +389,38 @@ describe('useSettingsStore', () => {
     expect(themeName.value).toBe('ocean')
   })
 
+  it('setScale preserves object log extras when toggling type', async () => {
+    const spec = { type: 'log' as const, axes: ['x'] as ['x'], baseX: 5, baseY: 10 }
+    holder.ref = ref(ds([{ type: 'line', scale: { ...spec } } as ChartConfig]))
+    const { useSettingsStore } = await import('./useSettingsStore')
+    const { activeConfig, setScale } = useSettingsStore()
+
+    setScale('log')
+    expect((activeConfig.value as { scale?: unknown }).scale).toEqual(spec)
+
+    setScale('linear')
+    expect((activeConfig.value as { scale?: unknown }).scale).toEqual({
+      ...spec,
+      type: 'linear',
+    })
+
+    setScale('log')
+    expect((activeConfig.value as { scale?: unknown }).scale).toEqual(spec)
+  })
+
+  it('setStack preserves object log extras when forcing linear', async () => {
+    const spec = { type: 'log' as const, axes: ['x'] as ['x'], base: 10 }
+    holder.ref = ref(ds([{ type: 'bar', scale: { ...spec } } as ChartConfig]))
+    const { useSettingsStore } = await import('./useSettingsStore')
+    const { activeConfig, setStack } = useSettingsStore()
+    setStack(true)
+    expect((activeConfig.value as { stack?: boolean }).stack).toBe(true)
+    expect((activeConfig.value as { scale?: unknown }).scale).toEqual({
+      ...spec,
+      type: 'linear',
+    })
+  })
+
   it('setStack without enabling keeps scale when stack is false', async () => {
     holder.ref = ref(
       ds([{ type: 'bar', sort: { enabled: false, order: 'asc' }, scale: 'log' } as ChartConfig])

--- a/ui/src/composables/useSettingsStore.ts
+++ b/ui/src/composables/useSettingsStore.ts
@@ -1,7 +1,8 @@
 import { computed, ref, watch } from 'vue'
-import type { ChartConfig, ChartType, Sort, ScaleType } from '../types'
+import type { ChartConfig, ChartType, Sort, ScaleInput, ScaleType } from '../types'
 import { activeDataset } from './useDataPoint'
 import { isValidIndex } from '../lib/utils'
+import { applyScaleType, parseScale } from '../lib/scale'
 import { activeThemeName, applyTheme, isAvailableThemeName, normalizeTheme } from '../lib/themes'
 
 // Module-level singleton state. `activeChartIndex` is the cursor into
@@ -129,10 +130,21 @@ export function useSettingsStore() {
     Object.assign(cfg, fields)
   }
 
+  const currentScale = () => (activeConfig.value as { scale?: ScaleInput } | undefined)?.scale
+
   const setSort = (sort: Sort) => patchActive({ sort: { ...sort } })
-  const setScale = (scale: ScaleType) => patchActive({ scale })
-  const setStack = (stack: boolean) =>
-    patchActive(stack ? { stack, scale: 'linear' as const } : { stack })
+  const setScale = (scale: ScaleType) => {
+    const current = currentScale()
+    if (parseScale(current).type === scale) return
+    patchActive({ scale: applyScaleType(current, scale) })
+  }
+  const setStack = (stack: boolean) => {
+    if (!stack) {
+      patchActive({ stack })
+      return
+    }
+    patchActive({ stack, scale: applyScaleType(currentScale(), 'linear') })
+  }
   const setShowLabels = (show: boolean) => patchActive({ showLabels: show })
   const setSmooth = (smooth: boolean) => patchActive({ smooth }, (cfg) => cfg.type === 'line')
   const setHorizontal = (horizontal: boolean) =>

--- a/ui/src/composables/useSettingsStore.ts
+++ b/ui/src/composables/useSettingsStore.ts
@@ -138,13 +138,8 @@ export function useSettingsStore() {
     if (parseScale(current).type === scale) return
     patchActive({ scale: applyScaleType(current, scale) })
   }
-  const setStack = (stack: boolean) => {
-    if (!stack) {
-      patchActive({ stack })
-      return
-    }
-    patchActive({ stack, scale: applyScaleType(currentScale(), 'linear') })
-  }
+  const setStack = (stack: boolean) =>
+    patchActive(stack ? { stack, scale: applyScaleType(currentScale(), 'linear') } : { stack })
   const setShowLabels = (show: boolean) => patchActive({ showLabels: show })
   const setSmooth = (smooth: boolean) => patchActive({ smooth }, (cfg) => cfg.type === 'line')
   const setHorizontal = (horizontal: boolean) =>

--- a/ui/src/composables/useUrlRouter.test.ts
+++ b/ui/src/composables/useUrlRouter.test.ts
@@ -357,6 +357,29 @@ describe('useUrlRouter', () => {
     expect(scatter.stack).toBeUndefined()
   })
 
+  it('applies object log sc without flattening extras', async () => {
+    const spec = { type: 'log' as const, axes: ['x'] as ['x'], base: 10 }
+    holder.datasets = ref([ds([{ type: 'line', scale: { ...spec } }])])
+    mockWindow('?line.sc=log')
+    const { useUrlRouter } = await import('./useUrlRouter')
+    await useUrlRouter().initFromUrl()
+
+    const line = holder.datasets.value[0]!.settings[0] as LineConfig
+    expect(line.scale).toEqual(spec)
+  })
+
+  it('syncs object log type to sc without flattening extras', async () => {
+    const spec = { type: 'log' as const, axes: ['x'] as ['x'], base: 10 }
+    holder.datasets = ref([ds([{ type: 'line', scale: { ...spec } }])])
+    const replaceState = mockWindow('')
+    const { useUrlRouter } = await import('./useUrlRouter')
+    useUrlRouter().syncUrlToState()
+
+    const url = String(replaceState.mock.calls[0]?.[2] ?? '')
+    expect(url).toContain('line.sc=log')
+    expect(holder.datasets.value[0]!.settings[0]).toMatchObject({ scale: spec })
+  })
+
   it('uses a linear scale when enabling line stacking', async () => {
     holder.datasets = ref([ds([{ type: 'line', stack: false, scale: 'log' }])])
     mockWindow('?line.st=true')

--- a/ui/src/composables/useUrlRouter.ts
+++ b/ui/src/composables/useUrlRouter.ts
@@ -10,6 +10,7 @@ import type {
   Dataset,
 } from '../types'
 import { ALL_CHART_TYPES, SORT_ORDERS, SCALE_TYPES } from '../types'
+import { applyScaleType, parseScale } from '../lib/scale'
 import { useSettingsStore } from './useSettingsStore'
 import { useDataPoint } from './useDataPoint'
 import { activeDataset } from './useDataPoint'
@@ -78,7 +79,7 @@ const applyConfigUpdate = (type: ChartType, update: ConfigUpdate): boolean => {
   if (update.showLabels !== undefined) cfg.showLabels = update.showLabels
   if (cfg.type === 'bar' || cfg.type === 'line' || cfg.type === 'scatter') {
     const cartesian = cfg as BarConfig | LineConfig | ScatterConfig
-    if (update.scale) cartesian.scale = update.scale
+    if (update.scale) cartesian.scale = applyScaleType(cartesian.scale, update.scale)
     if (update.threeD !== undefined) cartesian.threeD = update.threeD
     if (update.threeDRotate !== undefined) cartesian.threeDRotate = update.threeDRotate
     if (update.threeDVisualMap !== undefined) cartesian.threeDVisualMap = update.threeDVisualMap
@@ -91,7 +92,7 @@ const applyConfigUpdate = (type: ChartType, update: ConfigUpdate): boolean => {
     if ((cfg.type === 'bar' || cfg.type === 'line') && update.stack !== undefined) {
       const stackable = cfg as BarConfig | LineConfig
       stackable.stack = update.stack
-      if (update.stack) stackable.scale = 'linear'
+      if (update.stack) stackable.scale = applyScaleType(stackable.scale, 'linear')
     }
   }
   return true
@@ -274,8 +275,8 @@ export function useUrlRouter() {
       else if (cfg.showLabels === false) params[`${ct}.l`] = 'false'
       if (cfg.type === 'bar' || cfg.type === 'line' || cfg.type === 'scatter') {
         const cartesian = cfg as BarConfig | LineConfig | ScatterConfig
-        if (typeof cartesian.scale === 'string' && cartesian.scale !== 'linear') {
-          params[`${ct}.sc`] = cartesian.scale
+        if (parseScale(cartesian.scale).type === 'log') {
+          params[`${ct}.sc`] = 'log'
         }
         if (cartesian.threeD === true) params[`${ct}.3d`] = 'true'
         if (cartesian.threeDRotate === true) params[`${ct}.3d-rt`] = 'true'

--- a/ui/src/lib/scale.test.ts
+++ b/ui/src/lib/scale.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   DEFAULT_LOG_BASE,
+  applyScaleType,
   asLogXPairs,
   axisIsLog,
   axisLogBase,
@@ -145,9 +146,9 @@ describe('scaleLogInfoText', () => {
     expect(scaleLogInfoText({ type: 'log', axes: ['x'], base: 10 })).toBe(
       'X log (base 10) · Y linear'
     )
-    expect(
-      scaleLogInfoText({ type: 'log', axes: ['x'], base: 10 }, ['z'])
-    ).toBe('X log (base 10) · Y linear · Z linear')
+    expect(scaleLogInfoText({ type: 'log', axes: ['x'], base: 10 }, ['z'])).toBe(
+      'X log (base 10) · Y linear · Z linear'
+    )
   })
 
   it('uses per-axis bases when both axes are log', () => {
@@ -158,5 +159,20 @@ describe('scaleLogInfoText', () => {
 
   it('treats an explicit empty axes list as all-linear chart axes', () => {
     expect(scaleLogInfoText({ type: 'log', axes: [] })).toBe('X linear · Y linear')
+  })
+})
+
+describe('applyScaleType', () => {
+  it('applyScaleType merges type into an object spec and returns strings as-is', () => {
+    const spec = { type: 'log' as const, axes: ['x'] as ['x'], base: 10, baseX: 5 }
+    expect(applyScaleType(spec, 'log')).toEqual(spec)
+    expect(applyScaleType(spec, 'linear')).toEqual({ ...spec, type: 'linear' })
+    expect(applyScaleType({ type: 'linear', axes: ['x'] }, 'log')).toEqual({
+      type: 'log',
+      axes: ['x'],
+    })
+    expect(applyScaleType('linear', 'log')).toBe('log')
+    expect(applyScaleType('log', 'linear')).toBe('linear')
+    expect(applyScaleType(undefined, 'log')).toBe('log')
   })
 })

--- a/ui/src/lib/scale.test.ts
+++ b/ui/src/lib/scale.test.ts
@@ -6,6 +6,7 @@ import {
   axisLogBase,
   numericLogXValues,
   parseScale,
+  scaleLogInfoText,
   validLogBase,
 } from './scale'
 
@@ -123,5 +124,39 @@ describe('validLogBase / numericLogXValues / asLogXPairs', () => {
       [10, 4],
     ])
     expect(asLogXPairs([1], [null], true)).toEqual([[1, null]])
+  })
+})
+
+describe('scaleLogInfoText', () => {
+  it('is empty for linear', () => {
+    expect(scaleLogInfoText(undefined)).toBeUndefined()
+    expect(scaleLogInfoText('linear')).toBeUndefined()
+    expect(scaleLogInfoText({ type: 'linear', axes: ['x'] })).toBeUndefined()
+  })
+
+  it('names only the default value axis for string log', () => {
+    expect(scaleLogInfoText('log')).toBe('Y log (base 10)')
+    expect(scaleLogInfoText('log', ['x'])).toBe('X log (base 10)')
+    expect(scaleLogInfoText('log', ['z'])).toBe('Z log (base 10)')
+    expect(scaleLogInfoText({ type: 'log' })).toBe('Y log (base 10)')
+  })
+
+  it('names linear axes when the object lists some axes but not others', () => {
+    expect(scaleLogInfoText({ type: 'log', axes: ['x'], base: 10 })).toBe(
+      'X log (base 10) · Y linear'
+    )
+    expect(
+      scaleLogInfoText({ type: 'log', axes: ['x'], base: 10 }, ['z'])
+    ).toBe('X log (base 10) · Y linear · Z linear')
+  })
+
+  it('uses per-axis bases when both axes are log', () => {
+    expect(scaleLogInfoText({ type: 'log', axes: ['x', 'y'], baseX: 5, baseY: 10 })).toBe(
+      'X log (base 5) · Y log (base 10)'
+    )
+  })
+
+  it('treats an explicit empty axes list as all-linear chart axes', () => {
+    expect(scaleLogInfoText({ type: 'log', axes: [] })).toBe('X linear · Y linear')
   })
 })

--- a/ui/src/lib/scale.ts
+++ b/ui/src/lib/scale.ts
@@ -29,6 +29,17 @@ function parseAxes(axes: unknown): ScaleAxis[] | null {
   return axes.filter(isScaleAxis)
 }
 
+/** Keep axes/base on an object spec; strings stay strings. */
+export function applyScaleType(
+  current: ScaleInput | undefined | null,
+  type: ScaleType
+): ScaleInput {
+  if (current != null && typeof current === 'object') {
+    return { ...current, type }
+  }
+  return type
+}
+
 /** Normalize Dataset `scale` (string or object) without applying chart defaults. */
 export function parseScale(input: ScaleInput | undefined | null): ParsedScale {
   if (input == null || typeof input !== 'object') {

--- a/ui/src/lib/scale.ts
+++ b/ui/src/lib/scale.ts
@@ -60,6 +60,33 @@ export function axisLogBase(parsed: ParsedScale, axis: ScaleAxis): number {
   return override ?? parsed.base
 }
 
+function axisPhrase(parsed: ParsedScale, axis: ScaleAxis, isLog: boolean): string {
+  const name = axis.toUpperCase()
+  return isLog ? `${name} log (base ${axisLogBase(parsed, axis)})` : `${name} linear`
+}
+
+/**
+ * Logarithmic hover copy, or `undefined` when the scale is not log.
+ * Omitted axes name only the default value axis; an explicit `axes` list names
+ * every chart axis and marks the rest linear.
+ */
+export function scaleLogInfoText(
+  scale: ScaleInput | undefined | null,
+  defaultAxes: readonly ScaleAxis[] = ['y']
+): string | undefined {
+  const parsed = parseScale(scale)
+  if (parsed.type !== 'log') return undefined
+
+  if (parsed.axes === null) {
+    return defaultAxes.map((axis) => axisPhrase(parsed, axis, true)).join(' · ')
+  }
+
+  const chartAxes: readonly ScaleAxis[] = defaultAxes.includes('z') ? ['x', 'y', 'z'] : ['x', 'y']
+  return chartAxes
+    .map((axis) => axisPhrase(parsed, axis, axisIsLog(parsed, axis, defaultAxes)))
+    .join(' · ')
+}
+
 /**
  * When X is log and every category label is a finite number > 0, return those
  * numbers so callers can coerce the category axis to a value/log axis.


### PR DESCRIPTION
## Summary
- Read-only info hover next to Logarithmic names axes and bases (`Y log (base 10)`, `X log (base 10) · Y linear`, …).
- Clicking Logarithmic still writes `"log"`. No axis chips or base input.

Stacked on #415 (`feat/415-per-axis-log-ui`).

Closes #416
Relates to #412

## Test Plan
- [x] `pnpm exec vitest run src/lib/scale.test.ts src/components/settings/controls.integration.test.ts`
