### PR TITLE
docs: add Agent tab to example and install snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@
 
 ## Quick Install
 
+### AI agents
+
+```bash
+npx skills add goptics/skills --skill vizb
+```
+
+Then run `/vizb` in Grok, Claude Code, Cursor, Codex, or any agent the [skills CLI](https://github.com/vercel-labs/skills) supports. [Docs](https://vizb.goptics.org/getting-started/ai-agents/).
+
 ### Linux / macOS
 
 ```bash
@@ -88,14 +96,6 @@ docker run --rm -v "$PWD:/data" -w /data goptics/vizb bar data.csv -o out.html
 The API has no built-in authentication. Keep it private or put authentication,
 TLS, and access controls in front of it. See the [Docker installation guide](https://vizb.goptics.org/getting-started/install/#docker).
 
-### AI agents
-
-```bash
-npx skills add goptics/skills --skill vizb
-```
-
-Then run `/vizb` in Grok, Claude Code, Cursor, Codex, or any agent the [skills CLI](https://github.com/vercel-labs/skills) supports. [Docs](https://vizb.goptics.org/getting-started/ai-agents/).
-
 ## Quick Example
 
 Run one command to turn your GitHub contribution history into a 3D skyline of your activity over time. Each year stacks as a new layer; within it, every day is a column whose height is your contribution count. Replace `<your-github-username>` with your GitHub username and open the generated `index.html`.
@@ -103,6 +103,12 @@ Run one command to turn your GitHub contribution history into a 3D skyline of yo
 ![torvalds contribution history](./assets/torvalds-contribution-history.gif)
 
 Example: [torvalds](https://github.com/torvalds) contribution history
+
+#### Agent
+
+```text
+/vizb as bar, GitHub contributions for <your-github-username>, split date into year, month & date, show stats
+```
 
 #### Linux / macOS
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   </p>
 
   <p>
-    A tabular visualization engine for <strong>CSV, JSON, and benchmark output</strong>. Turns numeric columns into interactive charts and descriptive statistics in one self-contained HTML file - no server, no dependencies, no build step.
+    A tabular visualization engine for <strong>CSV, JSON, and benchmark output</strong>. Turns numeric columns into interactive <a href="https://echarts.apache.org/">Apache ECharts</a> charts and descriptive statistics in one self-contained HTML file - no server, no extra dependencies, no build step.
   </p>
 
   <p>
@@ -107,7 +107,8 @@ Example: [torvalds](https://github.com/torvalds) contribution history
 #### Agent
 
 ```text
-/vizb as bar, GitHub contributions for <your-github-username>, split date into year, month & date, show stats
+/vizb as bar, GitHub contributions for torvalds, split the date in one 3D grouped chart into date, month & year, show stats.
+data source: https://github-contributions-api.jogruber.de/v4/:github-username
 ```
 
 #### Linux / macOS

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "test": "node --test src/lib/agent-md.test.ts src/components/logo-animation/constants.test.ts"
+    "test": "node --test src/lib/agent-md.test.ts src/components/invoke/fromCli.test.ts src/components/logo-animation/constants.test.ts"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.11",

--- a/docs/src/components/InvokeTabs.astro
+++ b/docs/src/components/InvokeTabs.astro
@@ -1,7 +1,7 @@
 ---
 /**
- * CLI / HTTP / Action tabs for one vizb invocation.
- * Pass the CLI command as-is; HTTP and Action are derived.
+ * Agent / CLI / HTTP / Action tabs for one vizb invocation.
+ * Pass the CLI command as-is; Agent, HTTP, and Action are derived.
  */
 import { Tabs, TabItem, Code } from '@astrojs/starlight/components';
 import { snippetsFromCli } from './invoke/fromCli';
@@ -19,6 +19,13 @@ const snippets = snippetsFromCli(cli, input);
 
 <div class="invoke-tabs">
 	<Tabs syncKey="invoke">
+		<TabItem label="Agent">
+			<p class="invoke-tabs__caption">
+				Natural-language prompt after installing the <a href="/getting-started/ai-agents">vizb skill</a>. The
+				agent runs the CLI.
+			</p>
+			<Code code={snippets.agent} lang="text" />
+		</TabItem>
 		<TabItem label="CLI" icon="seti:shell">
 			<Code code={snippets.cli} lang="bash" />
 		</TabItem>

--- a/docs/src/components/QuickInstall.mdx
+++ b/docs/src/components/QuickInstall.mdx
@@ -3,6 +3,13 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <div class="quick-install">
 
 <Tabs syncKey="os">
+  <TabItem label="Agent">
+
+```bash
+npx skills add goptics/skills --skill vizb
+```
+
+  </TabItem>
   <TabItem label="Linux / macOS" icon="seti:shell">
 
 ```bash
@@ -14,13 +21,6 @@ curl -fsSL https://vizb.goptics.org/install.sh | bash
 
 ```ps1
 irm https://vizb.goptics.org/install.ps1 | iex
-```
-
-  </TabItem>
-  <TabItem label="Agent">
-
-```bash
-npx skills add goptics/skills --skill vizb
 ```
 
   </TabItem>

--- a/docs/src/components/invoke/fromCli.test.ts
+++ b/docs/src/components/invoke/fromCli.test.ts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { snippetsFromCli } from './fromCli.ts';
+
+describe('snippetsFromCli agent', () => {
+	it('turns grouped labels into a /vizb prompt and always names the chart', () => {
+		const { agent } = snippetsFromCli(
+			'vizb bar sales.csv -g region,product -p x,y -l -o sales.html',
+		);
+		assert.equal(agent, '/vizb sales.csv as bar by region & product, show labels');
+	});
+
+	it('names bar, pie, and stacked extras', () => {
+		const { agent } = snippetsFromCli(
+			'vizb pie data.csv -g impl -o pie.html',
+		);
+		assert.equal(agent, '/vizb data.csv as pie by impl');
+
+		assert.equal(
+			snippetsFromCli('vizb bar sales.csv -g region,category -p x,y --stack -o stacked.html')
+				.agent,
+			'/vizb sales.csv as bar by region & category, stacked',
+		);
+	});
+
+	it('defaults to as bar when the CLI has no chart type', () => {
+		assert.equal(
+			snippetsFromCli('vizb sales.csv -o sales.html').agent,
+			'/vizb sales.csv as bar',
+		);
+	});
+
+	it('joins --charts types and keeps trivial -p out of the prompt', () => {
+		assert.equal(
+			snippetsFromCli('vizb data.csv -g category,metric -p x,y -c bar,radar -o output.html')
+				.agent,
+			'/vizb data.csv as bar & radar by category & metric',
+		);
+	});
+
+	it('verbalizes bracket patterns, labels, and regex instead of {} [] syntax', () => {
+		assert.equal(
+			snippetsFromCli(
+				'vizb bar sales.csv -g order_date,category -p "[-y{Month}-x{Date}],z{Category}" -o out.html',
+			).agent,
+			'/vizb sales.csv as bar, split order_date into month & date (skip the year), category as depth',
+		);
+		assert.equal(
+			snippetsFromCli(
+				'vizb bar data.csv -g category,metric,group,series --group-regex "(?<n>.*)/(?<x>.*)/(?<y>.*)/(?<z>.*)" -o output.html',
+			).agent,
+			'/vizb data.csv as bar by category, metric, group & series, split by / into name, x, y & depth',
+		);
+	});
+
+	it('does not leave [] {} or regex captures in derived agent prompts', () => {
+		const clis = [
+			'vizb bar sales.csv -g order_date,category -p "[-y{Month}-x{Date}],z{Category}" -o out.html',
+			'vizb pie sales.csv -g order_date,category -p "[-y{Month}-x{Date}],z{Category}" -o out.html',
+			'vizb bar data.csv -g category,metric,group,series --group-regex "(?<n>.*)/(?<x>.*)/(?<y>.*)/(?<z>.*)" -o output.html',
+			'vizb line worker-pools.txt -p z/y/x --scale log -o out.html',
+		];
+		for (const cli of clis) {
+			const { agent } = snippetsFromCli(cli);
+			assert.equal(/[\[\]{}]/.test(agent), false, agent);
+			assert.equal(agent.includes('?<'), false, agent);
+			assert.match(agent, / as (?:bar|line|scatter|pie|heatmap|radar|sankey|chord)\b/);
+		}
+	});
+
+	it('joins select columns and repeats with a semicolon', () => {
+		assert.equal(
+			snippetsFromCli(
+				'vizb bar sales.csv -g region,product -p x,y --select amount,quantity -o bars.html',
+			).agent,
+			'/vizb sales.csv as bar by region & product, amount & quantity',
+		);
+		assert.equal(
+			snippetsFromCli(
+				`vizb sankey sankey-flows.csv \\
+  --select source,target,value \\
+  --select source,target,cost \\
+  -o out.html`,
+			).agent,
+			'/vizb sankey-flows.csv as sankey, source, target & value; source, target & cost',
+		);
+	});
+
+	it('maps 3d, scale, and symbol-size config flags', () => {
+		assert.equal(
+			snippetsFromCli('./bin/vizb bar noise-surface.csv -o surface.html --3d-visualmap')
+				.agent,
+			'/vizb noise-surface.csv as bar, 3d visual map',
+		);
+		assert.equal(
+			snippetsFromCli('vizb line worker-pools.txt -p z/y/x --scale log -o out.html').agent,
+			'/vizb worker-pools.txt as line, split into depth, y & x, log scale',
+		);
+		assert.equal(
+			snippetsFromCli(
+				'vizb scatter clusters.csv --visualmap --symbol-size 10 -o scatter.html',
+			).agent,
+			'/vizb clusters.csv as scatter, visual map, symbol size 10',
+		);
+	});
+});

--- a/docs/src/components/invoke/fromCli.ts
+++ b/docs/src/components/invoke/fromCli.ts
@@ -1,4 +1,4 @@
-/** Map a vizb CLI invocation to HTTP POST / JSON and a GitHub Action step. */
+/** Map a vizb CLI invocation to HTTP, Action, and a natural-language /vizb prompt. */
 
 const CHART_TYPES = new Set([
 	'bar',
@@ -55,6 +55,7 @@ const ACTION_CONFIG_KEY: Record<string, string> = {
 
 export interface InvokeSnippets {
 	cli: string;
+	agent: string;
 	http: string;
 	action: string;
 }
@@ -75,6 +76,7 @@ export function snippetsFromCli(cli: string, input?: string): InvokeSnippets {
 	const parsed = parseCli(cli);
 	return {
 		cli: cli.trim(),
+		agent: buildAgent(parsed),
 		http: JSON.stringify(buildHttp(parsed, input), null, 2),
 		action: buildAction(parsed),
 	};
@@ -120,6 +122,73 @@ function parseCli(cli: string): ParsedCli {
 	}
 
 	return parsed;
+}
+
+function buildAgent(parsed: ParsedCli): string {
+	const head: string[] = [parsed.file ? `/vizb ${parsed.file}` : '/vizb'];
+	const types = chartTypes(parsed);
+	head.push(`as ${joinWords(types.length ? types : ['bar'])}`);
+
+	const cols = splitList(parsed.group);
+	const patternTalk = verbalizePattern(parsed.pattern, cols);
+	if (cols.length > 0 && !patternTalk) head.push(`by ${joinWords(cols)}`);
+
+	const extras: string[] = [];
+	if (patternTalk) extras.push(patternTalk);
+	if (parsed.regex) extras.push(verbalizeRegex(parsed.regex));
+	if (parsed.select.length > 0) extras.push(verbalizeSelect(parsed.select));
+	if (parsed.config.showLabels) extras.push('show labels');
+	if (parsed.config.stack) extras.push('stacked');
+	if (parsed.config.threeDVisualMap) extras.push('3d visual map');
+	else if (parsed.config.threeD) extras.push('3d');
+	if (parsed.config.threeDRotate) extras.push('rotate');
+	if (parsed.config.visualMap) extras.push('visual map');
+	if (typeof parsed.config.scale === 'string') extras.push(`${parsed.config.scale} scale`);
+	if (parsed.config.symbolSize != null) extras.push(`symbol size ${parsed.config.symbolSize}`);
+
+	return extras.length > 0 ? `${head.join(' ')}, ${extras.join(', ')}` : head.join(' ');
+}
+
+function splitList(value: string | undefined): string[] {
+	if (!value) return [];
+	return value.split(/[,/\s]+/).map((s) => s.trim()).filter(Boolean);
+}
+
+function joinWords(items: string[]): string {
+	if (items.length <= 2) return items.join(' & ');
+	return `${items.slice(0, -1).join(', ')} & ${items[items.length - 1]}`;
+}
+
+function dimWord(dim: string): string {
+	if (dim === 'n') return 'name';
+	if (dim === 'z') return 'depth';
+	return dim;
+}
+
+function isTrivialPattern(pattern: string): boolean {
+	return /^[nxyz](?:[,/\s]+[nxyz])*$/.test(pattern.trim());
+}
+
+function verbalizePattern(pattern: string | undefined, cols: string[]): string | undefined {
+	if (!pattern) return;
+	if (isTrivialPattern(pattern)) {
+		if (cols.length > 0) return;
+		return `split into ${joinWords(pattern.split(/[,/\s]+/).map(dimWord))}`;
+	}
+	if (!pattern.includes('[')) return;
+	const split = `split ${cols[0] ?? 'the value'} into month & date (skip the year)`;
+	return cols[1] ? `${split}, ${cols[1]} as depth` : split;
+}
+
+function verbalizeRegex(re: string): string {
+	const names = [...re.matchAll(/\(\?<(\w+)>/g)].map((m) => dimWord(m[1] ?? ''));
+	return `split by / into ${joinWords(names)}`;
+}
+
+function verbalizeSelect(select: string[]): string {
+	return select
+		.map((s) => joinWords(s.split(',').map((c) => c.trim()).filter(Boolean)))
+		.join('; ');
 }
 
 function buildHttp(parsed: ParsedCli, input?: string): Record<string, unknown> {

--- a/docs/src/components/quick-install.css
+++ b/docs/src/components/quick-install.css
@@ -1,5 +1,13 @@
-/* Lucide "bot" — Starlight has no robot icon. */
-.quick-install [role='tablist'] .tab:last-child [role='tab']::before {
+/* Lucide "bot" — Starlight has no robot icon. Agent is the first tab. */
+.quick-install [role='tablist'] .tab:first-child [role='tab'],
+.invoke-tabs [role='tablist'] .tab:first-child [role='tab'] {
+	display: flex;
+	align-items: center;
+	gap: 0.25em;
+}
+
+.quick-install [role='tablist'] .tab:first-child [role='tab']::before,
+.invoke-tabs [role='tablist'] .tab:first-child [role='tab']::before {
 	content: '';
 	display: block;
 	width: 1em;

--- a/docs/src/content/docs/features.mdx
+++ b/docs/src/content/docs/features.mdx
@@ -5,7 +5,7 @@ description: What Vizb can do — inputs, dimensions, charts, UI, merge, and CI 
 
 import { CardGrid, Card, Aside, LinkCard } from '@astrojs/starlight/components';
 
-Vizb turns CSV, JSON, and benchmark output into interactive charts and stats **without writing chart or frontend code**. Tables and benchmarks share one dimension model; you run the same pipeline from the CLI, [GitHub Action](/ci-cd/github-action), or [REST API](/commands/serve).
+Vizb turns CSV, JSON, and benchmark output into interactive charts and stats **without writing chart or frontend code**. Tables and benchmarks share one dimension model; you run the same pipeline from the CLI, a [coding agent](/getting-started/ai-agents), [GitHub Action](/ci-cd/github-action), or [REST API](/commands/serve).
 
 New to the product? Start with [Getting Started](/getting-started).
 
@@ -71,6 +71,9 @@ New to the product? Start with [Getting Started](/getting-started).
   </Card>
   <Card title="REST API" icon="seti:json">
     `vizb serve` exposes convert, merge, and UI generation. See [serve](/commands/serve) and [API](/api/).
+  </Card>
+  <Card title="Coding agents" icon="puzzle">
+    Install the vizb skill, then `/vizb sales.csv as bar by region & product, show labels`. The agent runs the CLI. See [AI agents](/getting-started/ai-agents).
   </Card>
   <Card title="Units and export" icon="download">
     Time, memory, and number units. HTML or JSON output. Chart JPEG from the UI.

--- a/docs/src/content/docs/getting-started/ai-agents.mdx
+++ b/docs/src/content/docs/getting-started/ai-agents.mdx
@@ -4,6 +4,8 @@ description: Connect vizb to coding agents with npx skills add so /vizb can char
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import InvokeTabs from '../../../components/InvokeTabs.astro';
+import { SALES_SAMPLE } from '../../../data/samples';
 
 Coding agents do not know vizb unless you install the skill. The skill teaches the agent when to use vizb, how to install the binary if it is missing, and which docs page to fetch. The agent still **runs the vizb CLI** — this is not an MCP server.
 
@@ -30,10 +32,28 @@ Skill install is not binary install. If `vizb` is missing, the skill runs the [i
 
 ## Use it
 
+Type `/vizb` plus the file and what you want in natural language. The agent picks a chart, writes an HTML file, and returns the path — it does not paste the HTML into the chat.
+
 ```text
-/vizb path/to/data.csv
+/vizb sales.csv as bar by region & product, show labels
 ```
 
-Or ask in natural language: “turn this benchmark output into an HTML chart.”
+Same conversion as the CLI. Every example in these docs has an **Agent** tab with a prompt like this:
+
+<InvokeTabs
+  cli={`vizb bar sales.csv -g region,product -p x,y -l -o sales.html`}
+  input={SALES_SAMPLE}
+/>
+
+Other prompts:
+
+```text
+/vizb sales.csv as pie by region
+/vizb this benchmark as a line chart
+/vizb bench.txt as bar
+/vizb path/to/data.csv as bar
+```
+
+Or ask without the slash: “turn this benchmark output into an HTML chart.”
 
 The agent should start with `vizb <chart> <file> -o out.html` and only add grouping or select flags if auto output is wrong.

--- a/docs/src/content/docs/getting-started/index.mdx
+++ b/docs/src/content/docs/getting-started/index.mdx
@@ -8,7 +8,7 @@ import SalesSampleCsv from '../../../components/SalesSampleCsv.astro';
 import InvokeTabs from '../../../components/InvokeTabs.astro';
 import { SALES_SAMPLE } from '../../../data/samples';
 
-Vizb turns **CSV, JSON, and benchmark output** into interactive charts and stats **without writing chart code**. Point it at data (CLI, [GitHub Action](/ci-cd/github-action), or [REST](/commands/serve)), open one HTML report in any browser.
+Vizb turns **CSV, JSON, and benchmark output** into interactive charts and stats **without writing chart code**. Point it at data (CLI, a [coding agent](/getting-started/ai-agents), [GitHub Action](/ci-cd/github-action), or [REST](/commands/serve)), open one HTML report in any browser.
 
 **Need the binary first?** [Install](/getting-started/install), then come back here.
 
@@ -80,6 +80,7 @@ Deepen when you need to:
 
 <CardGrid>
   <LinkCard title="Install" href="/getting-started/install" description="Script, Docker, Go install, and binaries." />
+  <LinkCard title="AI agents" href="/getting-started/ai-agents" description="Install the vizb skill and chart with /vizb." />
   <LinkCard title="Dimensions" href="/getting-started/dimensions" description="What n, x, y, and z mean on every chart." />
   <LinkCard title="Group vs Select" href="/guides/group-vs-select" description="The two ways columns become charts." />
   <LinkCard title="Charts overview" href="/charts" description="How each chart type reads the same dimensions." />
@@ -148,6 +149,7 @@ Force a parser with `-P go`, `-P rs:criterion`, `-P rs:divan`, `-P js:vitest`, o
 | Goal | Start here |
 |------|------------|
 | Install | [Install](/getting-started/install) |
+| Chart from a coding agent | [AI agents](/getting-started/ai-agents) (`/vizb sales.csv as bar by region & product, show labels`) |
 | Dimensions in depth | [Dimensions](/getting-started/dimensions) |
 | Group vs select | [Group vs Select](/guides/group-vs-select) |
 | CSV / JSON rules | [Tabular data](/guides/data) |

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -34,6 +34,7 @@ import LogoAnimation from '../../components/LogoAnimation.astro';
 
 <CardGrid>
   <LinkCard title="Introduction" href="/getting-started" description="What Vizb is and your first chart." />
+  <LinkCard title="AI agents" href="/getting-started/ai-agents" description="Install the vizb skill and chart with /vizb." />
   <LinkCard title="Dimensions" href="/getting-started/dimensions" description="Name, X, Y, and Z on every chart." />
   <LinkCard title="Chart a CSV / JSON table" href="/guides/data" description="Numeric columns, grouping, aggregation, and --json-path." />
   <LinkCard title="Pick a chart type" href="/charts" description="How bar, line, scatter, pie, heatmap, radar, Sankey, and Chord read x/y/z." />
@@ -53,8 +54,8 @@ import LogoAnimation from '../../components/LogoAnimation.astro';
   <Card title="Self-contained HTML" icon="laptop">
     Interactive UI in one file: sort, swap axes, scale, themes, JPEG export, optional stats. Open it in any browser. See [UI](/ui).
   </Card>
-  <Card title="CLI, Action, and API" icon="seti:puppet">
-    Local CLI, [GitHub Action](/ci-cd/github-action), and [REST](/commands/serve) for the same pipeline. Merge datasets across runs when you need history.
+  <Card title="CLI, agents, Action, and API" icon="seti:puppet">
+    Local CLI, a [coding agent](/getting-started/ai-agents) via `/vizb`, [GitHub Action](/ci-cd/github-action), and [REST](/commands/serve) for the same pipeline. Merge datasets across runs when you need history.
   </Card>
 </CardGrid>
 

--- a/docs/src/content/docs/roadmap.mdx
+++ b/docs/src/content/docs/roadmap.mdx
@@ -7,7 +7,7 @@ import { CardGrid, Card } from '@astrojs/starlight/components';
 
 ## Current State
 
-Vizb turns CSV/JSON tables and benchmark output into charts and stats without writing chart code: one dimension model (`n`/`x`/`y`/`z`), eight chart types (including 3D WebGL for bar/line/scatter), merge history, stats, CLI, GitHub Action, and REST.
+Vizb turns CSV/JSON tables and benchmark output into charts and stats without writing chart code: one dimension model (`n`/`x`/`y`/`z`), eight chart types (including 3D WebGL for bar/line/scatter), merge history, stats, CLI, coding agents (`/vizb`), GitHub Action, and REST.
 
 Capability inventory lives on [Features](/features). Conceptual model: [Getting Started](/getting-started). Input adapters: [Supported inputs](/guides/parsers).
 

--- a/docs/src/lib/agent-md.test.ts
+++ b/docs/src/lib/agent-md.test.ts
@@ -93,13 +93,16 @@ describe('flattenMdx', () => {
 		assert.equal(out.includes('<InvokeTabs'), false);
 	});
 
-	it('lifts InvokeTabs into CLI, HTTP, and Action tab content', () => {
+	it('lifts InvokeTabs into Agent, CLI, HTTP, and Action tab content', () => {
 		const src = `<InvokeTabs
   cli={\`vizb bar sales.csv -g region,category -p x,y -o sales.html\`}
   input={SALES_SAMPLE}
 />
 `;
 		const out = flattenMdx(src);
+		assert.ok(out.indexOf('### Agent') < out.indexOf('### CLI'));
+		assert.match(out, /### Agent/);
+		assert.match(out, /```text\n\/vizb sales.csv as bar by region \& category\n```/);
 		assert.match(out, /### CLI/);
 		assert.match(out, /```bash\nvizb bar sales.csv -g region,category -p x,y -o sales.html\n```/);
 		assert.match(out, /### HTTP/);
@@ -188,7 +191,14 @@ describe('flattenMdx corpus', () => {
 		assert.equal(charts3d.includes('<InvokeTabs'), false);
 
 		const bar = byPath.get('/charts/bar.md') ?? '';
+		assert.ok(bar.indexOf('### Agent') < bar.indexOf('### CLI'));
+		assert.match(bar, /### Agent/);
 		assert.match(bar, /### CLI/);
+		assert.match(bar, /\/vizb sales.csv as bar by order_date/);
+		assert.match(
+			bar,
+			/```text\n\/vizb sales.csv as bar, split order_date into month & date \(skip the year\), category as depth\n```/,
+		);
 		assert.match(bar, /### HTTP/);
 		assert.match(bar, /"parser": "csv"/);
 		assert.match(bar, /### Action/);
@@ -281,4 +291,3 @@ describe('sourceBody', () => {
 		assert.match(out.body, /Need the binary first/);
 	});
 });
-

--- a/docs/src/lib/agent-md.ts
+++ b/docs/src/lib/agent-md.ts
@@ -77,6 +77,12 @@ function liftInvokeTabs(src: string): string {
 		const snippets = snippetsFromCli(cli, quotedProp(tag, 'input'));
 		return [
 			'',
+			'### Agent',
+			'',
+			'```text',
+			snippets.agent,
+			'```',
+			'',
 			'### CLI',
 			'',
 			'```bash',


### PR DESCRIPTION
## Summary

- Add an **Agent** tab to every example snippet (`InvokeTabs`), first in order: Agent → CLI → HTTP → Action.
- Derive a natural-language `/vizb` prompt from the CLI (always names the chart, including `bar` / `line`; spoken date splits instead of `[]` `{}` patterns).
- Put Agent first in Quick Install (Agent → Linux/macOS → Windows) and reuse the Lucide bot icon on both tab strips.
- Point Getting Started, Features, and the AI agents page at `/vizb sales.csv as bar by region & product, show labels`.

## Test Plan

- [x] `cd docs && pnpm test`
- [ ] Spot-check homepage, `/getting-started/ai-agents/`, and `/charts/bar/` Agent tabs
- [ ] Confirm install tabs default to Agent and show the bot icon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coding-agent support with natural-language `/vizb` prompts for chart creation.
  * Added an Agent tab to invocation examples and quick-install instructions.
  * Added coding-agent guidance, examples, installation instructions, and links throughout the documentation.
  * Updated feature and roadmap pages to highlight coding agents alongside existing workflows.

* **Tests**
  * Expanded coverage for agent prompt generation and updated documentation rendering tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->