### PR TITLE
fix(ui): restrict line charts to slider-only dataZoom

### DIFF
--- a/ui/src/composables/charts/shared/chartConfig.test.ts
+++ b/ui/src/composables/charts/shared/chartConfig.test.ts
@@ -3,6 +3,9 @@ import {
   createAxisConfig,
   createValueAxisConfig,
   createDataZoomConfig,
+  createHorizontalDataZoomConfig,
+  INSIDE_XY_ZOOM,
+  resolveCartesianDataZoom,
   createGridConfig,
   legendBandPx,
   createTooltipConfig,
@@ -103,6 +106,70 @@ describe('createDataZoomConfig', () => {
       bottom: 34,
       height: 28,
       textStyle: { color: styling.textColor },
+    })
+  })
+})
+
+describe('resolveCartesianDataZoom', () => {
+  const ctx = { styling }
+
+  it.each([
+    { chartType: 'line' as const, numericX: true, largeX: false },
+    { chartType: 'line' as const, numericX: true, largeX: true },
+    { chartType: 'line' as const, numericX: false, largeX: false },
+  ])('omits zoom for line ($numericX numericX, $largeX largeX)', (flags) => {
+    expect(resolveCartesianDataZoom('line', { ...ctx, ...flags })).toEqual({ hasXSlider: false })
+  })
+
+  it('uses a slider-only window for large category line axes', () => {
+    const { dataZoom, hasXSlider } = resolveCartesianDataZoom('line', {
+      ...ctx,
+      numericX: false,
+      largeX: true,
+    })
+    expect(hasXSlider).toBe(true)
+    expect(dataZoom).toEqual(createDataZoomConfig([], styling).filter((z) => z.type === 'slider'))
+  })
+
+  it.each(['scatter', 'bar'] as const)(
+    'uses inside zoom for %s unless the category axis is large',
+    (chartType) => {
+      for (const flags of [
+        { numericX: true, largeX: false },
+        { numericX: true, largeX: true },
+        { numericX: false, largeX: false },
+      ]) {
+        expect(resolveCartesianDataZoom(chartType, { ...ctx, ...flags })).toEqual({
+          dataZoom: INSIDE_XY_ZOOM,
+          hasXSlider: false,
+        })
+      }
+    }
+  )
+
+  it.each(['scatter', 'bar'] as const)(
+    'adds inside+slider for large category %s axes',
+    (chartType) => {
+      expect(
+        resolveCartesianDataZoom(chartType, { ...ctx, numericX: false, largeX: true })
+      ).toEqual({
+        dataZoom: createDataZoomConfig([], styling),
+        hasXSlider: true,
+      })
+    }
+  )
+
+  it('uses a Y slider for large horizontal bars and does not reserve the X band', () => {
+    expect(
+      resolveCartesianDataZoom('bar', {
+        ...ctx,
+        numericX: false,
+        largeX: true,
+        horizontal: true,
+      })
+    ).toEqual({
+      dataZoom: createHorizontalDataZoomConfig(styling),
+      hasXSlider: false,
     })
   })
 })

--- a/ui/src/composables/charts/shared/chartConfig.ts
+++ b/ui/src/composables/charts/shared/chartConfig.ts
@@ -191,6 +191,33 @@ export function createHorizontalDataZoomConfig(styling: ChartStyling): any[] {
   ]
 }
 
+export function resolveCartesianDataZoom(
+  chartType: 'line' | 'scatter' | 'bar',
+  ctx: {
+    numericX: boolean
+    largeX: boolean
+    styling: ChartStyling
+    horizontal?: boolean
+  }
+): { dataZoom?: any[]; hasXSlider: boolean } {
+  if (chartType === 'line') {
+    if (!ctx.numericX && ctx.largeX) {
+      return {
+        dataZoom: createDataZoomConfig([], ctx.styling).filter((z) => z.type === 'slider'),
+        hasXSlider: true,
+      }
+    }
+    return { hasXSlider: false }
+  }
+  if (ctx.numericX || !ctx.largeX) {
+    return { dataZoom: INSIDE_XY_ZOOM, hasXSlider: false }
+  }
+  if (ctx.horizontal) {
+    return { dataZoom: createHorizontalDataZoomConfig(ctx.styling), hasXSlider: false }
+  }
+  return { dataZoom: createDataZoomConfig([], ctx.styling), hasXSlider: true }
+}
+
 export interface ChartStyling {
   textColor: string
   axisColor: string

--- a/ui/src/composables/charts/shared/mixedMode.test.ts
+++ b/ui/src/composables/charts/shared/mixedMode.test.ts
@@ -233,7 +233,9 @@ describe('buildMixedAxes2DOptions', () => {
     const s = series0(option)
     expect(s.symbol).toBe('none')
     expect(s.sampling).toBe('lttb')
-    expect(option.dataZoom).toBeTruthy()
+    const dataZoom = option.dataZoom as { type: string }[]
+    expect(dataZoom).toHaveLength(1)
+    expect(dataZoom[0]!.type).toBe('slider')
 
     const scatter = buildMixedAxes2DOptions(
       cfg({
@@ -285,6 +287,29 @@ describe('buildMixedAxes2DOptions', () => {
 
   it('uses inside zoom for small category axes', () => {
     const option = buildMixedAxes2DOptions(cfg())
+    expect(option.dataZoom).toEqual([
+      { type: 'inside', xAxisIndex: 0 },
+      { type: 'inside', yAxisIndex: 0 },
+    ])
+  })
+
+  it('omits inside zoom for small mixed line axes', () => {
+    expect(buildMixedAxes2DOptions(cfg(), 'line').dataZoom).toBeUndefined()
+  })
+
+  it('does not reserve the category slider band for mixed scatter log-X', () => {
+    const cats = Array.from({ length: LARGE_X_THRESHOLD + 1 }, (_, i) => String(i + 1))
+    const tuples = cats.map((_, i) => [i, i + 1] as [number, number])
+    const option = buildMixedAxes2DOptions(
+      cfg({
+        scale: { type: 'log', axes: ['x'] },
+        chartData: makeMixedChartData({ xCategories: cats, mixedTuples: tuples }),
+      }),
+      'scatter'
+    )
+    const grid = option.grid as { bottom?: number; containLabel?: boolean }
+    expect(grid.bottom).toBe(28)
+    expect(grid.containLabel).toBe(true)
     expect(option.dataZoom).toEqual([
       { type: 'inside', xAxisIndex: 0 },
       { type: 'inside', yAxisIndex: 0 },

--- a/ui/src/composables/charts/shared/mixedMode.ts
+++ b/ui/src/composables/charts/shared/mixedMode.ts
@@ -5,7 +5,6 @@ import { axisIsLog, axisLogBase, numericLogXValues, parseScale } from '@/lib/sca
 import { type BaseChartConfig, getBaseOptions } from '../baseChartOptions'
 import {
   createAxisConfig,
-  createDataZoomConfig,
   createLabelConfig,
   createValueAxisConfig,
   createValueModeGridConfig,
@@ -16,8 +15,8 @@ import {
   getChartStyling,
   getTooltipTheme,
   isLargeXAxis,
-  INSIDE_XY_ZOOM,
   LARGE_DATA_THRESHOLD,
+  resolveCartesianDataZoom,
   scatterSeriesLargeOpts,
 } from './chartConfig'
 import {
@@ -197,16 +196,22 @@ export function buildMixedAxes2DOptions(
         axisLogBase(parsed, 'y')
       )
 
+  const zoom = resolveCartesianDataZoom(chartType, {
+    numericX: xNums !== null,
+    largeX,
+    styling,
+  })
+
   return {
     ...baseOptions,
     legend: { show: false },
-    grid: createValueModeGridConfig(largeX),
+    grid: createValueModeGridConfig(zoom.hasXSlider),
     visualMap: resolve2DScatterVisualMap(useVisualMap, colorValues, styling, 1),
     tooltip: xNums
       ? createValueModeTooltip(isDark.value, xLabel, yLabel, true)
       : createMixedModeTooltip(isDark.value, xCategories, chartType, xLabel, yLabel),
     ...axisConfig,
-    dataZoom: xNums || !largeX ? INSIDE_XY_ZOOM : createDataZoomConfig(xCategories, styling),
+    ...(zoom.dataZoom ? { dataZoom: zoom.dataZoom } : {}),
     series: [series],
   } as EChartsOption
 }

--- a/ui/src/composables/charts/shared/valueMode.test.ts
+++ b/ui/src/composables/charts/shared/valueMode.test.ts
@@ -233,6 +233,15 @@ describe('buildValueAxes2DOptions', () => {
 
     const line = buildValueAxes2DOptions(cfg(), 'line')
     expect(seriesOf(line).symbolSize).toBe(7)
+    expect(line.dataZoom).toBeUndefined()
+  })
+
+  it('keeps inside zoom on scatter and omits it on value-mode line', () => {
+    expect(buildValueAxes2DOptions(cfg(), 'scatter').dataZoom).toEqual([
+      { type: 'inside', xAxisIndex: 0 },
+      { type: 'inside', yAxisIndex: 0 },
+    ])
+    expect(buildValueAxes2DOptions(cfg(), 'line').dataZoom).toBeUndefined()
   })
 
   it('enables smooth lines and visualMap color dimension from third tuple slot', () => {

--- a/ui/src/composables/charts/shared/valueMode.ts
+++ b/ui/src/composables/charts/shared/valueMode.ts
@@ -150,7 +150,7 @@ export function buildValueAxes2DOptions(
         yLogBase: axisLogBase(parsed, 'y'),
       }
     ),
-    dataZoom: INSIDE_XY_ZOOM,
+    ...(chartType === 'line' ? {} : { dataZoom: INSIDE_XY_ZOOM }),
     series: [series],
   } as EChartsOption
 }

--- a/ui/src/composables/charts/useBarChartOptions.ts
+++ b/ui/src/composables/charts/useBarChartOptions.ts
@@ -5,11 +5,9 @@ import { type BaseChartConfig, getBaseOptions } from './baseChartOptions'
 import { getNextColorFor, hasXAxis } from '@/lib/utils'
 import {
   createAxisConfig,
-  createDataZoomConfig,
   createGridConfig,
   createValueModeGridConfig,
   createHorizontalAxisConfig,
-  createHorizontalDataZoomConfig,
   createLabelConfig,
   createLegendConfig,
   createTooltipConfig,
@@ -19,8 +17,8 @@ import {
   legendBandPx,
   isLargeXAxis,
   makeLegendTitle,
-  INSIDE_XY_ZOOM,
   LARGE_DATA_THRESHOLD,
+  resolveCartesianDataZoom,
 } from './shared/chartConfig'
 import { useSortedSeriesData, resolveLogScale, computeSeriesTotals } from './shared/common'
 import { asLogXPairs, axisIsLog, axisLogBase, numericLogXValues, parseScale } from '@/lib/scale'
@@ -159,13 +157,12 @@ export function useBarChartOptions(config: BaseChartConfig) {
       : isHorizontal
         ? createHorizontalAxisConfig(styling, xAxisData, yScale, xLabel, largeX, yLogBase)
         : createAxisConfig(styling, xAxisData, yScale, xLabel, largeX, false, yLogBase)
-    const groupedDataZoom = xNums
-      ? INSIDE_XY_ZOOM
-      : largeX
-        ? isHorizontal
-          ? createHorizontalDataZoomConfig(styling)
-          : createDataZoomConfig(xAxisData, styling)
-        : undefined
+    const zoom = resolveCartesianDataZoom('bar', {
+      numericX: xNums !== null,
+      largeX,
+      styling,
+      horizontal: isHorizontal,
+    })
     const useStack = stack?.value === true && yScale !== 'log'
 
     if (!hasYAxis && isHorizontal) {
@@ -195,7 +192,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
         tooltip: createTooltipConfig(false, isDark.value),
         legend: { show: false },
         ...groupedAxes,
-        ...(groupedDataZoom ? { dataZoom: groupedDataZoom } : {}),
+        dataZoom: zoom.dataZoom,
         series: [seriesItem],
       } as EChartsOption
     }
@@ -226,13 +223,13 @@ export function useBarChartOptions(config: BaseChartConfig) {
       applyBackgroundToSeries([seriesItem], backgroundStyle)
       return {
         ...baseOptions,
-        grid: createValueModeGridConfig(xNums ? false : largeX),
+        grid: createValueModeGridConfig(zoom.hasXSlider),
         tooltip: xNums
           ? createValueModeTooltip(isDark.value, xLabel, chartData.value.axisLabels?.y, true)
           : createTooltipConfig(false, isDark.value),
         legend: { show: false },
         ...groupedAxes,
-        ...(groupedDataZoom ? { dataZoom: groupedDataZoom } : {}),
+        dataZoom: zoom.dataZoom,
         series: [seriesItem],
       } as EChartsOption
     }
@@ -318,7 +315,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
           { bottom: 0 }
         ),
         ...groupedAxes,
-        ...(groupedDataZoom ? { dataZoom: groupedDataZoom } : {}),
+        dataZoom: zoom.dataZoom,
         series: transposedSeries,
       } as EChartsOption
     }
@@ -326,7 +323,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
     return {
       ...baseOptions,
       ...(showLegendTitle ? { title: makeLegendTitle(yLabel!, styling) } : {}),
-      grid: createGridConfig(transposedSeries.length, xNums ? false : largeX, showLegendTitle),
+      grid: createGridConfig(transposedSeries.length, zoom.hasXSlider, showLegendTitle),
       tooltip: xNums
         ? hasMultipleSeries
           ? createTooltipConfig(hasXAxis(chartData), isDark.value, seriesTotals, 'line')
@@ -339,7 +336,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
         showLegendTitle ? { top: 24 } : undefined
       ),
       ...groupedAxes,
-      ...(groupedDataZoom ? { dataZoom: groupedDataZoom } : {}),
+      dataZoom: zoom.dataZoom,
       series: transposedSeries,
     } as EChartsOption
   })

--- a/ui/src/composables/charts/useCategorySeriesChartOptions.test.ts
+++ b/ui/src/composables/charts/useCategorySeriesChartOptions.test.ts
@@ -89,7 +89,9 @@ describe('useCategorySeriesChartOptions — line', () => {
     const series = options.value.series as { symbol?: string; sampling?: string }[]
     expect(series[0]!.symbol).toBe('none')
     expect(series[0]!.sampling).toBe('lttb')
-    expect(options.value.dataZoom).toBeDefined()
+    const dataZoom = options.value.dataZoom as { type: string }[]
+    expect(dataZoom).toHaveLength(1)
+    expect(dataZoom[0]!.type).toBe('slider')
   })
 
   it('omits legend title when y axis label missing', () => {
@@ -233,6 +235,24 @@ describe('useCategorySeriesChartOptions — remaining branches', () => {
     expect(series[1]!.data).toEqual([[2, null]])
   })
 
+  it('gives scatter log-X inside zoom and line log-X none', () => {
+    const chartData = emptyChartData({
+      title: 'steps',
+      yAxis: [],
+      series: [
+        { xAxis: '1', values: [10], benchmarkId: '' },
+        { xAxis: '2', values: [20], benchmarkId: '' },
+      ],
+      axisLabels: { x: 'step' },
+    })
+    const cfg = baseConfig({ chartData, scale: { type: 'log', axes: ['x'] } })
+    expect(useCategorySeriesChartOptions(cfg, 'line').options.value.dataZoom).toBeUndefined()
+    expect(useCategorySeriesChartOptions(cfg, 'scatter').options.value.dataZoom).toEqual([
+      { type: 'inside', xAxisIndex: 0 },
+      { type: 'inside', yAxisIndex: 0 },
+    ])
+  })
+
   it('smooth x-only lines and large grouped dataZoom', () => {
     const { options } = useCategorySeriesChartOptions(
       baseConfig({ chartData: xOnly(), smooth: true }),
@@ -245,6 +265,8 @@ describe('useCategorySeriesChartOptions — remaining branches', () => {
       series: many.map((x) => ({ xAxis: x, values: [1, 2], benchmarkId: '' })),
     })
     const { options: wide } = useCategorySeriesChartOptions(baseConfig({ chartData }), 'line')
-    expect(wide.value.dataZoom).toBeDefined()
+    const dataZoom = wide.value.dataZoom as { type: string }[]
+    expect(dataZoom).toHaveLength(1)
+    expect(dataZoom[0]!.type).toBe('slider')
   })
 })

--- a/ui/src/composables/charts/useCategorySeriesChartOptions.ts
+++ b/ui/src/composables/charts/useCategorySeriesChartOptions.ts
@@ -4,7 +4,6 @@ import { type BaseChartConfig, getBaseOptions } from './baseChartOptions'
 import { getNextColorFor, hasXAxis } from '@/lib/utils'
 import {
   createAxisConfig,
-  createDataZoomConfig,
   createGridConfig,
   createValueModeGridConfig,
   createLabelConfig,
@@ -16,8 +15,8 @@ import {
   getChartStyling,
   isLargeXAxis,
   makeLegendTitle,
-  INSIDE_XY_ZOOM,
   LARGE_DATA_THRESHOLD,
+  resolveCartesianDataZoom,
   scatterSeriesLargeOpts,
 } from './shared/chartConfig'
 import {
@@ -105,11 +104,11 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
           yLogBase,
         })
       : createAxisConfig(styling, xAxisData, yScale, xLabel, largeX, true, yLogBase)
-    const groupedDataZoom = coerceX
-      ? INSIDE_XY_ZOOM
-      : largeX
-        ? createDataZoomConfig(xAxisData, styling)
-        : undefined
+    const zoom = resolveCartesianDataZoom(kind, {
+      numericX: coerceX,
+      largeX,
+      styling,
+    })
     const seriesExtras = resolveSeriesSymbol(
       largeX ? style.largeSymbol : style.defaultSymbol,
       config.symbol?.value,
@@ -141,12 +140,12 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
       }
       return {
         ...baseOptions,
-        grid: createValueModeGridConfig(coerceX ? false : largeX),
+        grid: createValueModeGridConfig(zoom.hasXSlider),
         tooltip: coerceX
           ? createValueModeTooltip(isDark.value, xLabel, chartData.value.axisLabels?.y, true)
           : createPinnedAxisTooltip(isDark.value),
         ...groupedAxes,
-        ...(groupedDataZoom ? { dataZoom: groupedDataZoom } : {}),
+        ...(zoom.dataZoom ? { dataZoom: zoom.dataZoom } : {}),
         legend: { show: false },
         visualMap: resolve2DScatterVisualMap(
           useVisualMap,
@@ -188,7 +187,7 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
     return {
       ...baseOptions,
       ...(yLabel ? { title: makeLegendTitle(yLabel, styling) } : {}),
-      grid: createGridConfig(transposedSeries.length, coerceX ? false : largeX, !!yLabel),
+      grid: createGridConfig(transposedSeries.length, zoom.hasXSlider, !!yLabel),
       visualMap: resolve2DScatterVisualMap(
         useVisualMap,
         groupedScatterColorValues(transposedSeries),
@@ -201,7 +200,7 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
           : createTooltipConfig(showXBreakdown, isDark.value, seriesTotals, 'line')
         : createTooltipConfig(showXBreakdown, isDark.value, seriesTotals),
       ...groupedAxes,
-      ...(groupedDataZoom ? { dataZoom: groupedDataZoom } : {}),
+      ...(zoom.dataZoom ? { dataZoom: zoom.dataZoom } : {}),
       legend: createLegendConfig(
         transposedSeries.map((s) => ({ xAxis: s.name })),
         styling,

--- a/ui/src/composables/charts/useLineChartOptions.test.ts
+++ b/ui/src/composables/charts/useLineChartOptions.test.ts
@@ -160,6 +160,9 @@ describe('useLineChartOptions — simple 1D', () => {
     expect(grid.top).toBe(VALUE_MODE_GRID_TOP)
     expect(grid.bottom).toBe(100)
     expect(grid.containLabel).toBe(false)
+    const dataZoom = options.value.dataZoom as { type: string }[]
+    expect(dataZoom).toHaveLength(1)
+    expect(dataZoom[0]!.type).toBe('slider')
   })
 
   it('uses no-legend top on numeric log-X 1D lines', () => {
@@ -224,6 +227,9 @@ describe('useLineChartOptions — grouped mode', () => {
     expect(grid.top).toBe(48)
     expect(grid.bottom).toBe(100)
     expect(grid.containLabel).toBe(false)
+    const dataZoom = options.value.dataZoom as { type: string }[]
+    expect(dataZoom).toHaveLength(1)
+    expect(dataZoom[0]!.type).toBe('slider')
   })
 
   it('emits stacked area line series when stack is enabled', () => {
@@ -355,6 +361,7 @@ describe('useLineChartOptions — per-axis log scale', () => {
     expect(grid.top).toBe(48)
     expect(grid.bottom).toBe(28)
     expect(grid.containLabel).toBe(true)
+    expect(options.value.dataZoom).toBeUndefined()
   })
 
   it('does not reserve the category slider band when numeric log-X has many steps', () => {
@@ -372,6 +379,7 @@ describe('useLineChartOptions — per-axis log scale', () => {
     expect(grid.top).toBe(48)
     expect(grid.bottom).toBe(28)
     expect(grid.containLabel).toBe(true)
+    expect(options.value.dataZoom).toBeUndefined()
   })
 
   it('grouped log-X with 2+ y series uses axis tooltip not cross', () => {


### PR DESCRIPTION
## Summary

Line charts no longer pan or wheel-zoom on the canvas. The only line zoom control is the existing category **dataZoom slider**, and only when X categories exceed `LARGE_X_THRESHOLD` (50). Scatter and bar keep inside (and large-category slider) zoom.

Zoom choice for cartesian 2D charts now goes through `resolveCartesianDataZoom` instead of nested ternaries in each builder.

- Line + numeric/log X, value-mode, or ≤50 categories: no `dataZoom`
- Line + category X > 50: slider only (`filterMode: 'filter'`, same 20% window / chrome)
- Scatter / bar: inside zoom; large category X still gets inside + slider (horizontal bars keep the Y slider)
- Mixed scatter/bar with log-X no longer reserve an empty slider band

`sample.json` is not in this PR.

## Test plan

- [x] Focused Vitest on chart option builders and `resolveCartesianDataZoom`
- [x] Lefthook `test:ui:coverage` (100% gates)
- [ ] Line with ≤50 categories: canvas drag and wheel do not pan; no bottom slider
- [ ] Line with >50 categories: bottom slider zooms; canvas drag does not
- [ ] Scatter still canvas-zooms (2D inside)
- [ ] Bar log-X still inside-zooms, no slider; large vertical bar still has the bottom slider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved chart zoom controls across line, scatter, and bar charts.
  * Added adaptive zoom behavior for large datasets, numeric axes, horizontal charts, and mixed chart types.
  * Line charts with numeric axes no longer display unnecessary zoom controls.

* **Bug Fixes**
  * Corrected slider placement and axis zoom behavior for large categorical and mixed charts.
  * Standardized zoom behavior across chart configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->