### PR TITLE
feat(cli): add pie --donut flag with filled-pie default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Notable changes to Vizb documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased]
+
+### Added
+
+- **cli** — Add pie `--donut` flag
+
+### Changed
+
+- **cli** — Default pie charts to filled (missing `donut` means filled pie, not a hole)
+
 # [v0.20.0] - 2026-08-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adhere
 ### Added
 
 - **cli** — Add pie `--donut` flag
+- **api** — Accept donut on PieChartConfig
 
 ### Changed
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -834,6 +834,7 @@ components:
         swap: { type: string }
         sort: { $ref: '#/components/schemas/Sort' }
         showLabels: { type: boolean }
+        donut: { type: boolean }
         stat: { $ref: '#/components/schemas/StatisticsConfig' }
     HeatmapChartConfig:
       type: object

--- a/cmd/charts/pie/pie.go
+++ b/cmd/charts/pie/pie.go
@@ -10,7 +10,7 @@ import (
 
 func init() {
 	charts.Register(charts.Spec{Type: "pie", Factory: piechart.New})
-	charts.SetFlags("pie", slices.Clone(charts.BaseChartFlags))
+	charts.SetFlags("pie", append(slices.Clone(charts.BaseChartFlags), charts.DonutFlag))
 	cli.SetChartMeta(cli.ChartMeta{
 		Type:  "pie",
 		Use:   "pie [target]",

--- a/cmd/cli/command_test.go
+++ b/cmd/cli/command_test.go
@@ -47,6 +47,7 @@ func (s *CommandSuite) TestVariableFlagsBoundPerChart() {
 	pie := s.byUse["pie"]
 	s.Nil(pie.Flags().Lookup("scale"))
 	s.NotNil(pie.Flags().Lookup("swap"))
+	s.NotNil(pie.Flags().Lookup("donut"))
 
 	// sankey uses BaseChartFlags only (no scale/stack/3d/visualMap).
 	sankey := s.byUse["sankey"]

--- a/internal/charts/chord/chord_test.go
+++ b/internal/charts/chord/chord_test.go
@@ -60,7 +60,7 @@ func (s *ChordSuite) TestJSONOmitsInapplicableChartFields() {
 
 	var m map[string]any
 	s.Require().NoError(json.Unmarshal(raw, &m))
-	for _, key := range []string{"scale", "stack", "threeD", "threeDRotate", "threeDVisualMap", "visualMap", "smooth", "horizontal"} {
+	for _, key := range []string{"scale", "stack", "threeD", "threeDRotate", "threeDVisualMap", "visualMap", "smooth", "horizontal", "donut"} {
 		_, ok := m[key]
 		s.False(ok, "chord JSON must not carry %q", key)
 	}

--- a/internal/charts/flag.go
+++ b/internal/charts/flag.go
@@ -102,6 +102,12 @@ var (
 		Kind:    flags.KindBool,
 		JSONKey: "smooth",
 	}
+	DonutFlag = flags.Flag{
+		Name:    "donut",
+		Usage:   "Render as a donut (hole); default is a filled pie",
+		Kind:    flags.KindBool,
+		JSONKey: "donut",
+	}
 	HorizontalFlag = flags.Flag{
 		Name:    "horizontal",
 		Usage:   "Horizontal bars (categories on Y, values on X)",

--- a/internal/charts/materialise_test.go
+++ b/internal/charts/materialise_test.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/goptics/vizb/cmd/charts/bar"
 	_ "github.com/goptics/vizb/cmd/charts/heatmap"
 	_ "github.com/goptics/vizb/cmd/charts/line"
+	_ "github.com/goptics/vizb/cmd/charts/pie"
 	_ "github.com/goptics/vizb/cmd/charts/radar"
 	"github.com/goptics/vizb/internal/charts"
 	barchart "github.com/goptics/vizb/internal/charts/bar"
@@ -105,6 +106,13 @@ func (s *MaterialiseSuite) TestLineSmoothSeed() {
 	got := s.materialise("line", seed, nil).(*linechart.Config)
 	s.Require().NotNil(got.Smooth)
 	s.True(*got.Smooth)
+}
+
+func (s *MaterialiseSuite) TestPieDonutSeed() {
+	seed := map[string]any{"donut": true}
+	got := s.materialise("pie", seed, nil).(*piechart.Config)
+	s.Require().NotNil(got.Donut)
+	s.True(*got.Donut)
 }
 
 func (s *MaterialiseSuite) TestStatSeed() {

--- a/internal/charts/pie/pie.go
+++ b/internal/charts/pie/pie.go
@@ -15,6 +15,7 @@ type Config struct {
 	Swap       string             `json:"swap,omitempty"`
 	Sort       *shared.Sort       `json:"sort,omitempty"`
 	ShowLabels *bool              `json:"showLabels,omitempty"`
+	Donut      *bool              `json:"donut,omitempty"`
 	Stat       *shared.StatConfig `json:"stat,omitempty"`
 }
 

--- a/internal/charts/registry_test.go
+++ b/internal/charts/registry_test.go
@@ -74,6 +74,21 @@ func (s *RegistrySuite) TestSmoothFlagIsLineOnly() {
 	}
 }
 
+func (s *RegistrySuite) TestDonutFlagIsPieOnly() {
+	flagNames := func(chartType string) map[string]bool {
+		out := map[string]bool{}
+		for _, f := range charts.FlagsFor(chartType) {
+			out[f.EffectiveKey()] = true
+		}
+		return out
+	}
+
+	s.True(flagNames("pie")["donut"])
+	for _, chartType := range []string{"bar", "line", "scatter", "heatmap", "radar", "sankey", "chord"} {
+		s.False(flagNames(chartType)["donut"], "%s should not register donut", chartType)
+	}
+}
+
 func (s *RegistrySuite) TestHorizontalFlagIsBarOnly() {
 	flagNames := func(chartType string) map[string]bool {
 		out := map[string]bool{}

--- a/internal/charts/sankey/sankey_test.go
+++ b/internal/charts/sankey/sankey_test.go
@@ -62,7 +62,7 @@ func (s *SankeySuite) TestJSONOmitsInapplicableChartFields() {
 	s.Require().NoError(json.Unmarshal(raw, &m))
 	// Sankey is a flow layout: scale/stack/3D/visualMap never apply and must
 	// not leak into the emitted config JSON.
-	for _, key := range []string{"scale", "stack", "threeD", "threeDRotate", "threeDVisualMap", "visualMap", "smooth", "horizontal"} {
+	for _, key := range []string{"scale", "stack", "threeD", "threeDRotate", "threeDVisualMap", "visualMap", "smooth", "horizontal", "donut"} {
 		_, ok := m[key]
 		s.False(ok, "sankey JSON must not carry %q", key)
 	}

--- a/shared/chart_spec_test.go
+++ b/shared/chart_spec_test.go
@@ -87,6 +87,19 @@ func (s *ChartSpecSuite) TestParseOverridesLineSmooth() {
 	s.Nil(s.payload(got["bar"])["smooth"])
 }
 
+func (s *ChartSpecSuite) TestParseOverridesPieDonut() {
+	got, warnings, err := ParseOverrides([]string{"pie:donut"}, []string{"pie"}, s.xynAxes)
+	s.Require().NoError(err)
+	s.Empty(warnings)
+	s.Equal(true, s.payload(got["pie"])["donut"])
+
+	got, warnings, err = ParseOverrides([]string{"bar:donut"}, []string{"bar"}, s.xynAxes)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(warnings)
+	s.Contains(warnings[0], "donut")
+	s.Nil(s.payload(got["bar"])["donut"])
+}
+
 func (s *ChartSpecSuite) TestParseOverridesBarHorizontal() {
 	got, warnings, err := ParseOverrides([]string{"bar:horizontal"}, []string{"bar"}, s.xynAxes)
 	s.Require().NoError(err)


### PR DESCRIPTION
## Summary

Adds pie-only `--donut` with a **filled pie** default. Missing `donut` in JSON means filled. `--donut` and `--chart pie:donut` seed `"donut": true`.

Also adds OpenAPI `PieChartConfig.donut` in the same PR so `TestReusableSchemasMatchGoWireTypes` stays lockstep (CLI `pie.Config` and the schema cannot land on opposite sides of `main`).

Closes #429
Closes #430

## Acceptance

- [x] `vizb pie --help` lists `--donut`
- [x] `vizb pie` JSON settings omit `donut`
- [x] `vizb pie --donut` and `--chart pie:donut` set `"donut": true`
- [x] `FlagsFor("pie")` includes `donut`; other chart types do not
- [x] `bar:donut` warns and does not seed bar config
- [x] CHANGELOG **Changed** (breaking filled-pie default) + **Added** (`--donut`)
- [x] `go test -count=1 ./api` passes against `pie.Config` with `Donut`

## Tests run

- `go test -count=1 ./internal/charts ./internal/charts/sankey ./internal/charts/chord ./shared ./cmd/cli ./api`
- Real binary: help, default JSON, `--donut`, `--chart pie:donut`, `--chart bar:donut`, `pie --smooth`
- `task lint:cli`, `task format:check:cli`

## Constraints

- Does **not** edit `action.yml` or GitHub Action docs (the Action `chart` input already forwards `--chart pie:donut`).
- Does **not** commit `pkg/template/vizb-ui.gen.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--donut` option for pie charts in the CLI.
  * Added API support for configuring pie charts as donut charts.
  * Donut settings are accepted for pie charts and ignored with a warning for other chart types.

* **Changed**
  * Pie charts now render as filled pies by default when the donut option is not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->