### PR TITLE
fix(ui): restore line canvas zoom and keep horizontal bar slider working

### DIFF
--- a/ui/src/composables/charts/shared/chartConfig.test.ts
+++ b/ui/src/composables/charts/shared/chartConfig.test.ts
@@ -96,13 +96,16 @@ describe('createDataZoomConfig', () => {
       expect(entry.start).toBe(0)
       expect(entry.end).toBe(DATAZOOM_INITIAL_END_PERCENT)
       expect(entry.xAxisIndex).toBe(0)
+      expect(entry.yAxisIndex).toEqual([])
       expect(entry.filterMode).toBe('filter')
     }
+    expect(dataZoom.map((z) => z.id)).toEqual(['cartesian-x-inside', 'cartesian-x-slider'])
   })
 
   it('keeps slider chrome and themed boundary labels', () => {
     const slider = createDataZoomConfig(xAxisData, styling).find((z) => z.type === 'slider')
     expect(slider).toMatchObject({
+      id: 'cartesian-x-slider',
       bottom: 34,
       height: 28,
       textStyle: { color: styling.textColor },
@@ -447,11 +450,27 @@ describe('createHorizontalDataZoomConfig', () => {
     const dz = createHorizontalDataZoomConfig(styling)
     expect(dz).toHaveLength(2)
     expect(dz[0]).toMatchObject({
+      id: 'cartesian-y-inside',
       type: 'inside',
       yAxisIndex: 0,
+      xAxisIndex: [],
       end: DATAZOOM_INITIAL_END_PERCENT,
+      filterMode: 'none',
+      minValueSpan: 1,
+      moveOnMouseWheel: true,
+      zoomOnMouseWheel: false,
     })
-    expect(dz[1]).toMatchObject({ type: 'slider', yAxisIndex: 0 })
+    expect(dz[1]).toMatchObject({
+      id: 'cartesian-y-slider',
+      type: 'slider',
+      yAxisIndex: 0,
+      xAxisIndex: [],
+      right: 20,
+      width: 20,
+      filterMode: 'none',
+      minValueSpan: 1,
+      showDetail: false,
+    })
   })
 })
 
@@ -485,7 +504,8 @@ describe('createHorizontalAxisConfig log + large', () => {
     expect(axes.xAxis.min).toBe('dataMin')
     expect(axes.xAxis.max).toBe('dataMax')
     expect(axes.yAxis.axisLabel.interval).toBe('auto')
-    expect(axes.yAxis.nameGap).toBe(88)
+    expect(axes.yAxis.nameGap).toBe(30)
+    expect(axes.xAxis.name).toBeNull()
   })
 
   it('adds tick margin when no name and no dataZoom', async () => {

--- a/ui/src/composables/charts/shared/chartConfig.test.ts
+++ b/ui/src/composables/charts/shared/chartConfig.test.ts
@@ -121,14 +121,14 @@ describe('resolveCartesianDataZoom', () => {
     expect(resolveCartesianDataZoom('line', { ...ctx, ...flags })).toEqual({ hasXSlider: false })
   })
 
-  it('uses a slider-only window for large category line axes', () => {
+  it('uses inside+slider for large category line axes', () => {
     const { dataZoom, hasXSlider } = resolveCartesianDataZoom('line', {
       ...ctx,
       numericX: false,
       largeX: true,
     })
     expect(hasXSlider).toBe(true)
-    expect(dataZoom).toEqual(createDataZoomConfig([], styling).filter((z) => z.type === 'slider'))
+    expect(dataZoom).toEqual(createDataZoomConfig([], styling))
   })
 
   it.each(['scatter', 'bar'] as const)(

--- a/ui/src/composables/charts/shared/chartConfig.ts
+++ b/ui/src/composables/charts/shared/chartConfig.ts
@@ -144,8 +144,10 @@ export function createDataZoomConfig(_xAxisData: string[], styling: ChartStyling
   const end = DATAZOOM_INITIAL_END_PERCENT
   return [
     {
+      id: 'cartesian-x-inside',
       type: 'inside',
       xAxisIndex: 0,
+      yAxisIndex: [],
       start: 0,
       end,
       filterMode: 'filter',
@@ -154,10 +156,13 @@ export function createDataZoomConfig(_xAxisData: string[], styling: ChartStyling
     // name, which is pushed below it via a larger nameGap. Heights coordinated
     // with createGridConfig's fixed px bottom so spacing is stable across sizes.
     // textStyle colors the left/right boundary labels to match the theme text
-    // (ECharts' default gray is too dim in dark mode).
+    // (ECharts' default gray is too dim in dark mode). Distinct ids so
+    // vue-echarts 8 replaceMerges this pair when swapping to a Y slider.
     {
+      id: 'cartesian-x-slider',
       type: 'slider',
       xAxisIndex: 0,
+      yAxisIndex: [],
       start: 0,
       end,
       bottom: 34,
@@ -172,20 +177,33 @@ export function createHorizontalDataZoomConfig(styling: ChartStyling): any[] {
   const end = DATAZOOM_INITIAL_END_PERCENT
   return [
     {
+      id: 'cartesian-y-inside',
       type: 'inside',
       yAxisIndex: 0,
+      xAxisIndex: [],
       start: 0,
       end,
-      filterMode: 'filter',
+      // Viewport the inverted Y list; 'filter' deletes off-window categories
+      // and can empty the plot when the window hits 0 at the slider end.
+      filterMode: 'none',
+      minValueSpan: 1,
+      // Wheel pans the list. Do not zoomLock: ECharts then skips mousewheel
+      // entirely (including pan). zoomOnMouseWheel false keeps the window size.
+      moveOnMouseWheel: true,
+      zoomOnMouseWheel: false,
     },
     {
+      id: 'cartesian-y-slider',
       type: 'slider',
       yAxisIndex: 0,
+      xAxisIndex: [],
       start: 0,
       end,
       right: 20,
       width: 20,
-      filterMode: 'filter',
+      filterMode: 'none',
+      minValueSpan: 1,
+      showDetail: false,
       textStyle: { color: styling.textColor },
     },
   ]
@@ -467,6 +485,8 @@ export function createHorizontalAxisConfig(
     nameMoveOverlap: false,
     inverse: false,
     data: null,
+    // Clear a sticky category-axis title after toggling off horizontal.
+    name: null,
     splitLine: {
       lineStyle: { opacity: styling.opacity },
     },
@@ -491,7 +511,8 @@ export function createHorizontalAxisConfig(
         ? {
             name: categoryAxisName,
             nameLocation: 'middle',
-            nameGap: hasDataZoom ? 88 : 30,
+            // Y slider sits on the right; 88px is the bottom X-slider band.
+            nameGap: 30,
             nameTextStyle: axisNameStyle,
           }
         : {}),
@@ -859,6 +880,7 @@ export function createLegendConfig(
 // (the y group on 2D bar/line). ECharts legends have no native title.
 export function makeLegendTitle(text: string, styling: ChartStyling): any {
   return {
+    show: true,
     text,
     left: 'center',
     top: 0,

--- a/ui/src/composables/charts/shared/chartConfig.ts
+++ b/ui/src/composables/charts/shared/chartConfig.ts
@@ -201,13 +201,10 @@ export function resolveCartesianDataZoom(
   }
 ): { dataZoom?: any[]; hasXSlider: boolean } {
   if (chartType === 'line') {
-    if (!ctx.numericX && ctx.largeX) {
-      return {
-        dataZoom: createDataZoomConfig([], ctx.styling).filter((z) => z.type === 'slider'),
-        hasXSlider: true,
-      }
+    if (ctx.numericX || !ctx.largeX) {
+      return { hasXSlider: false }
     }
-    return { hasXSlider: false }
+    return { dataZoom: createDataZoomConfig([], ctx.styling), hasXSlider: true }
   }
   if (ctx.numericX || !ctx.largeX) {
     return { dataZoom: INSIDE_XY_ZOOM, hasXSlider: false }

--- a/ui/src/composables/charts/shared/mixedMode.test.ts
+++ b/ui/src/composables/charts/shared/mixedMode.test.ts
@@ -130,6 +130,7 @@ function series0(option: ReturnType<typeof buildMixedAxes2DOptions>) {
     symbol?: string
     symbolSize?: number
     sampling?: string
+    showAllSymbol?: boolean
     itemStyle?: { color?: string }
     label?: { formatter?: (p: { data: [number, number | null] }) => string }
   }
@@ -219,6 +220,7 @@ describe('buildMixedAxes2DOptions', () => {
     expect(series0(line).type).toBe('line')
     expect(series0(line).smooth).toBe(true)
     expect(series0(line).symbolSize).toBe(7)
+    expect(series0(line).showAllSymbol).toBe(true)
   })
 
   it('uses large symbols and dataZoom when categories exceed threshold', () => {
@@ -231,11 +233,12 @@ describe('buildMixedAxes2DOptions', () => {
       'line'
     )
     const s = series0(option)
-    expect(s.symbol).toBe('none')
-    expect(s.sampling).toBe('lttb')
+    expect(s.symbol).toBe('circle')
+    expect(s.symbolSize).toBe(7)
+    expect(s.sampling).toBeUndefined()
+    expect(s.showAllSymbol).toBe(true)
     const dataZoom = option.dataZoom as { type: string }[]
-    expect(dataZoom).toHaveLength(1)
-    expect(dataZoom[0]!.type).toBe('slider')
+    expect(dataZoom.map((z) => z.type)).toEqual(['inside', 'slider'])
 
     const scatter = buildMixedAxes2DOptions(
       cfg({

--- a/ui/src/composables/charts/shared/mixedMode.ts
+++ b/ui/src/composables/charts/shared/mixedMode.ts
@@ -36,7 +36,6 @@ import type { Series3DData } from '@/types'
 const defaultScatterSymbol = { symbol: 'circle' as const, symbolSize: 8 }
 const largeScatterSymbol = { symbol: 'circle' as const, symbolSize: 5 }
 const defaultLineSymbol = { symbol: 'circle' as const, symbolSize: 7 }
-const largeLineSymbol = { symbol: 'none' as const, sampling: 'lttb' as const }
 
 export type Mixed2DChartType = 'scatter' | 'bar' | 'line'
 export type Mixed3DChartType = 'scatter3D' | 'bar3D' | 'line3D'
@@ -163,8 +162,9 @@ export function buildMixedAxes2DOptions(
             large: true,
             largeThreshold: LARGE_DATA_THRESHOLD,
             smooth: smoothLines,
+            showAllSymbol: true as const,
             ...resolveSeriesSymbol(
-              largeX ? largeLineSymbol : defaultLineSymbol,
+              defaultLineSymbol,
               config.symbol?.value,
               config.symbolSize?.value
             ),

--- a/ui/src/composables/charts/shared/valueMode.test.ts
+++ b/ui/src/composables/charts/shared/valueMode.test.ts
@@ -86,6 +86,7 @@ function seriesOf(option: ReturnType<typeof buildValueAxes2DOptions>) {
     symbol?: string
     symbolSize?: number
     sampling?: string
+    showAllSymbol?: boolean
     itemStyle?: { color?: string }
     label?: { formatter?: (p: { data: [number, number | null, number?] }) => string }
   }
@@ -198,7 +199,7 @@ describe('buildValueAxes2DOptions', () => {
     expect(s.symbol).toBeUndefined()
   })
 
-  it('applies large scatter/line symbols when point count exceeds threshold', () => {
+  it('shrinks large scatter symbols and keeps line dots when point count exceeds threshold', () => {
     const many = Array.from(
       { length: LARGE_X_THRESHOLD + 1 },
       (_, i) => [i, i + 1] as [number, number]
@@ -214,8 +215,10 @@ describe('buildValueAxes2DOptions', () => {
       'line'
     )
     const ls = seriesOf(line)
-    expect(ls.symbol).toBe('none')
-    expect(ls.sampling).toBe('lttb')
+    expect(ls.symbol).toBe('circle')
+    expect(ls.symbolSize).toBe(7)
+    expect(ls.sampling).toBeUndefined()
+    expect(ls.showAllSymbol).toBe(true)
   })
 
   it('uses default symbols for small scatter/line and honors overrides', () => {
@@ -233,6 +236,7 @@ describe('buildValueAxes2DOptions', () => {
 
     const line = buildValueAxes2DOptions(cfg(), 'line')
     expect(seriesOf(line).symbolSize).toBe(7)
+    expect(seriesOf(line).showAllSymbol).toBe(true)
     expect(line.dataZoom).toBeUndefined()
   })
 

--- a/ui/src/composables/charts/shared/valueMode.ts
+++ b/ui/src/composables/charts/shared/valueMode.ts
@@ -21,7 +21,6 @@ import { resolve2DScatterVisualMap } from './visualMap'
 const defaultScatterSymbol = { symbol: 'circle' as const, symbolSize: 8 }
 const largeScatterSymbol = { symbol: 'circle' as const, symbolSize: 5 }
 const defaultLineSymbol = { symbol: 'circle' as const, symbolSize: 7 }
-const largeLineSymbol = { symbol: 'none', sampling: 'lttb' as const }
 
 export function sortValueTuples(
   tuples: [number, number, number?][],
@@ -67,7 +66,7 @@ const seriesSymbol = (
     )
   }
   if (chartType === 'line') {
-    return resolveSeriesSymbol(largeX ? largeLineSymbol : defaultLineSymbol, symbol, symbolSize)
+    return resolveSeriesSymbol(defaultLineSymbol, symbol, symbolSize)
   }
   return {}
 }
@@ -122,7 +121,7 @@ export function buildValueAxes2DOptions(
     ...(chartType === 'scatter'
       ? scatterSeriesLargeOpts(useVisualMap)
       : { large: true as const, largeThreshold: LARGE_DATA_THRESHOLD }),
-    ...(chartType === 'line' ? { smooth: smoothLines } : {}),
+    ...(chartType === 'line' ? { smooth: smoothLines, showAllSymbol: true as const } : {}),
     ...(useVisualMap ? {} : { itemStyle: { color: getNextColorFor(chartData.value.title) } }),
     ...seriesSymbol(chartType, largeX, config.symbol?.value, config.symbolSize?.value),
   }

--- a/ui/src/composables/charts/useBarChartOptions.test.ts
+++ b/ui/src/composables/charts/useBarChartOptions.test.ts
@@ -9,7 +9,13 @@ import {
   makeNumericStepChartData,
   baseConfig,
 } from '@/test-utils'
-import { LARGE_X_THRESHOLD, VALUE_MODE_GRID_TOP } from './shared/chartConfig'
+import {
+  LARGE_X_THRESHOLD,
+  VALUE_MODE_GRID_TOP,
+  createDataZoomConfig,
+  createHorizontalDataZoomConfig,
+  getChartStyling,
+} from './shared/chartConfig'
 
 let restoreDpr = installDevicePixelRatio()
 afterAll(() => restoreDpr())
@@ -285,7 +291,7 @@ describe('useBarChartOptions — horizontal mode', () => {
     expect((opt.yAxis as { type: string }).type).toBe('category')
     expect((opt.yAxis as { data: string[] }).data).toEqual(['A', 'B', 'C'])
     expect((opt.yAxis as { name?: string }).name).toBe('category')
-    expect((opt.xAxis as { name?: string }).name).toBeUndefined()
+    expect((opt.xAxis as { name?: string | null }).name).toBeNull()
   })
 
   it('renders horizontal grouped bars with correct series', () => {
@@ -294,7 +300,7 @@ describe('useBarChartOptions — horizontal mode', () => {
     expect((opt.xAxis as { type: string }).type).toBe('value')
     expect((opt.yAxis as { type: string }).type).toBe('category')
     expect((opt.yAxis as { name?: string }).name).toBe('category')
-    expect((opt.xAxis as { name?: string }).name).toBeUndefined()
+    expect((opt.xAxis as { name?: string | null }).name).toBeNull()
     const series = opt.series as { type: string; name: string; data: number[] }[]
     expect(series.length).toBe(2)
     expect(series[0]!.name).toBe('North')
@@ -588,8 +594,9 @@ describe('useBarChartOptions — value mode and branches', () => {
       isDark: ref(false),
       horizontal: ref(true),
     })
-    expect(options.value.dataZoom).toBeDefined()
-    expect((options.value.grid as { right?: number }).right).toBe(44)
+    expect(options.value.dataZoom).toEqual(createHorizontalDataZoomConfig(getChartStyling(false)))
+    expect((options.value.grid as { right?: number; outerBoundsMode?: string }).right).toBe(44)
+    expect((options.value.grid as { outerBoundsMode?: string }).outerBoundsMode).toBe('none')
   })
 
   it('adds vertical dataZoom for large simple categories', () => {
@@ -609,7 +616,7 @@ describe('useBarChartOptions — value mode and branches', () => {
       showLabels: ref(false),
       isDark: ref(false),
     })
-    expect(options.value.dataZoom).toBeDefined()
+    expect(options.value.dataZoom).toEqual(createDataZoomConfig([], getChartStyling(false)))
   })
 
   it('handles horizontal simple bars without x label', () => {
@@ -661,7 +668,9 @@ describe('useBarChartOptions — value mode and branches', () => {
       isDark: ref(false),
       horizontal: ref(true),
     })
-    expect(options.value.dataZoom).toBeDefined()
+    expect(options.value.dataZoom).toEqual(createHorizontalDataZoomConfig(getChartStyling(false)))
+    expect((options.value.grid as { outerBoundsMode?: string }).outerBoundsMode).toBe('none')
+    expect(options.value.title).toBeUndefined()
   })
 })
 

--- a/ui/src/composables/charts/useBarChartOptions.ts
+++ b/ui/src/composables/charts/useBarChartOptions.ts
@@ -188,6 +188,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
           bottom: '3%',
           top: 8,
           containLabel: true,
+          outerBoundsMode: 'none',
         },
         tooltip: createTooltipConfig(false, isDark.value),
         legend: { show: false },
@@ -306,6 +307,7 @@ export function useBarChartOptions(config: BaseChartConfig) {
           bottom: hasMultipleSeries ? legendBandPx(transposedSeries.length) : '3%',
           top: 8,
           containLabel: true,
+          outerBoundsMode: 'none',
         },
         tooltip: createTooltipConfig(hasXAxis(chartData), isDark.value, seriesTotals),
         legend: createLegendConfig(

--- a/ui/src/composables/charts/useCategorySeriesChartOptions.test.ts
+++ b/ui/src/composables/charts/useCategorySeriesChartOptions.test.ts
@@ -78,7 +78,7 @@ describe('useCategorySeriesChartOptions — line', () => {
     expect((options.value.tooltip as { trigger?: string }).trigger).toBe('axis')
   })
 
-  it('uses large-series symbol none and dataZoom for wide x axes', () => {
+  it('keeps line dots and dataZoom for wide x axes', () => {
     const many = Array.from({ length: LARGE_X_THRESHOLD + 1 }, (_, i) => `x${i}`)
     const chartData = emptyChartData({
       title: 'wide',
@@ -86,12 +86,18 @@ describe('useCategorySeriesChartOptions — line', () => {
       axisLabels: { x: 'x' },
     })
     const { options } = useCategorySeriesChartOptions(baseConfig({ chartData }), 'line')
-    const series = options.value.series as { symbol?: string; sampling?: string }[]
-    expect(series[0]!.symbol).toBe('none')
-    expect(series[0]!.sampling).toBe('lttb')
+    const series = options.value.series as {
+      symbol?: string
+      symbolSize?: number
+      sampling?: string
+      showAllSymbol?: boolean
+    }[]
+    expect(series[0]!.symbol).toBe('circle')
+    expect(series[0]!.symbolSize).toBe(7)
+    expect(series[0]!.sampling).toBeUndefined()
+    expect(series[0]!.showAllSymbol).toBe(true)
     const dataZoom = options.value.dataZoom as { type: string }[]
-    expect(dataZoom).toHaveLength(1)
-    expect(dataZoom[0]!.type).toBe('slider')
+    expect(dataZoom.map((z) => z.type)).toEqual(['inside', 'slider'])
   })
 
   it('omits legend title when y axis label missing', () => {
@@ -266,7 +272,6 @@ describe('useCategorySeriesChartOptions — remaining branches', () => {
     })
     const { options: wide } = useCategorySeriesChartOptions(baseConfig({ chartData }), 'line')
     const dataZoom = wide.value.dataZoom as { type: string }[]
-    expect(dataZoom).toHaveLength(1)
-    expect(dataZoom[0]!.type).toBe('slider')
+    expect(dataZoom.map((z) => z.type)).toEqual(['inside', 'slider'])
   })
 })

--- a/ui/src/composables/charts/useCategorySeriesChartOptions.ts
+++ b/ui/src/composables/charts/useCategorySeriesChartOptions.ts
@@ -37,13 +37,13 @@ const SERIES_STYLE: Record<
   CategorySeriesKind,
   {
     defaultSymbol: { symbol: 'circle'; symbolSize: number }
-    largeSymbol: { symbol: 'circle' | 'none'; symbolSize?: number; sampling?: 'lttb' }
+    largeSymbol: { symbol: 'circle'; symbolSize: number }
     connectNulls?: true
   }
 > = {
   line: {
     defaultSymbol: { symbol: 'circle', symbolSize: 7 },
-    largeSymbol: { symbol: 'none', sampling: 'lttb' },
+    largeSymbol: { symbol: 'circle', symbolSize: 7 },
     connectNulls: true,
   },
   scatter: {
@@ -134,7 +134,7 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
           ? scatterSeriesLargeOpts(useVisualMap)
           : { large: true as const, largeThreshold: LARGE_DATA_THRESHOLD }),
         ...(style.connectNulls ? { connectNulls: true } : {}),
-        ...(kind === 'line' ? { smooth: smoothLines } : {}),
+        ...(kind === 'line' ? { smooth: smoothLines, showAllSymbol: true as const } : {}),
         ...(useVisualMap ? {} : { itemStyle: { color: getNextColorFor(chartData.value.title) } }),
         ...seriesExtras,
       }
@@ -174,7 +174,12 @@ export function useCategorySeriesChartOptions(config: BaseChartConfig, kind: Cat
         : { large: true as const, largeThreshold: LARGE_DATA_THRESHOLD }),
       ...(style.connectNulls ? { connectNulls: true } : {}),
       ...(kind === 'line'
-        ? { smooth: smoothLines, stack: useStack ? 'total' : null, areaStyle: useStack ? {} : null }
+        ? {
+            smooth: smoothLines,
+            stack: useStack ? 'total' : null,
+            areaStyle: useStack ? {} : null,
+            showAllSymbol: true as const,
+          }
         : {}),
       ...(useVisualMap ? {} : { itemStyle: { color: getNextColorFor(yAxisLabel) } }),
       ...seriesExtras,

--- a/ui/src/composables/charts/useLineChartOptions.test.ts
+++ b/ui/src/composables/charts/useLineChartOptions.test.ts
@@ -161,8 +161,7 @@ describe('useLineChartOptions — simple 1D', () => {
     expect(grid.bottom).toBe(100)
     expect(grid.containLabel).toBe(false)
     const dataZoom = options.value.dataZoom as { type: string }[]
-    expect(dataZoom).toHaveLength(1)
-    expect(dataZoom[0]!.type).toBe('slider')
+    expect(dataZoom.map((z) => z.type)).toEqual(['inside', 'slider'])
   })
 
   it('uses no-legend top on numeric log-X 1D lines', () => {
@@ -228,8 +227,7 @@ describe('useLineChartOptions — grouped mode', () => {
     expect(grid.bottom).toBe(100)
     expect(grid.containLabel).toBe(false)
     const dataZoom = options.value.dataZoom as { type: string }[]
-    expect(dataZoom).toHaveLength(1)
-    expect(dataZoom[0]!.type).toBe('slider')
+    expect(dataZoom.map((z) => z.type)).toEqual(['inside', 'slider'])
   })
 
   it('emits stacked area line series when stack is enabled', () => {


### PR DESCRIPTION
## Summary

Follow-up to #425 for cartesian zoom:

- **Line:** large category X (>50) uses inside + slider again, so wheel zoom and drag pan work when the slider is present. Small / numeric / log-X lines stay unzoomed. Line series keep circle dots instead of hiding them with LTTB at the slider threshold.
- **Horizontal bar:** Y dataZoom windows the inverted category axis (`filterMode: 'none'`) instead of deleting dates, so scrolling to the end cannot blank the plot. Distinct zoom ids `replaceMerge` when toggling orientation so the X slider cannot stick as a stub. Wheel pans the date list without resizing the slider window.

`sample.json` is not in this PR.

## Test plan

- [x] Focused Vitest on line/bar option builders and `resolveCartesianDataZoom`
- [x] Lefthook `test:ui:coverage` (100% gates)
- [ ] Line, ≤50 categories: no slider; wheel/drag do not pan
- [ ] Line, >50 categories: bottom slider **and** canvas wheel/drag; dots stay visible
- [ ] Bar, >50 categories, horizontal: right Y slider; wheel pans the list; scrolling to the last row does not empty the chart
- [ ] Toggle Horizontal on/off for a large-X bar: Y slider stays a full vertical track (not a bottom-right stub); toggle back restores the X slider
- [ ] Vertical bar / scatter zoom unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved navigation and zoom controls for large categorical line charts with both interactive and slider-based zooming.
  - Large line and scatter charts now consistently display circular data points for improved visibility.
  - Refined horizontal chart navigation, including smoother panning and clearer axis labeling.
  - Improved chart layout boundaries and legend title visibility for horizontal bar charts.
- **Bug Fixes**
  - Prevented stale category-axis titles from appearing when chart configurations change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->