### PR TITLE
feat(appearance): add --font-size and nest themes under dataset.appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adhere
 
 ### Added
 
-- **cli** — Add `--font-size` (number or `series=;legend=;label=` bag) on root and chart subcommands
+- **cli** — Add `--font-size` (number or `series=16;legend=10;label=12` bag) on root and chart subcommands
 - **action** — Add `font-size` input forwarded as `--font-size`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Notable changes to Vizb documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased]
+
+### Added
+
+- **cli** — Add `--font-size` (number or `series=;legend=;label=` bag) on root and chart subcommands
+- **action** — Add `font-size` input forwarded as `--font-size`
+
+### Changed
+
+- **cli / api / ui** — Move theme catalog and inbound `theme` string under `dataset.appearance` (breaking JSON/API wire; no root-field compatibility)
+
 # [v0.21.0] - 2026-09-09
 
 ### Added

--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,9 @@ inputs:
   parser:
     description: "Parser to use: csv, json, go, js:tinybench, js:vitest, rs:criterion, rs:divan (-P flag)"
     default: "auto"
+  font-size:
+    description: "Chart text size in px (--font-size). A number sets series, legend, and axis ticks; or series=;legend=;label= bag."
+    default: ""
   show-labels:
     description: "DEPRECATED: use 'chart' input instead (e.g. chart: 'pie:labels'). Show labels on charts (-l flag)"
     default: "false"

--- a/action/lib.mjs
+++ b/action/lib.mjs
@@ -62,6 +62,7 @@ export function resolveInputs(env = process.env) {
     chart: input('chart'),
     charts: input('charts'),
     parser: input('parser'),
+    fontSize: input('font-size'),
     showLabels: input('show-labels') === 'true',
     enable3d: input('enable-3d') === 'true',
     mergeFiles,
@@ -161,6 +162,7 @@ export function buildConvertArgs(inputs) {
   if (inputs.jsonPath) args.push('--json-path', inputs.jsonPath)
   if (inputs.showLabels) args.push('-l')
   if (inputs.parser) args.push('-P', inputs.parser)
+  if (inputs.fontSize) args.push('--font-size', inputs.fontSize)
   return appendChartStatFlags(args, inputs.charts, inputs.chart, inputs.stat)
 }
 

--- a/action/lib.test.mjs
+++ b/action/lib.test.mjs
@@ -62,6 +62,7 @@ describe('buildConvertArgs', () => {
     chart: '',
     charts: '',
     parser: 'auto',
+    fontSize: '',
     showLabels: false,
     enable3d: false,
     mergeFiles: '',
@@ -102,6 +103,11 @@ describe('buildConvertArgs', () => {
     assert.ok(args.includes('-c') && args.includes('bar'))
     assert.ok(args.includes('--chart') && args.includes('bar:scale=log'))
     assert.ok(args.includes('--stat'))
+  })
+
+  it('forwards font-size', () => {
+    const args = buildConvertArgs({ ...base, fontSize: 'series=16;legend=10' })
+    assert.ok(args.includes('--font-size') && args.includes('series=16;legend=10'))
   })
 })
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -152,7 +152,8 @@ components:
                 name: API latency
                 description: Latency by region
                 tag: v2
-                theme: westeros
+                appearance:
+                  theme: westeros
                 parser: csv
                 select: ["region,latency"]
                 charts:
@@ -246,20 +247,21 @@ components:
                 name: API latency
                 description: Latency by region
                 tag: v2
-                themes:
-                  - name: westeros
-                    colors:
-                      - "#516b91"
-                      - "#59c4e6"
-                      - "#edafda"
-                      - "#93b7e3"
-                      - "#a5e7f0"
-                      - "#cbb0e3"
-                      - "#3f5575"
-                      - "#41a7cb"
-                      - "#d58fc4"
-                      - "#789bc7"
-                    visualMapColors: ["#59c4e6", "#d58fc4"]
+                appearance:
+                  themes:
+                    - name: westeros
+                      colors:
+                        - "#516b91"
+                        - "#59c4e6"
+                        - "#edafda"
+                        - "#93b7e3"
+                        - "#a5e7f0"
+                        - "#cbb0e3"
+                        - "#3f5575"
+                        - "#41a7cb"
+                        - "#d58fc4"
+                        - "#789bc7"
+                      visualMapColors: ["#59c4e6", "#d58fc4"]
                 axes: [{ key: name }, { key: y, type: value }]
                 settings: [{ type: bar, showLabels: true }, { type: line }]
                 data: [{ name: west, yAxis: "12" }, { name: east, yAxis: "18" }]
@@ -375,22 +377,8 @@ components:
         tag:
           type: string
           description: Dataset tag or run identifier.
-        themes:
-          type: array
-          description: >
-            Data-owned theme catalog embedded on the converted Dataset.
-            When non-empty, themes[0] is the active theme. Prefer this over the
-            legacy theme string. Built-in "default" is not embedded (UI owns it).
-          items:
-            $ref: '#/components/schemas/Theme'
-        theme:
-          type: string
-          minLength: 1
-          description: >
-            Legacy single theme name, structured theme, or comma-separated hex
-            palette. Expanded into themes when themes is omitted or empty.
-            Prefer themes for new clients.
-          examples: [westeros, "#5470C6,#3BA272"]
+        appearance:
+          $ref: '#/components/schemas/Appearance'
         parser:
           type: string
           enum: [auto, csv, json, go, javascript, rust]
@@ -507,6 +495,36 @@ components:
           items:
             type: string
             enum: [counts, center, spread, extremes, shape, percentiles, confidence, correlations]
+    Appearance:
+      type: object
+      additionalProperties: false
+      description: >
+        Dataset-level visual settings. themes[0] is the active theme when the
+        catalog is non-empty. theme is an inbound name or palette expanded into
+        themes and omitted from new output. fontSize is a number (all three
+        targets) or an object of series, legend, and label sizes in CSS pixels.
+      properties:
+        themes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Theme'
+        theme:
+          type: string
+          minLength: 1
+          examples: [westeros, "#5470C6,#3BA272"]
+        fontSize:
+          $ref: '#/components/schemas/FontSize'
+    FontSize:
+      description: Chart text size in CSS pixels for series labels, legend, and axis ticks.
+      oneOf:
+        - type: number
+          exclusiveMinimum: 0
+        - type: object
+          additionalProperties: false
+          properties:
+            series: { type: number, exclusiveMinimum: 0 }
+            legend: { type: number, exclusiveMinimum: 0 }
+            label: { type: number, exclusiveMinimum: 0 }
     Theme:
       type: object
       additionalProperties: false
@@ -539,18 +557,8 @@ components:
         tag: { type: string }
         timestamp: { type: string }
         name: { type: string }
-        themes:
-          type: array
-          description: >
-            Data-owned theme catalog. When non-empty, themes[0] is the active
-            theme. New writers emit themes only; legacy theme is migrated on load.
-          items:
-            $ref: '#/components/schemas/Theme'
-        theme:
-          type: string
-          description: >
-            Legacy single theme name or palette. Migrated into themes when themes
-            is empty; omitted from new output after migration.
+        appearance:
+          $ref: '#/components/schemas/Appearance'
         history:
           type: array
           items: { $ref: '#/components/schemas/HistoryEntry' }

--- a/api/openapi_test.go
+++ b/api/openapi_test.go
@@ -79,6 +79,7 @@ func (s *OpenAPISuite) TestReusableSchemasMatchGoWireTypes() {
 
 	for schemaName, value := range map[string]any{
 		"Dataset":            shared.Dataset{},
+		"Appearance":         shared.Appearance{},
 		"Theme":              shared.Theme{},
 		"HistoryEntry":       shared.HistoryEntry{},
 		"Meta":               shared.Meta{},
@@ -335,18 +336,12 @@ func (s *OpenAPISuite) TestRootConversionContract() {
 	schemas := mustMap(t, components["schemas"], "components.schemas")
 	request := mustMap(t, schemas["ConvertRequest"], "components.schemas.ConvertRequest")
 	s.Equal(
-		[]string{"charts", "description", "grouping", "id", "input", "jsonPath", "name", "output", "parser", "round", "select", "tag", "theme", "themes", "title", "units"},
+		[]string{"appearance", "charts", "description", "grouping", "id", "input", "jsonPath", "name", "output", "parser", "round", "select", "tag", "title", "units"},
 		propertyNames(t, request, "ConvertRequest"),
 	)
-	// themes is the data-owned catalog; theme remains as legacy convert input.
 	props := mustMap(t, request["properties"], "ConvertRequest.properties")
-	themes := mustMap(t, props["themes"], "ConvertRequest.properties.themes")
-	s.Equal("array", themes["type"])
-	themeItems := mustMap(t, themes["items"], "ConvertRequest.properties.themes.items")
-	s.Equal("#/components/schemas/Theme", themeItems["$ref"])
-	legacyTheme := mustMap(t, props["theme"], "ConvertRequest.properties.theme")
-	s.Equal("string", legacyTheme["type"])
-	s.Contains(fmt.Sprint(legacyTheme["description"]), "Legacy")
+	appearance := mustMap(t, props["appearance"], "ConvertRequest.properties.appearance")
+	s.Equal("#/components/schemas/Appearance", appearance["$ref"])
 	s.Equal([]string{"input"}, stringSliceValue(request["required"]))
 	s.NotContains(propertyNames(t, request, "ConvertRequest"), "metadata")
 

--- a/cmd/cli/dataflags.go
+++ b/cmd/cli/dataflags.go
@@ -26,6 +26,11 @@ var DataFlags = []flags.Flag{
 		Normalizer:   style.NormalizeTheme,
 		SoftValidate: style.ValidateTheme,
 	},
+	{
+		Name: "font-size", Kind: flags.KindString,
+		Usage: "Chart text size in px (number, or series=;legend=;label=)",
+		Label: "font-size",
+	},
 	{Name: "description", Shorthand: "d", Usage: "Dataset description", Kind: flags.KindString},
 	{Name: "output", Shorthand: "o", Usage: "Output path (.html or .json)", Kind: flags.KindString},
 	{Name: "tag", Shorthand: "t", Usage: "Tag for merge/compare", Kind: flags.KindString},

--- a/cmd/cli/flagbag.go
+++ b/cmd/cli/flagbag.go
@@ -27,8 +27,6 @@ type FlagBag struct {
 	floats       map[string]*float64
 	ints         map[string]*int
 	stringSlices map[string]*[]string // backs KindStringSlice, KindStat, and KindStringArray
-	fontSize     *shared.FontSize     // --font-size, parsed once during Validate
-	fontSizeSet  bool
 }
 
 // NewFlagBag allocates a bag and one typed pointer per flag.
@@ -155,13 +153,11 @@ func (b *FlagBag) Validate(cmd *cobra.Command) {
 }
 
 // validateFontSizeFlag warn-and-skips invalid keys/values; valid siblings stay.
-// The result is cached so Meta() does not re-parse the flag.
 func (b *FlagBag) validateFontSizeFlag(cmd *cobra.Command, f flags.Flag) {
 	if !cmd.Flags().Changed(f.Name) {
 		return
 	}
-	fontSize, warnings := shared.ParseFontSizeFlag(*b.strs[f.Name])
-	b.fontSize, b.fontSizeSet = fontSize, true
+	_, warnings := shared.ParseFontSizeFlag(*b.strs[f.Name])
 	for _, w := range warnings {
 		cliout.Warn(w)
 	}
@@ -449,16 +445,13 @@ func (b *FlagBag) ParseConfig() parser.Config {
 // Meta builds the pipeline RunMeta from the bag's metadata/parser data flags.
 // Theme specs stay as raw strings; the pipeline expands them via style.ResolveThemes.
 func (b *FlagBag) Meta() RunMeta {
-	if !b.fontSizeSet {
-		b.fontSize, _ = shared.ParseFontSizeFlag(b.String("font-size"))
-		b.fontSizeSet = true
-	}
+	fontSize, _ := shared.ParseFontSizeFlag(b.String("font-size"))
 	return RunMeta{
 		ID:          b.String("id"),
 		Name:        b.String("name"),
 		Title:       b.String("title"),
 		ThemeSpecs:  b.StringArray("theme"),
-		FontSize:    b.fontSize,
+		FontSize:    fontSize,
 		Description: b.String("description"),
 		Tag:         b.String("tag"),
 		OutputFile:  b.String("output"),

--- a/cmd/cli/flagbag.go
+++ b/cmd/cli/flagbag.go
@@ -27,6 +27,8 @@ type FlagBag struct {
 	floats       map[string]*float64
 	ints         map[string]*int
 	stringSlices map[string]*[]string // backs KindStringSlice, KindStat, and KindStringArray
+	fontSize     *shared.FontSize     // --font-size, parsed once during Validate
+	fontSizeSet  bool
 }
 
 // NewFlagBag allocates a bag and one typed pointer per flag.
@@ -140,6 +142,8 @@ func (b *FlagBag) Validate(cmd *cobra.Command) {
 			b.validateObjectFlag(cmd, f)
 		case f.Name == "scale":
 			b.validateScaleFlag(cmd, f)
+		case f.Name == "font-size":
+			b.validateFontSizeFlag(cmd, f)
 		case f.IsSoft():
 			b.applySoftRule(f)
 		case f.Validate != nil && cmd.Flags().Changed(f.Name):
@@ -147,6 +151,19 @@ func (b *FlagBag) Validate(cmd *cobra.Command) {
 				shared.ExitWithError(err.Error(), nil)
 			}
 		}
+	}
+}
+
+// validateFontSizeFlag warn-and-skips invalid keys/values; valid siblings stay.
+// The result is cached so Meta() does not re-parse the flag.
+func (b *FlagBag) validateFontSizeFlag(cmd *cobra.Command, f flags.Flag) {
+	if !cmd.Flags().Changed(f.Name) {
+		return
+	}
+	fontSize, warnings := shared.ParseFontSizeFlag(*b.strs[f.Name])
+	b.fontSize, b.fontSizeSet = fontSize, true
+	for _, w := range warnings {
+		cliout.Warn(w)
 	}
 }
 
@@ -432,11 +449,16 @@ func (b *FlagBag) ParseConfig() parser.Config {
 // Meta builds the pipeline RunMeta from the bag's metadata/parser data flags.
 // Theme specs stay as raw strings; the pipeline expands them via style.ResolveThemes.
 func (b *FlagBag) Meta() RunMeta {
+	if !b.fontSizeSet {
+		b.fontSize, _ = shared.ParseFontSizeFlag(b.String("font-size"))
+		b.fontSizeSet = true
+	}
 	return RunMeta{
 		ID:          b.String("id"),
 		Name:        b.String("name"),
 		Title:       b.String("title"),
 		ThemeSpecs:  b.StringArray("theme"),
+		FontSize:    b.fontSize,
 		Description: b.String("description"),
 		Tag:         b.String("tag"),
 		OutputFile:  b.String("output"),

--- a/cmd/cli/flagbag_test.go
+++ b/cmd/cli/flagbag_test.go
@@ -345,6 +345,37 @@ func (s *FlagBagSuite) TestMetaEmptyThemesWhenUnset() {
 	_, bag := s.newCmdBag(slices.Clone(DataFlags))
 	meta := bag.Meta()
 	s.Empty(meta.ThemeSpecs)
+	s.Nil(meta.FontSize)
+}
+
+func (s *FlagBagSuite) TestMetaFontSizeBareAndBag() {
+	cmd, bag := s.newCmdBag(slices.Clone(DataFlags))
+	s.Require().NoError(cmd.Flags().Set("font-size", "14"))
+	meta := bag.Meta()
+	s.Require().NotNil(meta.FontSize)
+	s.Equal(14.0, *meta.FontSize.Series)
+	s.Equal(14.0, *meta.FontSize.Legend)
+	s.Equal(14.0, *meta.FontSize.Label)
+
+	cmd, bag = s.newCmdBag(slices.Clone(DataFlags))
+	s.Require().NoError(cmd.Flags().Set("font-size", "series=16;legend=10"))
+	meta = bag.Meta()
+	s.Require().NotNil(meta.FontSize)
+	s.Equal(16.0, *meta.FontSize.Series)
+	s.Equal(10.0, *meta.FontSize.Legend)
+	s.Nil(meta.FontSize.Label)
+}
+
+func (s *FlagBagSuite) TestValidateFontSizeWarnsAndKeepsSiblings() {
+	cmd, bag := s.newCmdBag(slices.Clone(DataFlags))
+	s.Require().NoError(cmd.Flags().Set("font-size", "series=abc;legend=14;title=9"))
+	out := testutil.CaptureStderr(func() { bag.Validate(cmd) })
+	s.Contains(out, "Invalid font-size series")
+	s.Contains(out, "unknown key")
+	meta := bag.Meta()
+	s.Require().NotNil(meta.FontSize)
+	s.Nil(meta.FontSize.Series)
+	s.Equal(14.0, *meta.FontSize.Legend)
 }
 
 func (s *FlagBagSuite) TestChartSeedObjectFlagTriState() {

--- a/cmd/cli/pipeline.go
+++ b/cmd/cli/pipeline.go
@@ -154,6 +154,7 @@ type RunMeta struct {
 	Name        string
 	Title       string
 	ThemeSpecs  []string
+	FontSize    *shared.FontSize
 	Description string
 	Tag         string
 	OutputFile  string
@@ -403,7 +404,8 @@ func assembleDataset(results []shared.DataPoint, m RunMeta, configs []internal_c
 		Parser: m.Parser,
 		Config: cfg,
 		Metadata: core.Metadata{
-			ID: m.ID, Name: m.Name, Themes: resolveRunThemes(m), Description: m.Description, Tag: m.Tag,
+			ID: m.ID, Name: m.Name, Themes: resolveRunThemes(m), FontSize: m.FontSize,
+			Description: m.Description, Tag: m.Tag,
 			System: system,
 		},
 		Charts: configs,

--- a/cmd/cli/pipeline_test.go
+++ b/cmd/cli/pipeline_test.go
@@ -283,8 +283,8 @@ func (s *PipelineSuite) TestRunLinearGeneratesOutputFile() {
 		var ds shared.Dataset
 		s.Require().NoError(json.Unmarshal(content, &ds))
 		s.Require().Len(ds.Settings, 1)
-		s.Empty(ds.Theme)
-		s.Empty(ds.Themes)
+		s.Empty(ds.Appearance)
+		s.Empty(ds.ThemeCatalog())
 		s.Equal("bar", ds.Settings[0].ChartType())
 		typed, ok := ds.Settings[0].(*barchart.Config)
 		s.Require().True(ok, "expected *barchart.Config, got %T", ds.Settings[0])
@@ -308,10 +308,11 @@ func (s *PipelineSuite) TestRunLinearPreservesCustomTheme() {
 	s.Contains(string(content), `"themes"`)
 	var ds shared.Dataset
 	s.Require().NoError(json.Unmarshal(content, &ds))
-	s.Empty(ds.Theme)
-	s.Require().Len(ds.Themes, 1)
-	s.Equal("custom", ds.Themes[0].Name)
-	s.Equal([]string{"#f00", "#00ff00"}, ds.Themes[0].Colors)
+	s.Require().NotNil(ds.Appearance)
+	s.Empty(ds.Appearance.Theme)
+	s.Require().Len(ds.ThemeCatalog(), 1)
+	s.Equal("custom", ds.ThemeCatalog()[0].Name)
+	s.Equal([]string{"#f00", "#00ff00"}, ds.ThemeCatalog()[0].Colors)
 }
 
 func (s *PipelineSuite) TestChartScaleBagRoundTripsThroughMaterialise() {
@@ -880,10 +881,11 @@ func (s *PipelineSuite) TestAssembleDatasetPreservesTheme() {
 		},
 	}
 	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv", ThemeSpecs: []string{"walden"}}, nil, cfg, nil)
-	s.Empty(ds.Theme)
-	s.Require().Len(ds.Themes, 1)
-	s.Equal("walden", ds.Themes[0].Name)
-	s.NotEmpty(ds.Themes[0].Colors)
+	s.Require().NotNil(ds.Appearance)
+	s.Empty(ds.Appearance.Theme)
+	s.Require().Len(ds.ThemeCatalog(), 1)
+	s.Equal("walden", ds.ThemeCatalog()[0].Name)
+	s.NotEmpty(ds.ThemeCatalog()[0].Colors)
 }
 
 func (s *PipelineSuite) TestAssembleDatasetMultipleThemesFirstIsActive() {
@@ -894,10 +896,11 @@ func (s *PipelineSuite) TestAssembleDatasetMultipleThemesFirstIsActive() {
 		Parser:     "csv",
 		ThemeSpecs: []string{"westeros", "vintage"},
 	}, nil, cfg, nil)
-	s.Empty(ds.Theme)
-	s.Require().Len(ds.Themes, 2)
-	s.Equal("westeros", ds.Themes[0].Name)
-	s.Equal("vintage", ds.Themes[1].Name)
+	s.Require().NotNil(ds.Appearance)
+	s.Empty(ds.Appearance.Theme)
+	s.Require().Len(ds.ThemeCatalog(), 2)
+	s.Equal("westeros", ds.ThemeCatalog()[0].Name)
+	s.Equal("vintage", ds.ThemeCatalog()[1].Name)
 }
 
 func (s *PipelineSuite) TestAssembleDatasetSkipsDefaultTheme() {
@@ -908,17 +911,33 @@ func (s *PipelineSuite) TestAssembleDatasetSkipsDefaultTheme() {
 		Parser:     "csv",
 		ThemeSpecs: []string{"default", "roma"},
 	}, nil, cfg, nil)
-	s.Empty(ds.Theme)
-	s.Require().Len(ds.Themes, 1)
-	s.Equal("roma", ds.Themes[0].Name)
+	s.Require().NotNil(ds.Appearance)
+	s.Empty(ds.Appearance.Theme)
+	s.Require().Len(ds.ThemeCatalog(), 1)
+	s.Equal("roma", ds.ThemeCatalog()[0].Name)
+}
+
+func (s *PipelineSuite) TestAssembleDatasetFontSize() {
+	results := []shared.DataPoint{{XAxis: "1", YAxis: "2", Stats: []shared.Stat{}}}
+	cfg := parser.Config{GroupPattern: "x"}
+	ds := assembleDataset(results, RunMeta{
+		Name:     "T",
+		Parser:   "csv",
+		FontSize: &shared.FontSize{Series: shared.F64(16), Legend: shared.F64(10)},
+	}, nil, cfg, nil)
+	s.Require().NotNil(ds.Appearance)
+	s.Require().NotNil(ds.Appearance.FontSize)
+	s.Equal(16.0, *ds.Appearance.FontSize.Series)
+	s.Equal(10.0, *ds.Appearance.FontSize.Legend)
+	s.Nil(ds.Appearance.FontSize.Label)
 }
 
 func (s *PipelineSuite) TestAssembleDatasetEmptyThemesWhenUnset() {
 	results := []shared.DataPoint{{XAxis: "1", YAxis: "2", Stats: []shared.Stat{}}}
 	cfg := parser.Config{GroupPattern: "x"}
 	ds := assembleDataset(results, RunMeta{Name: "T", Parser: "csv"}, nil, cfg, nil)
-	s.Empty(ds.Theme)
-	s.Empty(ds.Themes)
+	s.Nil(ds.Appearance)
+	s.Empty(ds.ThemeCatalog())
 }
 
 func (s *PipelineSuite) TestAssembleDatasetThemeExpandFailureEmbedsNone() {
@@ -935,8 +954,8 @@ func (s *PipelineSuite) TestAssembleDatasetThemeExpandFailureEmbedsNone() {
 		}, nil, cfg, nil)
 	})
 	s.Require().NotNil(ds)
-	s.Empty(ds.Theme)
-	s.Empty(ds.Themes)
+	s.Nil(ds.Appearance)
+	s.Empty(ds.ThemeCatalog())
 	s.Contains(out, "theme expand failed")
 }
 

--- a/cmd/serve_contract.go
+++ b/cmd/serve_contract.go
@@ -58,25 +58,42 @@ func (o *statisticsOptions) UnmarshalJSON(data []byte) error {
 }
 
 type convertRequest struct {
-	Input json.RawMessage `json:"input"`
-	ID    *string         `json:"id"`
-	Name  *string         `json:"name"`
-	Title *string         `json:"title"`
-	// Themes is the preferred data-owned theme catalog (Themes[0] active).
-	Themes []shared.Theme `json:"themes"`
-	// Theme is the legacy single theme name/spec; expanded into Themes when
-	// Themes is empty. Prefer Themes for new clients.
-	Theme       *string          `json:"theme"`
-	Description *string          `json:"description"`
-	Tag         *string          `json:"tag"`
-	Parser      *string          `json:"parser"`
-	Grouping    *groupingOptions `json:"grouping"`
-	Units       *unitOptions     `json:"units"`
-	Round       bool             `json:"round"`
-	Select      []string         `json:"select"`
-	JSONPath    string           `json:"jsonPath"`
-	Charts      chartSelection   `json:"charts"`
-	Output      *convertOutput   `json:"output"`
+	Input       json.RawMessage    `json:"input"`
+	ID          *string            `json:"id"`
+	Name        *string            `json:"name"`
+	Title       *string            `json:"title"`
+	Appearance  *appearanceRequest `json:"appearance"`
+	Description *string            `json:"description"`
+	Tag         *string            `json:"tag"`
+	Parser      *string            `json:"parser"`
+	Grouping    *groupingOptions   `json:"grouping"`
+	Units       *unitOptions       `json:"units"`
+	Round       bool               `json:"round"`
+	Select      []string           `json:"select"`
+	JSONPath    string             `json:"jsonPath"`
+	Charts      chartSelection     `json:"charts"`
+	Output      *convertOutput     `json:"output"`
+}
+
+type appearanceRequest struct {
+	Themes   []shared.Theme  `json:"themes"`
+	Theme    *string         `json:"theme"`
+	FontSize json.RawMessage `json:"fontSize"`
+}
+
+func (a *appearanceRequest) UnmarshalJSON(data []byte) error {
+	if err := rejectNullFields(data, "/appearance", map[string]string{
+		"themes": "/appearance/themes", "theme": "/appearance/theme", "fontSize": "/appearance/fontSize",
+	}); err != nil {
+		return err
+	}
+	type wire appearanceRequest
+	var decoded wire
+	if err := strictDecodeRequestObject(data, &decoded, "/appearance"); err != nil {
+		return err
+	}
+	*a = appearanceRequest(decoded)
+	return nil
 }
 
 type convertOutput struct {
@@ -85,7 +102,7 @@ type convertOutput struct {
 
 func (r *convertRequest) UnmarshalJSON(data []byte) error {
 	if err := rejectNullFields(data, "/", map[string]string{
-		"id": "/id", "name": "/name", "title": "/title", "themes": "/themes", "theme": "/theme",
+		"id": "/id", "name": "/name", "title": "/title", "appearance": "/appearance",
 		"description": "/description", "tag": "/tag", "parser": "/parser", "grouping": "/grouping",
 		"units": "/units", "round": "/round", "select": "/select", "jsonPath": "/jsonPath",
 		"charts": "/charts", "output": "/output",
@@ -391,32 +408,55 @@ func buildConvertMetadata(request convertRequest) (core.Metadata, *apiValidation
 		metadata.Tag = *request.Tag
 	}
 
-	// Prefer non-empty themes[] (data-owned catalog). Themes[0] is active.
-	// Built-in "default" is omitted (UI owns the default palette).
-	// Empty or omitted themes falls through to the legacy theme string.
-	if len(request.Themes) > 0 {
-		themes, validationErr := validateRequestThemes(request.Themes, "/themes")
-		if validationErr != nil {
-			return core.Metadata{}, validationErr
-		}
-		metadata.Themes = themes
+	if request.Appearance == nil {
 		return metadata, nil
+	}
+	themes, fontSize, validationErr := resolveAppearanceRequest(request.Appearance, "/appearance")
+	if validationErr != nil {
+		return core.Metadata{}, validationErr
+	}
+	metadata.Themes = themes
+	metadata.FontSize = fontSize
+	return metadata, nil
+}
+
+func resolveAppearanceRequest(req *appearanceRequest, prefix string) ([]shared.Theme, *shared.FontSize, *apiValidationError) {
+	var themes []shared.Theme
+	if len(req.Themes) > 0 {
+		validated, validationErr := validateRequestThemes(req.Themes, prefix+"/themes")
+		if validationErr != nil {
+			return nil, nil, validationErr
+		}
+		themes = validated
+	} else if req.Theme != nil {
+		normalized := style.NormalizeTheme(*req.Theme)
+		resolved, err := style.ResolveThemes([]string{normalized})
+		if err != nil {
+			validationErr := bodyValidationError(prefix+"/theme", "invalid_value", err.Error())
+			return nil, nil, &validationErr
+		}
+		if len(resolved) > 0 {
+			themes = styleThemesToShared(resolved)
+		}
 	}
 
-	// Legacy theme string → expand into Themes via ResolveThemes / ParseThemeSpec.
-	if request.Theme == nil {
-		return metadata, nil
+	fontSize, validationErr := decodeAPIFontSize(req.FontSize, prefix+"/fontSize")
+	if validationErr != nil {
+		return nil, nil, validationErr
 	}
-	normalized := style.NormalizeTheme(*request.Theme)
-	resolved, err := style.ResolveThemes([]string{normalized})
+	return themes, fontSize, nil
+}
+
+func decodeAPIFontSize(raw json.RawMessage, path string) (*shared.FontSize, *apiValidationError) {
+	if len(bytes.TrimSpace(raw)) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, nil
+	}
+	fs, err := shared.ParseFontSizeJSONStrict(raw)
 	if err != nil {
-		validationErr := bodyValidationError("/theme", "invalid_value", err.Error())
-		return core.Metadata{}, &validationErr
+		validationErr := bodyValidationError(path, "invalid_value", err.Error())
+		return nil, &validationErr
 	}
-	if len(resolved) > 0 {
-		metadata.Themes = styleThemesToShared(resolved)
-	}
-	return metadata, nil
+	return fs, nil
 }
 
 // validateRequestThemes checks data-owned theme objects and returns a clone for
@@ -964,8 +1004,7 @@ type datasetWire struct {
 	Tag          string              `json:"tag"`
 	Timestamp    string              `json:"timestamp"`
 	Name         *string             `json:"name"`
-	Themes       []shared.Theme      `json:"themes"`
-	Theme        string              `json:"theme"` // legacy; expanded when Themes empty
+	Appearance   *appearanceRequest  `json:"appearance"`
 	History      []historyWire       `json:"history"`
 	Description  string              `json:"description"`
 	Meta         *shared.Meta        `json:"meta"`
@@ -1056,7 +1095,7 @@ func decodeStrictDataset(raw json.RawMessage, path string) (shared.Dataset, *api
 		history = append(history, shared.HistoryEntry{Tag: *entry.Tag, Timestamp: *entry.Timestamp, Meta: entry.Meta})
 	}
 
-	themes, validationErr := resolveDatasetWireThemes(wire.Themes, wire.Theme, path)
+	appearance, validationErr := decodeDatasetAppearance(wire.Appearance, path)
 	if validationErr != nil {
 		return shared.Dataset{}, validationErr
 	}
@@ -1066,7 +1105,7 @@ func decodeStrictDataset(raw json.RawMessage, path string) (shared.Dataset, *api
 		Tag:          wire.Tag,
 		Timestamp:    wire.Timestamp,
 		Name:         *wire.Name,
-		Themes:       themes,
+		Appearance:   appearance,
 		History:      history,
 		Description:  wire.Description,
 		Meta:         wire.Meta,
@@ -1077,26 +1116,32 @@ func decodeStrictDataset(raw json.RawMessage, path string) (shared.Dataset, *api
 	}, nil
 }
 
-// resolveDatasetWireThemes validates themes[] when non-empty, otherwise expands a
-// legacy theme string. Themes[0] is active; the legacy Theme string is not retained
-// on the returned catalog (new output uses Themes only).
-func resolveDatasetWireThemes(themes []shared.Theme, legacy string, datasetPath string) ([]shared.Theme, *apiValidationError) {
-	if len(themes) > 0 {
-		return validateRequestThemes(themes, datasetPath+"/themes")
-	}
-	legacy = strings.TrimSpace(legacy)
-	if legacy == "" || strings.EqualFold(legacy, "default") {
+func decodeDatasetAppearance(req *appearanceRequest, datasetPath string) (*shared.Appearance, *apiValidationError) {
+	if req == nil {
 		return nil, nil
 	}
-	// Match shared migrate: invalid legacy specs leave Themes empty rather
-	// than failing the whole dataset decode (soft for merge/UI inputs).
-	// Structured names equal to "default" also yield an empty catalog.
-	normalized := style.NormalizeTheme(legacy)
-	resolved, err := style.ResolveThemes([]string{normalized})
-	if err != nil || len(resolved) == 0 {
-		return nil, nil
+	var themes []shared.Theme
+	if len(req.Themes) > 0 {
+		validated, validationErr := validateRequestThemes(req.Themes, datasetPath+"/appearance/themes")
+		if validationErr != nil {
+			return nil, validationErr
+		}
+		themes = validated
+	} else if req.Theme != nil {
+		legacy := strings.TrimSpace(*req.Theme)
+		if legacy != "" && !strings.EqualFold(legacy, "default") {
+			normalized := style.NormalizeTheme(legacy)
+			resolved, err := style.ResolveThemes([]string{normalized})
+			if err == nil && len(resolved) > 0 {
+				themes = styleThemesToShared(resolved)
+			}
+		}
 	}
-	return styleThemesToShared(resolved), nil
+	fontSize, validationErr := decodeAPIFontSize(req.FontSize, datasetPath+"/appearance/fontSize")
+	if validationErr != nil {
+		return nil, validationErr
+	}
+	return shared.CompactAppearance(&shared.Appearance{Themes: themes, FontSize: fontSize}), nil
 }
 
 func decodeDatasetArray(rawDatasets []json.RawMessage, path string) ([]shared.Dataset, *apiValidationError) {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1428,6 +1428,8 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 			path   string
 		}{
 			{name: "null convert field", raw: `{"appearance":null}`, target: new(convertRequest), path: "/appearance"},
+			{name: "null appearance field", raw: `{"themes":null}`, target: new(appearanceRequest), path: "/appearance/themes"},
+			{name: "unknown appearance field", raw: `{"unexpected":true}`, target: new(appearanceRequest), path: "/appearance/unexpected"},
 			{name: "null title", raw: `{"title":null}`, target: new(convertRequest), path: "/title"},
 			{name: "null round", raw: `{"round":null}`, target: new(convertRequest), path: "/round"},
 			{name: "null col axis", raw: `{"colAxis":null}`, target: new(groupingOptions), path: "/grouping/colAxis"},
@@ -1539,6 +1541,20 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 		_, _, validationErr = buildConvertInput(convertRequest{Appearance: &appearanceRequest{Theme: &invalidTheme}}, []byte("x,y\\na,1\\n"))
 		s.Require().NotNil(validationErr)
 		s.Equal("/appearance/theme", validationErr.Path)
+
+		metadata, validationErr = buildConvertMetadata(convertRequest{
+			Appearance: &appearanceRequest{FontSize: json.RawMessage(`{"series":16,"legend":10}`)},
+		})
+		s.Require().Nil(validationErr)
+		s.Require().NotNil(metadata.FontSize)
+		s.Equal(16.0, *metadata.FontSize.Series)
+		s.Equal(10.0, *metadata.FontSize.Legend)
+
+		_, validationErr = buildConvertMetadata(convertRequest{
+			Appearance: &appearanceRequest{FontSize: json.RawMessage(`"14px"`)},
+		})
+		s.Require().NotNil(validationErr)
+		s.Equal("/appearance/fontSize", validationErr.Path)
 
 		_, _, validationErr = buildConvertInput(convertRequest{
 			Appearance: &appearanceRequest{Themes: []shared.Theme{{Name: "", Colors: []string{"#f00"}, VisualMapColors: []string{"#f00", "#0f0"}}}},
@@ -1654,6 +1670,18 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 		ds, validationErr = decodeStrictDataset(raw, "/datasets/0")
 		s.Require().Nil(validationErr)
 		s.Empty(ds.ThemeCatalog())
+
+		raw, err = json.Marshal(map[string]any{
+			"name":       name,
+			"appearance": map[string]any{"fontSize": 0},
+			"axes":       []map[string]any{{"key": "name"}, {"key": "y"}},
+			"settings":   []map[string]any{{"type": "bar"}},
+			"data":       []map[string]any{{"name": "case", "yAxis": "1"}},
+		})
+		s.Require().NoError(err)
+		_, validationErr = decodeStrictDataset(raw, "/datasets/0")
+		s.Require().NotNil(validationErr)
+		s.Equal("/datasets/0/appearance/fontSize", validationErr.Path)
 	})
 
 	s.Run("chart config decoding", func() {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -494,49 +494,54 @@ func (s *ServeSuite) TestConvertEndpoint() {
 func (s *ServeSuite) TestConvertEndpointEmbedsThemesCatalog() {
 	handler := newRESTHandler()
 
-	// Legacy theme string expands into themes[]; response has no legacy theme field.
+	// appearance.theme expands into appearance.themes; response has no theme string.
 	recorder := s.apiRequest(
 		handler,
 		"/",
-		`{"input":"region,value\nwest,12\n","parser":"csv","theme":"Westeros","charts":{"types":["bar"]}}`,
+		`{"input":"region,value\nwest,12\n","parser":"csv","appearance":{"theme":"Westeros"},"charts":{"types":["bar"]}}`,
 		"application/json",
 		"application/json",
 	)
 	s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
 	var dataset map[string]any
 	s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &dataset))
-	themes, ok := dataset["themes"].([]any)
+	appearance, ok := dataset["appearance"].(map[string]any)
+	s.Require().True(ok)
+	themes, ok := appearance["themes"].([]any)
 	s.Require().True(ok)
 	s.Require().Len(themes, 1)
 	s.Equal("westeros", themes[0].(map[string]any)["name"])
 	s.NotEmpty(themes[0].(map[string]any)["colors"])
 	s.Len(themes[0].(map[string]any)["visualMapColors"], 2)
-	_, hasLegacy := dataset["theme"]
+	_, hasLegacy := appearance["theme"]
 	s.False(hasLegacy)
+	_, hasRootTheme := dataset["theme"]
+	s.False(hasRootTheme)
+	_, hasRootThemes := dataset["themes"]
+	s.False(hasRootThemes)
 
-	// Explicit themes[] is echoed with themes[0] active.
 	body := `{
 		"input":"region,value\nwest,12\n",
 		"parser":"csv",
-		"themes":[
+		"appearance":{"themes":[
 			{"name":"brand","colors":["#f00","#0f0","#00f"],"visualMapColors":["#f00","#00f"]},
 			{"name":"alt","colors":["#111","#222"],"visualMapColors":["#111","#222"]}
-		],
+		]},
 		"charts":{"types":["bar"]}
 	}`
 	recorder = s.apiRequest(handler, "/", body, "application/json", "application/json")
 	s.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
 	s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &dataset))
-	themes = dataset["themes"].([]any)
+	appearance = dataset["appearance"].(map[string]any)
+	themes = appearance["themes"].([]any)
 	s.Require().Len(themes, 2)
 	s.Equal("brand", themes[0].(map[string]any)["name"])
 	s.Equal("alt", themes[1].(map[string]any)["name"])
 
-	// Invalid themes entry reports a clear JSON pointer path.
 	recorder = s.apiRequest(
 		handler,
 		"/",
-		`{"input":"x,y\na,1\n","themes":[{"name":"x","colors":["#f00"],"visualMapColors":["#f00"]}],"charts":{"types":["bar"]}}`,
+		`{"input":"x,y\na,1\n","appearance":{"themes":[{"name":"x","colors":["#f00"],"visualMapColors":["#f00"]}]},"charts":{"types":["bar"]}}`,
 		"application/json",
 		"application/json",
 	)
@@ -546,7 +551,7 @@ func (s *ServeSuite) TestConvertEndpointEmbedsThemesCatalog() {
 	}
 	s.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &problem))
 	s.Require().NotEmpty(problem.Errors)
-	s.Equal("/themes/0/visualMapColors", problem.Errors[0].Path)
+	s.Equal("/appearance/themes/0/visualMapColors", problem.Errors[0].Path)
 }
 
 func (s *ServeSuite) TestConvertEndpointSupportsBenchmarkFamilies() {
@@ -1422,8 +1427,7 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 			target any
 			path   string
 		}{
-			{name: "null convert field", raw: `{"theme":null}`, target: new(convertRequest), path: "/theme"},
-			{name: "null themes field", raw: `{"themes":null}`, target: new(convertRequest), path: "/themes"},
+			{name: "null convert field", raw: `{"appearance":null}`, target: new(convertRequest), path: "/appearance"},
 			{name: "null title", raw: `{"title":null}`, target: new(convertRequest), path: "/title"},
 			{name: "null round", raw: `{"round":null}`, target: new(convertRequest), path: "/round"},
 			{name: "null col axis", raw: `{"colAxis":null}`, target: new(groupingOptions), path: "/grouping/colAxis"},
@@ -1455,7 +1459,7 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 			Name:        &name,
 			Description: &description,
 			Tag:         &tag,
-			Theme:       &theme,
+			Appearance:  &appearanceRequest{Theme: &theme},
 		})
 		s.Require().Nil(validationErr)
 		s.Equal(id, metadata.ID)
@@ -1467,39 +1471,38 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 		s.NotEmpty(metadata.Themes[0].Colors)
 		s.Len(metadata.Themes[0].VisualMapColors, 2)
 
-		// themes[] wins over legacy theme string; Themes[0] is active.
 		legacy := "roma"
 		metadata, validationErr = buildConvertMetadata(convertRequest{
-			Themes: []shared.Theme{{
-				Name:            "brand",
-				Colors:          []string{"#f00", "#0f0", "#00f"},
-				VisualMapColors: []string{"#f00", "#00f"},
-			}, {
-				Name:            "secondary",
-				Colors:          []string{"#111", "#222"},
-				VisualMapColors: []string{"#111", "#222"},
-			}},
-			Theme: &legacy,
+			Appearance: &appearanceRequest{
+				Themes: []shared.Theme{{
+					Name:            "brand",
+					Colors:          []string{"#f00", "#0f0", "#00f"},
+					VisualMapColors: []string{"#f00", "#00f"},
+				}, {
+					Name:            "secondary",
+					Colors:          []string{"#111", "#222"},
+					VisualMapColors: []string{"#111", "#222"},
+				}},
+				Theme: &legacy,
+			},
 		})
 		s.Require().Nil(validationErr)
 		s.Require().Len(metadata.Themes, 2)
 		s.Equal("brand", metadata.Themes[0].Name)
 		s.Equal("secondary", metadata.Themes[1].Name)
 
-		// Built-in default is not embedded.
 		metadata, validationErr = buildConvertMetadata(convertRequest{
-			Themes: []shared.Theme{{
+			Appearance: &appearanceRequest{Themes: []shared.Theme{{
 				Name:            "default",
 				Colors:          []string{"#f00", "#0f0"},
 				VisualMapColors: []string{"#f00", "#0f0"},
-			}},
+			}}},
 		})
 		s.Require().Nil(validationErr)
 		s.Empty(metadata.Themes)
 
-		// Case-insensitive duplicate names are rejected.
 		_, _, validationErr = buildConvertInput(convertRequest{
-			Themes: []shared.Theme{{
+			Appearance: &appearanceRequest{Themes: []shared.Theme{{
 				Name:            "brand",
 				Colors:          []string{"#111", "#222"},
 				VisualMapColors: []string{"#111", "#222"},
@@ -1507,15 +1510,14 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 				Name:            "Brand",
 				Colors:          []string{"#aaa", "#bbb"},
 				VisualMapColors: []string{"#aaa", "#bbb"},
-			}},
+			}}},
 		}, []byte("x,y\\na,1\\n"))
 		s.Require().NotNil(validationErr)
-		s.Equal("/themes/1/name", validationErr.Path)
+		s.Equal("/appearance/themes/1/name", validationErr.Path)
 		s.Equal("duplicate_value", validationErr.Code)
 
-		// Duplicate "default" (including case variants) is also rejected.
 		_, _, validationErr = buildConvertInput(convertRequest{
-			Themes: []shared.Theme{{
+			Appearance: &appearanceRequest{Themes: []shared.Theme{{
 				Name:            "default",
 				Colors:          []string{"#f00", "#0f0"},
 				VisualMapColors: []string{"#f00", "#0f0"},
@@ -1523,69 +1525,71 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 				Name:            "DEFAULT",
 				Colors:          []string{"#0f0", "#00f"},
 				VisualMapColors: []string{"#0f0", "#00f"},
-			}},
+			}}},
 		}, []byte("x,y\\na,1\\n"))
 		s.Require().NotNil(validationErr)
-		s.Equal("/themes/1/name", validationErr.Path)
+		s.Equal("/appearance/themes/1/name", validationErr.Path)
 
 		defaultTheme := "default"
-		metadata, validationErr = buildConvertMetadata(convertRequest{Theme: &defaultTheme})
+		metadata, validationErr = buildConvertMetadata(convertRequest{Appearance: &appearanceRequest{Theme: &defaultTheme}})
 		s.Require().Nil(validationErr)
 		s.Empty(metadata.Themes)
 
 		invalidTheme := "not-a-theme"
-		_, _, validationErr = buildConvertInput(convertRequest{Theme: &invalidTheme}, []byte("x,y\\na,1\\n"))
+		_, _, validationErr = buildConvertInput(convertRequest{Appearance: &appearanceRequest{Theme: &invalidTheme}}, []byte("x,y\\na,1\\n"))
 		s.Require().NotNil(validationErr)
-		s.Equal("/theme", validationErr.Path)
+		s.Equal("/appearance/theme", validationErr.Path)
 
 		_, _, validationErr = buildConvertInput(convertRequest{
-			Themes: []shared.Theme{{Name: "", Colors: []string{"#f00"}, VisualMapColors: []string{"#f00", "#0f0"}}},
+			Appearance: &appearanceRequest{Themes: []shared.Theme{{Name: "", Colors: []string{"#f00"}, VisualMapColors: []string{"#f00", "#0f0"}}}},
 		}, []byte("x,y\\na,1\\n"))
 		s.Require().NotNil(validationErr)
-		s.Equal("/themes/0/name", validationErr.Path)
+		s.Equal("/appearance/themes/0/name", validationErr.Path)
 
 		_, _, validationErr = buildConvertInput(convertRequest{
-			Themes: []shared.Theme{{Name: "brand", Colors: nil, VisualMapColors: []string{"#f00", "#0f0"}}},
+			Appearance: &appearanceRequest{Themes: []shared.Theme{{Name: "brand", Colors: nil, VisualMapColors: []string{"#f00", "#0f0"}}}},
 		}, []byte("x,y\\na,1\\n"))
 		s.Require().NotNil(validationErr)
-		s.Equal("/themes/0/colors", validationErr.Path)
+		s.Equal("/appearance/themes/0/colors", validationErr.Path)
 
 		_, _, validationErr = buildConvertInput(convertRequest{
-			Themes: []shared.Theme{{Name: "brand", Colors: []string{"#f00", "#0f0"}, VisualMapColors: []string{"#f00"}}},
+			Appearance: &appearanceRequest{Themes: []shared.Theme{{Name: "brand", Colors: []string{"#f00", "#0f0"}, VisualMapColors: []string{"#f00"}}}},
 		}, []byte("x,y\\na,1\\n"))
 		s.Require().NotNil(validationErr)
-		s.Equal("/themes/0/visualMapColors", validationErr.Path)
+		s.Equal("/appearance/themes/0/visualMapColors", validationErr.Path)
 
 		_, _, validationErr = buildConvertInput(convertRequest{
-			Themes: []shared.Theme{{
+			Appearance: &appearanceRequest{Themes: []shared.Theme{{
 				Name:            "brand",
 				Colors:          []string{"  ", "#0f0"},
 				VisualMapColors: []string{"#f00", "#0f0"},
-			}},
+			}}},
 		}, []byte("x,y\\na,1\\n"))
 		s.Require().NotNil(validationErr)
-		s.Equal("/themes/0/colors/0", validationErr.Path)
+		s.Equal("/appearance/themes/0/colors/0", validationErr.Path)
 
 		_, _, validationErr = buildConvertInput(convertRequest{
-			Themes: []shared.Theme{{
+			Appearance: &appearanceRequest{Themes: []shared.Theme{{
 				Name:            "brand",
 				Colors:          []string{"#f00", "#0f0"},
 				VisualMapColors: []string{"#f00", "  "},
-			}},
+			}}},
 		}, []byte("x,y\\na,1\\n"))
 		s.Require().NotNil(validationErr)
-		s.Equal("/themes/0/visualMapColors/1", validationErr.Path)
+		s.Equal("/appearance/themes/0/visualMapColors/1", validationErr.Path)
 	})
 
 	s.Run("dataset wire themes", func() {
 		name := "Bench"
 		raw, err := json.Marshal(map[string]any{
 			"name": name,
-			"themes": []map[string]any{{
-				"name":            "roma",
-				"colors":          []string{"#E01F54", "#001852"},
-				"visualMapColors": []string{"#a4d8c2", "#E01F54"},
-			}},
+			"appearance": map[string]any{
+				"themes": []map[string]any{{
+					"name":            "roma",
+					"colors":          []string{"#E01F54", "#001852"},
+					"visualMapColors": []string{"#a4d8c2", "#E01F54"},
+				}},
+			},
 			"axes":     []map[string]any{{"key": "name"}, {"key": "y"}},
 			"settings": []map[string]any{{"type": "bar"}},
 			"data":     []map[string]any{{"name": "case", "yAxis": "1"}},
@@ -1593,33 +1597,31 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 		s.Require().NoError(err)
 		ds, validationErr := decodeStrictDataset(raw, "/datasets/0")
 		s.Require().Nil(validationErr)
-		s.Require().Len(ds.Themes, 1)
-		s.Equal("roma", ds.Themes[0].Name)
-		s.Empty(ds.Theme)
+		s.Require().Len(ds.ThemeCatalog(), 1)
+		s.Equal("roma", ds.ThemeCatalog()[0].Name)
 
-		// Legacy theme string expands into Themes.
 		raw, err = json.Marshal(map[string]any{
-			"name":     name,
-			"theme":    "vintage",
-			"axes":     []map[string]any{{"key": "name"}, {"key": "y"}},
-			"settings": []map[string]any{{"type": "bar"}},
-			"data":     []map[string]any{{"name": "case", "yAxis": "1"}},
+			"name":       name,
+			"appearance": map[string]any{"theme": "vintage"},
+			"axes":       []map[string]any{{"key": "name"}, {"key": "y"}},
+			"settings":   []map[string]any{{"type": "bar"}},
+			"data":       []map[string]any{{"name": "case", "yAxis": "1"}},
 		})
 		s.Require().NoError(err)
 		ds, validationErr = decodeStrictDataset(raw, "/datasets/0")
 		s.Require().Nil(validationErr)
-		s.Require().Len(ds.Themes, 1)
-		s.Equal("vintage", ds.Themes[0].Name)
-		s.Empty(ds.Theme)
+		s.Require().Len(ds.ThemeCatalog(), 1)
+		s.Equal("vintage", ds.ThemeCatalog()[0].Name)
 
-		// Invalid themes[] entry surfaces a clear path.
 		raw, err = json.Marshal(map[string]any{
 			"name": name,
-			"themes": []map[string]any{{
-				"name":            "bad",
-				"colors":          []string{"#f00"},
-				"visualMapColors": []string{"#f00"},
-			}},
+			"appearance": map[string]any{
+				"themes": []map[string]any{{
+					"name":            "bad",
+					"colors":          []string{"#f00"},
+					"visualMapColors": []string{"#f00"},
+				}},
+			},
 			"axes":     []map[string]any{{"key": "name"}, {"key": "y"}},
 			"settings": []map[string]any{{"type": "bar"}},
 			"data":     []map[string]any{{"name": "case", "yAxis": "1"}},
@@ -1627,33 +1629,31 @@ func (s *ServeSuite) TestRequestContractHelpers() {
 		s.Require().NoError(err)
 		_, validationErr = decodeStrictDataset(raw, "/datasets/0")
 		s.Require().NotNil(validationErr)
-		s.Equal("/datasets/0/themes/0/visualMapColors", validationErr.Path)
+		s.Equal("/datasets/0/appearance/themes/0/visualMapColors", validationErr.Path)
 
-		// Invalid legacy theme is soft: empty Themes, no validation error.
 		raw, err = json.Marshal(map[string]any{
-			"name":     name,
-			"theme":    "not-a-theme",
-			"axes":     []map[string]any{{"key": "name"}, {"key": "y"}},
-			"settings": []map[string]any{{"type": "bar"}},
-			"data":     []map[string]any{{"name": "case", "yAxis": "1"}},
+			"name":       name,
+			"appearance": map[string]any{"theme": "not-a-theme"},
+			"axes":       []map[string]any{{"key": "name"}, {"key": "y"}},
+			"settings":   []map[string]any{{"type": "bar"}},
+			"data":       []map[string]any{{"name": "case", "yAxis": "1"}},
 		})
 		s.Require().NoError(err)
 		ds, validationErr = decodeStrictDataset(raw, "/datasets/0")
 		s.Require().Nil(validationErr)
-		s.Empty(ds.Themes)
+		s.Empty(ds.ThemeCatalog())
 
-		// Structured default name expands to an empty catalog (UI owns default).
 		raw, err = json.Marshal(map[string]any{
-			"name":     name,
-			"theme":    "default:colors=#f00,#0f0",
-			"axes":     []map[string]any{{"key": "name"}, {"key": "y"}},
-			"settings": []map[string]any{{"type": "bar"}},
-			"data":     []map[string]any{{"name": "case", "yAxis": "1"}},
+			"name":       name,
+			"appearance": map[string]any{"theme": "default:colors=#f00,#0f0"},
+			"axes":       []map[string]any{{"key": "name"}, {"key": "y"}},
+			"settings":   []map[string]any{{"type": "bar"}},
+			"data":       []map[string]any{{"name": "case", "yAxis": "1"}},
 		})
 		s.Require().NoError(err)
 		ds, validationErr = decodeStrictDataset(raw, "/datasets/0")
 		s.Require().Nil(validationErr)
-		s.Empty(ds.Themes)
+		s.Empty(ds.ThemeCatalog())
 	})
 
 	s.Run("chart config decoding", func() {

--- a/docs/src/content/docs/ci-cd/github-action.mdx
+++ b/docs/src/content/docs/ci-cd/github-action.mdx
@@ -70,7 +70,7 @@ The action:
 | `chart` | `""` | Per-chart overrides (`--chart` flag, repeatable). One override per line: `<type>:<props>`. Keys include `swap`, `sort`, `scale`, `stack`, `labels`, `3d-rotate`, `3d`, `symbol`, `symbol-size`, `smooth`, `horizontal`, `border-radius`, `bg`, `stat`. Comma separates single-value props; for multi-value props (e.g. `stat=center,spread`) use semicolon between props or put the multi-value prop alone. Object props use `{field=value;field=value}` (semicolons inside braces; commas stay literal) — e.g. `bar:bg`, `bar:bg={color=rgba(180, 180, 180, 0.2);borderColor=#000}`. Unwrapped `bar:bg=color=…` is invalid. Blank lines and `#`-prefixed lines are ignored. |
 | `charts` | `"bar,line,pie"` | Chart types to generate (`-c` flag): `bar`, `line`, `scatter`, `pie`, `heatmap`, `radar`, `sankey`, `chord`. |
 | `parser` | `"auto"` | Parser to use: `csv`, `json`, `go`, `js:tinybench`, `js:vitest`, `rs:criterion`, `rs:divan` (`-P` flag). |
-| `font-size` | `""` | Chart text size (`--font-size`). A number sets series, legend, and axis ticks; or `series=;legend=;label=` bag. |
+| `font-size` | `""` | Chart text size (`--font-size`). A number sets series, legend, and axis ticks; or `series=16;legend=10;label=12` bag. |
 | `show-labels` | `"false"` | **Deprecated:** use `chart` input instead (e.g. `chart: 'pie:labels'`). Show labels on charts (`-l` flag). |
 | `enable-3d` | `"false"` | Bundle the 3D renderer for `vizb ui` (`--3d` flag, mainly useful with `data-url` when remote data shape is unknown at build time). |
 | `merge-files` | `""` | Space-separated JSON files to merge. |

--- a/docs/src/content/docs/ci-cd/github-action.mdx
+++ b/docs/src/content/docs/ci-cd/github-action.mdx
@@ -70,6 +70,7 @@ The action:
 | `chart` | `""` | Per-chart overrides (`--chart` flag, repeatable). One override per line: `<type>:<props>`. Keys include `swap`, `sort`, `scale`, `stack`, `labels`, `3d-rotate`, `3d`, `symbol`, `symbol-size`, `smooth`, `horizontal`, `border-radius`, `bg`, `stat`. Comma separates single-value props; for multi-value props (e.g. `stat=center,spread`) use semicolon between props or put the multi-value prop alone. Object props use `{field=value;field=value}` (semicolons inside braces; commas stay literal) — e.g. `bar:bg`, `bar:bg={color=rgba(180, 180, 180, 0.2);borderColor=#000}`. Unwrapped `bar:bg=color=…` is invalid. Blank lines and `#`-prefixed lines are ignored. |
 | `charts` | `"bar,line,pie"` | Chart types to generate (`-c` flag): `bar`, `line`, `scatter`, `pie`, `heatmap`, `radar`, `sankey`, `chord`. |
 | `parser` | `"auto"` | Parser to use: `csv`, `json`, `go`, `js:tinybench`, `js:vitest`, `rs:criterion`, `rs:divan` (`-P` flag). |
+| `font-size` | `""` | Chart text size (`--font-size`). A number sets series, legend, and axis ticks; or `series=;legend=;label=` bag. |
 | `show-labels` | `"false"` | **Deprecated:** use `chart` input instead (e.g. `chart: 'pie:labels'`). Show labels on charts (`-l` flag). |
 | `enable-3d` | `"false"` | Bundle the 3D renderer for `vizb ui` (`--3d` flag, mainly useful with `data-url` when remote data shape is unknown at build time). |
 | `merge-files` | `""` | Space-separated JSON files to merge. |

--- a/docs/src/content/docs/commands/root.mdx
+++ b/docs/src/content/docs/commands/root.mdx
@@ -76,6 +76,7 @@ See the [Parser Guide](/guides/parsers) for each parser's metrics, and the
 | `--parser` | `-P` | `auto` | Parser: `auto` (detect), `go`, `js:tinybench`, `js:vitest`, `rs:criterion`, `rs:divan`, `csv`, `json` |
 | `--name` | `-n` | `Benchmarks` | Dataset name |
 | `--theme` | | *(empty)* | Embed a color theme on the dataset (**repeatable**; first is active). Built-in name, structured `name:colors=#hex,...;visualMapColors=#hex,#hex`, or bare `#hex,#hex,...` palette. Empty when unset (UI default). Built-in `default` is not embedded. |
+| `--font-size` | | *(empty)* | Chart text size in CSS pixels. A number sets series data labels, legend, and axis ticks to that size. A bag sets keys individually: `series=16;legend=10;label=12`. Invalid keys/values warn and skip. |
 | `--description` | `-d` | `""` | Dataset description |
 | `--tag` | `-t` | `""` | Tag identifier for release tracking |
 | `--id` | | `""` | Stable dataset id for `?id=` deep links in the HTML UI |
@@ -95,9 +96,13 @@ See the [Parser Guide](/guides/parsers) for each parser's metrics, and the
 | `--round` | | off | Round numeric values to 2 decimal places **in the output data** (irreversible in the written file; off by default) |
 
 `--theme` changes series colors only; light/dark mode remains independent. Themes expand into
-`dataset.themes[]` with `themes[0]` active (no separate active field on new output). See [Color
+`dataset.appearance.themes[]` with `themes[0]` active (no separate active field on new output). See [Color
 Themes](/ui/themes) for the CLI catalog, structured syntax, multi-theme selector rules, and
 localStorage behavior.
+
+`--font-size` is baked into `dataset.appearance.fontSize` (CLI/JSON only; no settings-panel control).
+A JSON number means all three targets; an object sets `series` (data labels), `legend`, and `label`
+(axis ticks) independently. Omitted keys stay at 12px.
 
 ```bash
 # Built-in

--- a/docs/src/content/docs/commands/serve.mdx
+++ b/docs/src/content/docs/commands/serve.mdx
@@ -111,8 +111,8 @@ When non-empty, `themes[0]` is the active theme; there is no separate active
 field. Built-in `default` is not embedded (the UI owns it). Inbound
 `appearance.theme` is expanded into `appearance.themes` and omitted from
 responses. See [Color Themes](/ui/themes) and the [API reference](/api/)
-for the full `Theme` object shape. Optional `appearance.fontSize` is a number
-or `{series, legend, label}` object (CSS pixels).
+for the full `Theme` object shape. Optional `appearance.fontSize` is a positive number
+or `{series, legend, label}` object of positive sizes (CSS pixels).
 
 Top-level `round` (default `false`) matches CLI `--round`: round numeric values
 to 2 decimal places in the output data.

--- a/docs/src/content/docs/commands/serve.mdx
+++ b/docs/src/content/docs/commands/serve.mdx
@@ -90,13 +90,15 @@ curl -sS http://127.0.0.1:8080/ \
     "name": "API latency",
     "description": "Latency by region",
     "tag": "v2",
-    "themes": [
-      {
-        "name": "westeros",
-        "colors": ["#516b91", "#59c4e6", "#edafda", "#93b7e3", "#a5e7f0", "#cbb0e3", "#3f5575", "#41a7cb", "#d58fc4", "#789bc7"],
-        "visualMapColors": ["#59c4e6", "#d58fc4"]
-      }
-    ],
+    "appearance": {
+      "themes": [
+        {
+          "name": "westeros",
+          "colors": ["#516b91", "#59c4e6", "#edafda", "#93b7e3", "#a5e7f0", "#cbb0e3", "#3f5575", "#41a7cb", "#d58fc4", "#789bc7"],
+          "visualMapColors": ["#59c4e6", "#d58fc4"]
+        }
+      ]
+    },
     "parser": "csv",
     "select": ["region,latency"],
     "charts": { "types": ["bar", "line"] },
@@ -104,12 +106,13 @@ curl -sS http://127.0.0.1:8080/ \
   }'
 ```
 
-Prefer the data-owned `themes` array on convert requests and Dataset responses.
+Prefer `appearance.themes` on convert requests and Dataset responses.
 When non-empty, `themes[0]` is the active theme; there is no separate active
-field. Built-in `default` is not embedded (the UI owns it). The legacy string
-`theme` field is still accepted and expanded into `themes` when `themes` is
-omitted or empty. See [Color Themes](/ui/themes) and the [API reference](/api/)
-for the full `Theme` object shape.
+field. Built-in `default` is not embedded (the UI owns it). Inbound
+`appearance.theme` is expanded into `appearance.themes` and omitted from
+responses. See [Color Themes](/ui/themes) and the [API reference](/api/)
+for the full `Theme` object shape. Optional `appearance.fontSize` is a number
+or `{series, legend, label}` object (CSS pixels).
 
 Top-level `round` (default `false`) matches CLI `--round`: round numeric values
 to 2 decimal places in the output data.

--- a/docs/src/content/docs/ui/settings.mdx
+++ b/docs/src/content/docs/ui/settings.mdx
@@ -21,6 +21,7 @@ Prefer **per-chart** flags when generating multi-chart HTML. Root-level `--sort`
 | `--donut` / `--chart pie:donut` | Donut switch | on / off — pie only; off is filled |
 | `--chart bar:3d-rotate` (or line/scatter) | Auto rotate | on / off — 3D bar / line / scatter |
 | `--chart bar:bg` or `vizb bar --bg` | — | on / off — 2D bar only; CLI/config, no UI toggle; writes `background.active: true` |
+| `--font-size` | — | baked into `appearance.fontSize`; no panel control |
 | `--stat` | Statistics button | off unless set; see [Statistics](/ui/stats) |
 
 ## Setting Defaults from CLI

--- a/docs/src/content/docs/ui/themes.mdx
+++ b/docs/src/content/docs/ui/themes.mdx
@@ -15,10 +15,10 @@ Themes are **owned by the dataset**, not hard-coded into every report UI.
 | Layer | Role |
 |-------|------|
 | **UI** | Ships only the `default` palette. Always available as a fallback. |
-| **CLI / API** | Expand built-ins and custom specs into `dataset.themes[]` when you request them. |
-| **Wire format** | New output writes `themes` only. There is **no separate active `theme` field** — `themes[0]` is active when the array is non-empty. |
+| **CLI / API** | Expand built-ins and custom specs into `dataset.appearance.themes[]` when you request them. |
+| **Wire format** | New output writes `appearance.themes` only. There is **no separate active `theme` field** — `themes[0]` is active when the array is non-empty. Inbound `appearance.theme` (name or palette) expands into that catalog and is not re-emitted. |
 
-If you omit `--theme`, the dataset has no `themes` array and the report uses the UI `default` palette.
+If you omit `--theme`, the dataset has no `appearance.themes` array and the report uses the UI `default` palette.
 
 ```bash
 # Single built-in embedded as themes[0] (active)
@@ -30,8 +30,8 @@ vizb results.csv --theme westeros --theme vintage --theme roma -o report.html
 
 Built-in name `default` is **not** embedded (the UI already owns it).
 
-Legacy files that still carry a string `theme` field are migrated into `themes[]`
-on load; re-marshalled output drops the legacy field.
+Inbound `appearance.theme` is expanded into `appearance.themes[]` on load;
+re-marshalled output drops the string field.
 
 ## CLI syntax
 

--- a/docs/src/data/themeCatalog.ts
+++ b/docs/src/data/themeCatalog.ts
@@ -1,6 +1,6 @@
 // Docs-only CLI built-in swatches for /ui/themes. Source of truth is
 // pkg/style (theme catalog), not the UI bundle — the report UI ships only
-// `default`; other built-ins expand from the CLI into dataset.themes[].
+// `default`; other built-ins expand from the CLI into dataset.appearance.themes[].
 // Keep in sync when palettes change in pkg/style.
 
 export const THEMES = {

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -27,12 +27,13 @@ import (
 
 // Metadata is the caller-supplied Dataset metadata for Convert.
 // Themes is the data-owned theme catalog (Themes[0] active when non-empty).
-// Leave Themes empty for the UI default palette; do not set the legacy
-// Dataset.Theme string on new output.
+// Leave Themes empty for the UI default palette. Assemble writes both Themes
+// and FontSize into Dataset.Appearance.
 type Metadata struct {
 	ID          string
 	Name        string
 	Themes      []shared.Theme
+	FontSize    *shared.FontSize
 	Description string
 	Tag         string
 	System      *shared.Meta
@@ -379,9 +380,12 @@ func Assemble(in AssembleInput) *shared.Dataset {
 		timestamp = time.Now().UTC().Format(time.RFC3339)
 	}
 	ds := &shared.Dataset{
-		ID:           strings.TrimSpace(meta.ID),
-		Name:         name,
-		Themes:       meta.Themes,
+		ID:   strings.TrimSpace(meta.ID),
+		Name: name,
+		Appearance: shared.CompactAppearance(&shared.Appearance{
+			Themes:   meta.Themes,
+			FontSize: meta.FontSize,
+		}),
 		Description:  meta.Description,
 		Tag:          meta.Tag,
 		Timestamp:    timestamp,

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -361,8 +361,8 @@ func (s *CoreSuite) TestAssembleEmbedsThemesWithoutLegacyTheme() {
 		Metadata: Metadata{Name: "T", Themes: themes},
 		Charts:   []internalcharts.ChartConfig{&barchart.Config{Type: "bar"}},
 	})
-	s.Empty(dataset.Theme)
-	s.Equal(themes, dataset.Themes)
+	s.Equal(themes, dataset.ThemeCatalog())
+	s.Empty(dataset.Appearance.Theme)
 
 	empty := Assemble(AssembleInput{
 		Points:   []shared.DataPoint{{XAxis: "west", YAxis: "12"}},
@@ -371,8 +371,8 @@ func (s *CoreSuite) TestAssembleEmbedsThemesWithoutLegacyTheme() {
 		Metadata: Metadata{Name: "T"},
 		Charts:   []internalcharts.ChartConfig{&barchart.Config{Type: "bar"}},
 	})
-	s.Empty(empty.Theme)
-	s.Empty(empty.Themes)
+	s.Nil(empty.Appearance)
+	s.Empty(empty.ThemeCatalog())
 }
 
 func (s *CoreSuite) TestAssembleModesAndThreeD() {

--- a/shared/dataset.go
+++ b/shared/dataset.go
@@ -68,7 +68,7 @@ type HistoryEntry struct {
 }
 
 // Theme is a fully expanded color theme embedded on a dataset.
-// When Dataset.Themes is non-empty, Themes[0] is the active theme;
+// When Appearance.Themes is non-empty, Themes[0] is the active theme;
 // there is no separate active-theme field on the wire format.
 type Theme struct {
 	Name            string   `json:"name"`
@@ -76,18 +76,42 @@ type Theme struct {
 	VisualMapColors []string `json:"visualMapColors"`
 }
 
+// Appearance is dataset-level visual settings (theme catalog and font sizes).
+type Appearance struct {
+	Themes   []Theme   `json:"themes,omitempty"`
+	Theme    string    `json:"theme,omitempty"` // inbound string; cleared after expansion
+	FontSize *FontSize `json:"fontSize,omitempty"`
+}
+
+func (a *Appearance) empty() bool {
+	return a == nil || (len(a.Themes) == 0 && a.Theme == "" && a.FontSize.Empty())
+}
+
+// CompactAppearance returns nil when a has no themes, theme string, or fontSize.
+// ThemeCatalog returns appearance.themes, or nil when appearance is absent.
+func (d Dataset) ThemeCatalog() []Theme {
+	if d.Appearance == nil {
+		return nil
+	}
+	return d.Appearance.Themes
+}
+
+func CompactAppearance(a *Appearance) *Appearance {
+	if a.empty() {
+		return nil
+	}
+	if a.FontSize.Empty() {
+		a.FontSize = nil
+	}
+	return a
+}
+
 type Dataset struct {
-	ID        string `json:"id,omitempty"`
-	Tag       string `json:"tag,omitempty"`
-	Timestamp string `json:"timestamp,omitempty"`
-	Name      string `json:"name"`
-	// Themes is the data-owned theme catalog. Themes[0] is active when present.
-	// New output writes Themes only (not the legacy Theme string).
-	Themes []Theme `json:"themes,omitempty"`
-	// Theme is the legacy single theme name/spec (pre-themes-array wire).
-	// Used only when unmarshalling old files; migrateLegacyTheme expands it
-	// into Themes and clears this field so re-marshal does not emit both.
-	Theme       string                        `json:"theme,omitempty"`
+	ID          string                        `json:"id,omitempty"`
+	Tag         string                        `json:"tag,omitempty"`
+	Timestamp   string                        `json:"timestamp,omitempty"`
+	Name        string                        `json:"name"`
+	Appearance  *Appearance                   `json:"appearance,omitempty"`
 	History     []HistoryEntry                `json:"history,omitempty"`
 	Description string                        `json:"description,omitempty"`
 	Meta        *Meta                         `json:"meta,omitempty"`
@@ -119,8 +143,7 @@ func (d *Dataset) UnmarshalJSON(data []byte) error {
 		Tag          string          `json:"tag,omitempty"`
 		Timestamp    string          `json:"timestamp,omitempty"`
 		Name         string          `json:"name"`
-		Themes       []Theme         `json:"themes,omitempty"`
-		Theme        string          `json:"theme,omitempty"`
+		Appearance   *Appearance     `json:"appearance,omitempty"`
 		History      []HistoryEntry  `json:"history,omitempty"`
 		Description  string          `json:"description,omitempty"`
 		Meta         *Meta           `json:"meta,omitempty"`
@@ -136,8 +159,7 @@ func (d *Dataset) UnmarshalJSON(data []byte) error {
 	d.Tag = raw.Tag
 	d.Timestamp = raw.Timestamp
 	d.Name = raw.Name
-	d.Themes = raw.Themes
-	d.Theme = raw.Theme
+	d.Appearance = raw.Appearance
 	d.History = raw.History
 	d.Description = raw.Description
 	d.Meta = raw.Meta
@@ -149,7 +171,7 @@ func (d *Dataset) UnmarshalJSON(data []byte) error {
 	// Settings nil so MigrateDataset can populate it from the legacy struct.
 	if len(raw.Settings) == 0 || raw.Settings[0] != '[' {
 		d.Settings = nil
-		d.migrateLegacyTheme()
+		d.migrateAppearance()
 		return nil
 	}
 
@@ -159,7 +181,7 @@ func (d *Dataset) UnmarshalJSON(data []byte) error {
 	}
 	if len(entries) == 0 {
 		d.Settings = nil
-		d.migrateLegacyTheme()
+		d.migrateAppearance()
 		return nil
 	}
 
@@ -180,24 +202,29 @@ func (d *Dataset) UnmarshalJSON(data []byte) error {
 		}
 		d.Settings = append(d.Settings, cfg)
 	}
-	d.migrateLegacyTheme()
+	d.migrateAppearance()
 	return nil
 }
 
-// migrateLegacyTheme expands a legacy Theme string into Themes when Themes is
-// empty. Themes[0] is the active theme when present. Built-in "default" and
-// empty specs leave Themes empty (UI owns the default palette). Invalid specs
-// leave Theme untouched so data is not discarded.
-func (d *Dataset) migrateLegacyTheme() {
-	if len(d.Themes) > 0 {
-		// Prefer Themes; drop legacy string so re-marshal does not emit both.
-		d.Theme = ""
+func (d *Dataset) migrateAppearance() {
+	if d.Appearance != nil {
+		d.Appearance.migrateTheme()
+	}
+	d.Appearance = CompactAppearance(d.Appearance)
+}
+
+// migrateTheme expands Appearance.Theme into Themes when Themes is empty.
+// Built-in "default" and empty specs leave Themes empty (UI owns the default
+// palette). Invalid specs leave Theme untouched so data is not discarded.
+func (a *Appearance) migrateTheme() {
+	if len(a.Themes) > 0 {
+		a.Theme = ""
 		return
 	}
 
-	legacy := strings.TrimSpace(d.Theme)
+	legacy := strings.TrimSpace(a.Theme)
 	if legacy == "" || strings.EqualFold(legacy, "default") {
-		d.Theme = ""
+		a.Theme = ""
 		return
 	}
 
@@ -206,12 +233,12 @@ func (d *Dataset) migrateLegacyTheme() {
 		return
 	}
 	if strings.EqualFold(parsed.Name, "default") {
-		d.Theme = ""
+		a.Theme = ""
 		return
 	}
 
-	d.Themes = []Theme{themeFromStyle(parsed)}
-	d.Theme = ""
+	a.Themes = []Theme{themeFromStyle(parsed)}
+	a.Theme = ""
 }
 
 func themeFromStyle(t style.Theme) Theme {

--- a/shared/dataset_test.go
+++ b/shared/dataset_test.go
@@ -93,7 +93,7 @@ func (s *DatasetSuite) TestDatasetUnmarshalJSONEmptySettings() {
 func (s *DatasetSuite) TestDatasetIDTopLevelRoundTrip() {
 	raw := []byte(`{
 		"id":"bench-v1",
-		"theme":"purple-passion",
+		"appearance":{"theme":"purple-passion"},
 		"name":"bench",
 		"meta":{"os":"linux"},
 		"settings":[{"type":"bar"}],
@@ -103,16 +103,15 @@ func (s *DatasetSuite) TestDatasetIDTopLevelRoundTrip() {
 	var ds shared.Dataset
 	s.Require().NoError(json.Unmarshal(raw, &ds))
 	s.Equal("bench-v1", ds.ID)
-	// Legacy theme string migrates into Themes; Theme is cleared.
-	s.Empty(ds.Theme)
-	s.Require().Len(ds.Themes, 1)
-	s.Equal("purple-passion", ds.Themes[0].Name)
+	s.Require().Len(ds.ThemeCatalog(), 1)
+	s.Equal("purple-passion", ds.ThemeCatalog()[0].Name)
 	s.Require().NotNil(ds.Meta)
 	s.Equal("linux", ds.Meta.OS)
 
 	out, err := json.Marshal(ds)
 	s.Require().NoError(err)
 	s.Contains(string(out), `"id":"bench-v1"`)
+	s.Contains(string(out), `"appearance"`)
 	s.Contains(string(out), `"themes"`)
 	s.NotContains(string(out), `"theme":`)
 }
@@ -120,82 +119,80 @@ func (s *DatasetSuite) TestDatasetIDTopLevelRoundTrip() {
 func (s *DatasetSuite) TestUnmarshalNewThemesArray() {
 	raw := []byte(`{
 		"name":"bench",
-		"themes":[
+		"appearance":{"themes":[
 			{"name":"roma","colors":["#E01F54","#001852"],"visualMapColors":["#a4d8c2","#E01F54"]},
 			{"name":"custom","colors":["#f00","#0f0","#00f"],"visualMapColors":["#f00","#00f"]}
-		],
+		]},
 		"data":[]
 	}`)
 
 	var ds shared.Dataset
 	s.Require().NoError(json.Unmarshal(raw, &ds))
-	s.Empty(ds.Theme)
-	s.Require().Len(ds.Themes, 2)
-	s.Equal("roma", ds.Themes[0].Name)
-	s.Equal([]string{"#E01F54", "#001852"}, ds.Themes[0].Colors)
-	s.Equal([]string{"#a4d8c2", "#E01F54"}, ds.Themes[0].VisualMapColors)
-	s.Equal("custom", ds.Themes[1].Name)
-	s.Equal([]string{"#f00", "#0f0", "#00f"}, ds.Themes[1].Colors)
+	s.Require().Len(ds.ThemeCatalog(), 2)
+	s.Equal("roma", ds.ThemeCatalog()[0].Name)
+	s.Equal([]string{"#E01F54", "#001852"}, ds.ThemeCatalog()[0].Colors)
+	s.Equal([]string{"#a4d8c2", "#E01F54"}, ds.ThemeCatalog()[0].VisualMapColors)
+	s.Equal("custom", ds.ThemeCatalog()[1].Name)
+	s.Equal([]string{"#f00", "#0f0", "#00f"}, ds.ThemeCatalog()[1].Colors)
 }
 
-func (s *DatasetSuite) TestUnmarshalLegacyThemeRoma() {
-	raw := []byte(`{"name":"bench","theme":"roma","data":[]}`)
+func (s *DatasetSuite) TestUnmarshalAppearanceThemeRoma() {
+	raw := []byte(`{"name":"bench","appearance":{"theme":"roma"},"data":[]}`)
 
 	var ds shared.Dataset
 	s.Require().NoError(json.Unmarshal(raw, &ds))
-	s.Empty(ds.Theme)
-	s.Require().Len(ds.Themes, 1)
-	s.Equal("roma", ds.Themes[0].Name)
+	s.Require().Len(ds.ThemeCatalog(), 1)
+	s.Equal("roma", ds.ThemeCatalog()[0].Name)
 	s.Equal([]string{
 		"#E01F54", "#001852", "#f5e8c8", "#b8d2c7", "#c6b38e",
 		"#a4d8c2", "#f3d999", "#d3758f", "#dcc392", "#2e4783",
-	}, ds.Themes[0].Colors)
-	s.Equal([]string{"#a4d8c2", "#E01F54"}, ds.Themes[0].VisualMapColors)
+	}, ds.ThemeCatalog()[0].Colors)
+	s.Equal([]string{"#a4d8c2", "#E01F54"}, ds.ThemeCatalog()[0].VisualMapColors)
 }
 
-func (s *DatasetSuite) TestUnmarshalLegacyThemeCustomHex() {
-	raw := []byte(`{"name":"bench","theme":"#f00,#0f0","data":[]}`)
+func (s *DatasetSuite) TestUnmarshalAppearanceThemeCustomHex() {
+	raw := []byte(`{"name":"bench","appearance":{"theme":"#f00,#0f0"},"data":[]}`)
 
 	var ds shared.Dataset
 	s.Require().NoError(json.Unmarshal(raw, &ds))
-	s.Empty(ds.Theme)
-	s.Require().Len(ds.Themes, 1)
-	s.Equal("custom", ds.Themes[0].Name)
-	s.Equal([]string{"#f00", "#0f0"}, ds.Themes[0].Colors)
-	s.Equal([]string{"#f00", "#0f0"}, ds.Themes[0].VisualMapColors)
+	s.Require().Len(ds.ThemeCatalog(), 1)
+	s.Equal("custom", ds.ThemeCatalog()[0].Name)
+	s.Equal([]string{"#f00", "#0f0"}, ds.ThemeCatalog()[0].Colors)
+	s.Equal([]string{"#f00", "#0f0"}, ds.ThemeCatalog()[0].VisualMapColors)
 }
 
-func (s *DatasetSuite) TestUnmarshalLegacyThemeDefault() {
+func (s *DatasetSuite) TestUnmarshalAppearanceThemeDefault() {
 	for _, value := range []string{"default", "DEFAULT", " Default "} {
-		raw := []byte(fmt.Sprintf(`{"name":"bench","theme":%q,"data":[]}`, value))
+		raw := []byte(fmt.Sprintf(`{"name":"bench","appearance":{"theme":%q},"data":[]}`, value))
 		var ds shared.Dataset
 		s.Require().NoError(json.Unmarshal(raw, &ds), value)
-		s.Empty(ds.Themes, value)
-		s.Empty(ds.Theme, value)
+		s.Empty(ds.ThemeCatalog(), value)
+		s.Nil(ds.Appearance, value)
 	}
 }
 
-func (s *DatasetSuite) TestUnmarshalLegacyThemeEmpty() {
-	raw := []byte(`{"name":"bench","theme":"","data":[]}`)
+func (s *DatasetSuite) TestUnmarshalAppearanceThemeEmpty() {
+	raw := []byte(`{"name":"bench","appearance":{"theme":""},"data":[]}`)
 	var ds shared.Dataset
 	s.Require().NoError(json.Unmarshal(raw, &ds))
-	s.Empty(ds.Themes)
-	s.Empty(ds.Theme)
+	s.Empty(ds.ThemeCatalog())
+	s.Nil(ds.Appearance)
 }
 
 func (s *DatasetSuite) TestMarshalWithThemesOmitsLegacyTheme() {
 	ds := shared.Dataset{
 		Name: "bench",
-		Themes: []shared.Theme{{
+		Appearance: &shared.Appearance{Themes: []shared.Theme{{
 			Name:            "roma",
 			Colors:          []string{"#E01F54", "#001852"},
 			VisualMapColors: []string{"#a4d8c2", "#E01F54"},
-		}},
+		}}},
 		Data: []shared.DataPoint{},
 	}
 
 	out, err := json.Marshal(ds)
 	s.Require().NoError(err)
+	s.Contains(string(out), `"appearance"`)
 	s.Contains(string(out), `"themes"`)
 	s.Contains(string(out), `"roma"`)
 	s.NotContains(string(out), `"theme":`)
@@ -204,7 +201,7 @@ func (s *DatasetSuite) TestMarshalWithThemesOmitsLegacyTheme() {
 func (s *DatasetSuite) TestThemesRoundTrip() {
 	original := shared.Dataset{
 		Name: "bench",
-		Themes: []shared.Theme{
+		Appearance: &shared.Appearance{Themes: []shared.Theme{
 			{
 				Name: "westeros",
 				Colors: []string{
@@ -218,7 +215,7 @@ func (s *DatasetSuite) TestThemesRoundTrip() {
 				Colors:          []string{"#111", "#222", "#333"},
 				VisualMapColors: []string{"#111", "#333"},
 			},
-		},
+		}},
 		Axes: []shared.Axis{{Key: "x"}},
 		Data: []shared.DataPoint{},
 	}
@@ -228,54 +225,95 @@ func (s *DatasetSuite) TestThemesRoundTrip() {
 
 	var got shared.Dataset
 	s.Require().NoError(json.Unmarshal(raw, &got))
-	s.Empty(got.Theme)
-	s.Equal(original.Themes, got.Themes)
+	s.Equal(original.ThemeCatalog(), got.ThemeCatalog())
 }
 
-func (s *DatasetSuite) TestThemesArrayWinsOverLegacyTheme() {
+func (s *DatasetSuite) TestAppearanceThemesWinsOverThemeString() {
 	raw := []byte(`{
 		"name":"bench",
-		"theme":"roma",
-		"themes":[{"name":"chalk","colors":["#fc97af","#87f7cf"],"visualMapColors":["#87f7cf","#fc97af"]}],
+		"appearance":{
+			"theme":"roma",
+			"themes":[{"name":"chalk","colors":["#fc97af","#87f7cf"],"visualMapColors":["#87f7cf","#fc97af"]}]
+		},
 		"data":[]
 	}`)
 
 	var ds shared.Dataset
 	s.Require().NoError(json.Unmarshal(raw, &ds))
-	s.Empty(ds.Theme)
-	s.Require().Len(ds.Themes, 1)
-	s.Equal("chalk", ds.Themes[0].Name)
+	s.Require().Len(ds.ThemeCatalog(), 1)
+	s.Equal("chalk", ds.ThemeCatalog()[0].Name)
+	s.Empty(ds.Appearance.Theme)
 }
 
-func (s *DatasetSuite) TestUnmarshalInvalidLegacyThemeKeepsString() {
-	raw := []byte(`{"name":"bench","theme":"not-a-theme","data":[]}`)
+func (s *DatasetSuite) TestUnmarshalInvalidAppearanceThemeKeepsString() {
+	raw := []byte(`{"name":"bench","appearance":{"theme":"not-a-theme"},"data":[]}`)
 
 	var ds shared.Dataset
 	s.Require().NoError(json.Unmarshal(raw, &ds))
-	s.Empty(ds.Themes)
-	s.Equal("not-a-theme", ds.Theme)
+	s.Empty(ds.ThemeCatalog())
+	s.Equal("not-a-theme", ds.Appearance.Theme)
 }
 
-func (s *DatasetSuite) TestUnmarshalLegacyStructuredDefaultNameClearsTheme() {
-	// Structured name "default" is not the bare "default" short-circuit; ParseThemeSpec
-	// succeeds with Name "default", then migrate clears Theme without embedding.
-	raw := []byte(`{"name":"bench","theme":"default:colors=#f00,#0f0","data":[]}`)
+func (s *DatasetSuite) TestUnmarshalAppearanceStructuredDefaultNameClearsTheme() {
+	raw := []byte(`{"name":"bench","appearance":{"theme":"default:colors=#f00,#0f0"},"data":[]}`)
 
 	var ds shared.Dataset
 	s.Require().NoError(json.Unmarshal(raw, &ds))
-	s.Empty(ds.Themes)
-	s.Empty(ds.Theme)
+	s.Empty(ds.ThemeCatalog())
+	s.Nil(ds.Appearance)
 }
 
 func (s *DatasetSuite) TestUnmarshalEmptySettingsArrayStillMigratesTheme() {
-	raw := []byte(`{"name":"bench","theme":"roma","settings":[],"data":[]}`)
+	raw := []byte(`{"name":"bench","appearance":{"theme":"roma"},"settings":[],"data":[]}`)
 
 	var ds shared.Dataset
 	s.Require().NoError(json.Unmarshal(raw, &ds))
 	s.Nil(ds.Settings)
-	s.Empty(ds.Theme)
-	s.Require().Len(ds.Themes, 1)
-	s.Equal("roma", ds.Themes[0].Name)
+	s.Require().Len(ds.ThemeCatalog(), 1)
+	s.Equal("roma", ds.ThemeCatalog()[0].Name)
+}
+
+func (s *DatasetSuite) TestAppearanceFontSizeRoundTrip() {
+	ds := shared.Dataset{
+		Name: "bench",
+		Appearance: &shared.Appearance{
+			FontSize: &shared.FontSize{
+				Series: shared.F64(16),
+				Legend: shared.F64(10),
+			},
+		},
+		Data: []shared.DataPoint{},
+	}
+	raw, err := json.Marshal(ds)
+	s.Require().NoError(err)
+	s.Contains(string(raw), `"fontSize"`)
+	s.Contains(string(raw), `"series"`)
+	s.NotContains(string(raw), `"theme":`)
+
+	var got shared.Dataset
+	s.Require().NoError(json.Unmarshal(raw, &got))
+	s.Require().NotNil(got.Appearance.FontSize)
+	s.Equal(16.0, *got.Appearance.FontSize.Series)
+	s.Equal(10.0, *got.Appearance.FontSize.Legend)
+	s.Nil(got.Appearance.FontSize.Label)
+
+	all := shared.Dataset{
+		Name: "bench",
+		Appearance: &shared.Appearance{
+			FontSize: &shared.FontSize{Series: shared.F64(14), Legend: shared.F64(14), Label: shared.F64(14)},
+		},
+		Data: []shared.DataPoint{},
+	}
+	raw, err = json.Marshal(all)
+	s.Require().NoError(err)
+	s.Contains(string(raw), `"fontSize":14`)
+}
+
+func (s *DatasetSuite) TestRootThemeFieldsAreIgnored() {
+	raw := []byte(`{"name":"bench","theme":"roma","themes":[{"name":"chalk","colors":["#fc97af"]}],"data":[]}`)
+	var ds shared.Dataset
+	s.Require().NoError(json.Unmarshal(raw, &ds))
+	s.Nil(ds.Appearance)
 }
 
 func (s *DatasetSuite) TestDatasetUnmarshalJSONLegacySingleObject() {

--- a/shared/fontsize.go
+++ b/shared/fontsize.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -23,8 +24,21 @@ func (f *FontSize) Empty() bool {
 	return f == nil || (f.Series == nil && f.Legend == nil && f.Label == nil)
 }
 
+var errInvalidFontSize = errors.New("must be a finite number greater than 0")
+
 func validFontSize(n float64) bool {
 	return !math.IsNaN(n) && !math.IsInf(n, 0) && n > 0
+}
+
+func (f *FontSize) set(key string, n float64) {
+	switch key {
+	case "series":
+		f.Series = F64(n)
+	case "legend":
+		f.Legend = F64(n)
+	case "label":
+		f.Label = F64(n)
+	}
 }
 
 func (f FontSize) allEqual() bool {
@@ -44,48 +58,24 @@ func (f FontSize) MarshalJSON() ([]byte, error) {
 // dropped so a Dataset file still loads; the convert API validates strictly
 // before assignment.
 func (f *FontSize) UnmarshalJSON(data []byte) error {
-	trimmed := bytes.TrimSpace(data)
-	if bytes.Equal(trimmed, []byte("null")) || len(trimmed) == 0 {
+	fs, _ := parseFontSize(data, false)
+	if fs == nil {
 		*f = FontSize{}
 		return nil
 	}
-	if trimmed[0] != '{' {
-		n, ok := decodeFontSizeNumber(trimmed)
-		if !ok {
-			*f = FontSize{}
-			return nil
-		}
-		f.Series, f.Legend, f.Label = F64(n), F64(n), F64(n)
-		return nil
-	}
-
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(trimmed, &fields); err != nil {
-		*f = FontSize{}
-		return nil
-	}
-	out := FontSize{}
-	for key, raw := range fields {
-		n, ok := decodeFontSizeNumber(raw)
-		if !ok {
-			continue
-		}
-		switch strings.ToLower(strings.TrimSpace(key)) {
-		case "series":
-			out.Series = F64(n)
-		case "legend":
-			out.Legend = F64(n)
-		case "label":
-			out.Label = F64(n)
-		}
-	}
-	*f = out
+	*f = *fs
 	return nil
 }
 
 // ParseFontSizeJSONStrict decodes a JSON number or object and errors on unknown
 // keys, non-numeric values, non-finite numbers, and values ≤ 0.
 func ParseFontSizeJSONStrict(data []byte) (*FontSize, error) {
+	return parseFontSize(data, true)
+}
+
+// parseFontSize decodes a JSON number (all three keys) or object. In strict mode
+// unknown keys and invalid values error; otherwise they are dropped.
+func parseFontSize(data []byte, strict bool) (*FontSize, error) {
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
 		return nil, nil
@@ -93,39 +83,44 @@ func ParseFontSizeJSONStrict(data []byte) (*FontSize, error) {
 	if trimmed[0] != '{' {
 		var n float64
 		if err := json.Unmarshal(trimmed, &n); err != nil {
-			return nil, fmt.Errorf("must be a number or object")
+			if strict {
+				return nil, fmt.Errorf("must be a number or object")
+			}
+			return nil, nil
 		}
 		if !validFontSize(n) {
-			return nil, fmt.Errorf("must be a finite number greater than 0")
+			if strict {
+				return nil, errInvalidFontSize
+			}
+			return nil, nil
 		}
 		return &FontSize{Series: F64(n), Legend: F64(n), Label: F64(n)}, nil
 	}
 
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(trimmed, &fields); err != nil {
-		return nil, fmt.Errorf("must be a number or object")
+		if strict {
+			return nil, fmt.Errorf("must be a number or object")
+		}
+		return nil, nil
 	}
 	out := FontSize{}
 	for key, raw := range fields {
-		switch strings.ToLower(strings.TrimSpace(key)) {
+		k := strings.ToLower(strings.TrimSpace(key))
+		switch k {
 		case "series", "legend", "label":
-			var n float64
-			if err := json.Unmarshal(raw, &n); err != nil {
-				return nil, fmt.Errorf("%s must be a finite number greater than 0", key)
+			n, ok := decodeFontSizeNumber(raw)
+			if !ok {
+				if strict {
+					return nil, fmt.Errorf("%s %s", key, errInvalidFontSize)
+				}
+				continue
 			}
-			if !validFontSize(n) {
-				return nil, fmt.Errorf("%s must be a finite number greater than 0", key)
-			}
-			switch strings.ToLower(key) {
-			case "series":
-				out.Series = F64(n)
-			case "legend":
-				out.Legend = F64(n)
-			case "label":
-				out.Label = F64(n)
-			}
+			out.set(k, n)
 		default:
-			return nil, fmt.Errorf("unknown key %q", key)
+			if strict {
+				return nil, fmt.Errorf("unknown key %q", key)
+			}
 		}
 	}
 	if out.Empty() {
@@ -183,14 +178,7 @@ func ParseFontSizeFlag(raw string) (*FontSize, []string) {
 				warnings = append(warnings, fontSizeWarn("font-size "+key, val, err.Error()))
 				continue
 			}
-			switch key {
-			case "series":
-				out.Series = F64(n)
-			case "legend":
-				out.Legend = F64(n)
-			case "label":
-				out.Label = F64(n)
-			}
+			out.set(key, n)
 		default:
 			warnings = append(warnings, fontSizeWarn("font-size key", key, "unknown key"))
 		}
@@ -206,11 +194,8 @@ func ParseFontSizeFlag(raw string) (*FontSize, []string) {
 
 func parseFontSizeToken(raw string) (float64, error) {
 	n, err := strconv.ParseFloat(raw, 64)
-	if err != nil {
-		return 0, fmt.Errorf("must be a finite number greater than 0")
-	}
-	if !validFontSize(n) {
-		return 0, fmt.Errorf("must be a finite number greater than 0")
+	if err != nil || !validFontSize(n) {
+		return 0, errInvalidFontSize
 	}
 	return n, nil
 }

--- a/shared/fontsize.go
+++ b/shared/fontsize.go
@@ -99,10 +99,7 @@ func parseFontSize(data []byte, strict bool) (*FontSize, error) {
 
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(trimmed, &fields); err != nil {
-		if strict {
-			return nil, fmt.Errorf("must be a number or object")
-		}
-		return nil, nil
+		return nil, fmt.Errorf("must be a number or object")
 	}
 	out := FontSize{}
 	for key, raw := range fields {
@@ -184,9 +181,6 @@ func ParseFontSizeFlag(raw string) (*FontSize, []string) {
 		}
 	}
 	if out.Empty() {
-		if len(warnings) == 0 {
-			warnings = append(warnings, fontSizeWarn("font-size", raw, "empty bag"))
-		}
 		return nil, warnings
 	}
 	return &out, warnings

--- a/shared/fontsize.go
+++ b/shared/fontsize.go
@@ -1,0 +1,220 @@
+package shared
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// FontSize is the dataset-level chart text size (CSS pixels).
+// On the wire it is a hybrid: a JSON number when series, legend, and label are
+// all set and equal; otherwise an object of the keys that were set.
+type FontSize struct {
+	Series *float64 `json:"series,omitempty"`
+	Legend *float64 `json:"legend,omitempty"`
+	Label  *float64 `json:"label,omitempty"`
+}
+
+// Empty reports whether no size is set.
+func (f *FontSize) Empty() bool {
+	return f == nil || (f.Series == nil && f.Legend == nil && f.Label == nil)
+}
+
+func validFontSize(n float64) bool {
+	return !math.IsNaN(n) && !math.IsInf(n, 0) && n > 0
+}
+
+func (f FontSize) allEqual() bool {
+	return f.Series != nil && f.Legend != nil && f.Label != nil &&
+		*f.Series == *f.Legend && *f.Legend == *f.Label
+}
+
+func (f FontSize) MarshalJSON() ([]byte, error) {
+	if f.allEqual() {
+		return json.Marshal(*f.Series)
+	}
+	type wire FontSize
+	return json.Marshal(wire(f))
+}
+
+// UnmarshalJSON accepts a JSON number or object. Invalid keys and values are
+// dropped so a Dataset file still loads; the convert API validates strictly
+// before assignment.
+func (f *FontSize) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if bytes.Equal(trimmed, []byte("null")) || len(trimmed) == 0 {
+		*f = FontSize{}
+		return nil
+	}
+	if trimmed[0] != '{' {
+		n, ok := decodeFontSizeNumber(trimmed)
+		if !ok {
+			*f = FontSize{}
+			return nil
+		}
+		f.Series, f.Legend, f.Label = F64(n), F64(n), F64(n)
+		return nil
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &fields); err != nil {
+		*f = FontSize{}
+		return nil
+	}
+	out := FontSize{}
+	for key, raw := range fields {
+		n, ok := decodeFontSizeNumber(raw)
+		if !ok {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "series":
+			out.Series = F64(n)
+		case "legend":
+			out.Legend = F64(n)
+		case "label":
+			out.Label = F64(n)
+		}
+	}
+	*f = out
+	return nil
+}
+
+// ParseFontSizeJSONStrict decodes a JSON number or object and errors on unknown
+// keys, non-numeric values, non-finite numbers, and values ≤ 0.
+func ParseFontSizeJSONStrict(data []byte) (*FontSize, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil, nil
+	}
+	if trimmed[0] != '{' {
+		var n float64
+		if err := json.Unmarshal(trimmed, &n); err != nil {
+			return nil, fmt.Errorf("must be a number or object")
+		}
+		if !validFontSize(n) {
+			return nil, fmt.Errorf("must be a finite number greater than 0")
+		}
+		return &FontSize{Series: F64(n), Legend: F64(n), Label: F64(n)}, nil
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &fields); err != nil {
+		return nil, fmt.Errorf("must be a number or object")
+	}
+	out := FontSize{}
+	for key, raw := range fields {
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "series", "legend", "label":
+			var n float64
+			if err := json.Unmarshal(raw, &n); err != nil {
+				return nil, fmt.Errorf("%s must be a finite number greater than 0", key)
+			}
+			if !validFontSize(n) {
+				return nil, fmt.Errorf("%s must be a finite number greater than 0", key)
+			}
+			switch strings.ToLower(key) {
+			case "series":
+				out.Series = F64(n)
+			case "legend":
+				out.Legend = F64(n)
+			case "label":
+				out.Label = F64(n)
+			}
+		default:
+			return nil, fmt.Errorf("unknown key %q", key)
+		}
+	}
+	if out.Empty() {
+		return nil, nil
+	}
+	return &out, nil
+}
+
+func decodeFontSizeNumber(raw json.RawMessage) (float64, bool) {
+	var n float64
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return 0, false
+	}
+	if !validFontSize(n) {
+		return 0, false
+	}
+	return n, true
+}
+
+// ParseFontSizeFlag parses --font-size: a bare finite float64 > 0 (all three
+// keys) or a series=;legend=;label= bag. Invalid keys/values are skipped and
+// returned as warning strings. Nil means omit fontSize.
+func ParseFontSizeFlag(raw string) (*FontSize, []string) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	if !strings.Contains(raw, "=") {
+		n, err := parseFontSizeToken(raw)
+		if err != nil {
+			return nil, []string{fontSizeWarn("font-size", raw, err.Error())}
+		}
+		return &FontSize{Series: F64(n), Legend: F64(n), Label: F64(n)}, nil
+	}
+
+	out := FontSize{}
+	var warnings []string
+	for _, part := range strings.Split(raw, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key, val, ok := strings.Cut(part, "=")
+		if !ok {
+			warnings = append(warnings, fontSizeWarn("font-size", part, "expected key=value"))
+			continue
+		}
+		key = strings.ToLower(strings.TrimSpace(key))
+		val = strings.TrimSpace(val)
+		switch key {
+		case "series", "legend", "label":
+			n, err := parseFontSizeToken(val)
+			if err != nil {
+				warnings = append(warnings, fontSizeWarn("font-size "+key, val, err.Error()))
+				continue
+			}
+			switch key {
+			case "series":
+				out.Series = F64(n)
+			case "legend":
+				out.Legend = F64(n)
+			case "label":
+				out.Label = F64(n)
+			}
+		default:
+			warnings = append(warnings, fontSizeWarn("font-size key", key, "unknown key"))
+		}
+	}
+	if out.Empty() {
+		if len(warnings) == 0 {
+			warnings = append(warnings, fontSizeWarn("font-size", raw, "empty bag"))
+		}
+		return nil, warnings
+	}
+	return &out, warnings
+}
+
+func parseFontSizeToken(raw string) (float64, error) {
+	n, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, fmt.Errorf("must be a finite number greater than 0")
+	}
+	if !validFontSize(n) {
+		return 0, fmt.Errorf("must be a finite number greater than 0")
+	}
+	return n, nil
+}
+
+func fontSizeWarn(label, value, reason string) string {
+	return fmt.Sprintf("Warning: Invalid %s '%s'. Reason: %s. Skipping", label, value, reason)
+}

--- a/shared/fontsize.go
+++ b/shared/fontsize.go
@@ -102,10 +102,20 @@ func parseFontSize(data []byte, strict bool) (*FontSize, error) {
 		return nil, fmt.Errorf("must be a number or object")
 	}
 	out := FontSize{}
+	normalizedCounts := make(map[string]int, len(fields))
+	for key := range fields {
+		normalizedCounts[strings.ToLower(strings.TrimSpace(key))]++
+	}
 	for key, raw := range fields {
 		k := strings.ToLower(strings.TrimSpace(key))
 		switch k {
 		case "series", "legend", "label":
+			if normalizedCounts[k] > 1 {
+				if strict {
+					return nil, fmt.Errorf("duplicate key %q", k)
+				}
+				continue
+			}
 			n, ok := decodeFontSizeNumber(raw)
 			if !ok {
 				if strict {

--- a/shared/fontsize_test.go
+++ b/shared/fontsize_test.go
@@ -180,6 +180,19 @@ func (s *FontSizeSuite) TestParseStrictErrors() {
 	}
 }
 
+func (s *FontSizeSuite) TestParseStrictDuplicateNormalizedKey() {
+	fs, err := shared.ParseFontSizeJSONStrict([]byte(`{"series":16," Series ":10}`))
+	s.Require().Error(err)
+	s.Nil(fs)
+	s.EqualError(err, `duplicate key "series"`)
+}
+
+func (s *FontSizeSuite) TestUnmarshalDuplicateNormalizedKeySkipped() {
+	var fs shared.FontSize
+	s.Require().NoError(json.Unmarshal([]byte(`{"series":16," Series ":10}`), &fs))
+	s.True(fs.Empty())
+}
+
 func (s *FontSizeSuite) TestUnmarshalNull() {
 	var fs shared.FontSize
 	s.Require().NoError(json.Unmarshal([]byte("null"), &fs))

--- a/shared/fontsize_test.go
+++ b/shared/fontsize_test.go
@@ -1,0 +1,133 @@
+package shared_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/goptics/vizb/shared"
+	"github.com/stretchr/testify/suite"
+)
+
+type FontSizeSuite struct {
+	suite.Suite
+}
+
+func TestFontSizeSuite(t *testing.T) {
+	suite.Run(t, new(FontSizeSuite))
+}
+
+func (s *FontSizeSuite) TestMarshalAllEqualNumber() {
+	fs := shared.FontSize{
+		Series: shared.F64(14),
+		Legend: shared.F64(14),
+		Label:  shared.F64(14),
+	}
+	raw, err := json.Marshal(fs)
+	s.Require().NoError(err)
+	s.Equal("14", string(raw))
+}
+
+func (s *FontSizeSuite) TestMarshalPartialObject() {
+	fs := shared.FontSize{Series: shared.F64(16), Legend: shared.F64(10)}
+	raw, err := json.Marshal(fs)
+	s.Require().NoError(err)
+	s.JSONEq(`{"series":16,"legend":10}`, string(raw))
+}
+
+func (s *FontSizeSuite) TestMarshalFloat() {
+	fs := shared.FontSize{
+		Series: shared.F64(12.5),
+		Legend: shared.F64(12.5),
+		Label:  shared.F64(12.5),
+	}
+	raw, err := json.Marshal(fs)
+	s.Require().NoError(err)
+	s.Equal("12.5", string(raw))
+}
+
+func (s *FontSizeSuite) TestUnmarshalNumber() {
+	var fs shared.FontSize
+	s.Require().NoError(json.Unmarshal([]byte("14"), &fs))
+	s.Equal(14.0, *fs.Series)
+	s.Equal(14.0, *fs.Legend)
+	s.Equal(14.0, *fs.Label)
+}
+
+func (s *FontSizeSuite) TestUnmarshalObject() {
+	var fs shared.FontSize
+	s.Require().NoError(json.Unmarshal([]byte(`{"series":16,"legend":10}`), &fs))
+	s.Equal(16.0, *fs.Series)
+	s.Equal(10.0, *fs.Legend)
+	s.Nil(fs.Label)
+}
+
+func (s *FontSizeSuite) TestUnmarshalDropsInvalid() {
+	var fs shared.FontSize
+	s.Require().NoError(json.Unmarshal([]byte(`{"series":0,"legend":-1,"label":16,"title":14}`), &fs))
+	s.Nil(fs.Series)
+	s.Nil(fs.Legend)
+	s.Equal(16.0, *fs.Label)
+}
+
+func (s *FontSizeSuite) TestUnmarshalInvalidNumberDropped() {
+	var fs shared.FontSize
+	s.Require().NoError(json.Unmarshal([]byte(`"14px"`), &fs))
+	s.True(fs.Empty())
+}
+
+func (s *FontSizeSuite) TestParseBare() {
+	fs, warns := shared.ParseFontSizeFlag("14")
+	s.Empty(warns)
+	s.Require().NotNil(fs)
+	s.Equal(14.0, *fs.Series)
+	s.Equal(14.0, *fs.Legend)
+	s.Equal(14.0, *fs.Label)
+}
+
+func (s *FontSizeSuite) TestParseBareFloat() {
+	fs, warns := shared.ParseFontSizeFlag("12.5")
+	s.Empty(warns)
+	s.Require().NotNil(fs)
+	s.Equal(12.5, *fs.Series)
+}
+
+func (s *FontSizeSuite) TestParseBag() {
+	fs, warns := shared.ParseFontSizeFlag("series=16;legend=10")
+	s.Empty(warns)
+	s.Require().NotNil(fs)
+	s.Equal(16.0, *fs.Series)
+	s.Equal(10.0, *fs.Legend)
+	s.Nil(fs.Label)
+}
+
+func (s *FontSizeSuite) TestParseMixedValidInvalid() {
+	fs, warns := shared.ParseFontSizeFlag("series=abc;legend=14;title=9")
+	s.Len(warns, 2)
+	s.Require().NotNil(fs)
+	s.Nil(fs.Series)
+	s.Equal(14.0, *fs.Legend)
+}
+
+func (s *FontSizeSuite) TestParseInvalidBare() {
+	for _, raw := range []string{"0", "-1", "14px", "NaN", "Inf"} {
+		fs, warns := shared.ParseFontSizeFlag(raw)
+		s.Nil(fs, raw)
+		s.NotEmpty(warns, raw)
+	}
+	fs, warns := shared.ParseFontSizeFlag("inf")
+	s.Nil(fs)
+	s.NotEmpty(warns)
+}
+
+func (s *FontSizeSuite) TestParseEmptyBag() {
+	fs, warns := shared.ParseFontSizeFlag(";;")
+	s.Nil(fs)
+	s.NotEmpty(warns)
+}
+
+func (s *FontSizeSuite) TestParseCaseInsensitiveKeys() {
+	fs, warns := shared.ParseFontSizeFlag("Series=16")
+	s.Empty(warns)
+	s.Require().NotNil(fs)
+	s.Equal(16.0, *fs.Series)
+}

--- a/shared/fontsize_test.go
+++ b/shared/fontsize_test.go
@@ -131,3 +131,111 @@ func (s *FontSizeSuite) TestParseCaseInsensitiveKeys() {
 	s.Require().NotNil(fs)
 	s.Equal(16.0, *fs.Series)
 }
+
+func (s *FontSizeSuite) TestParseStrictNumber() {
+	fs, err := shared.ParseFontSizeJSONStrict([]byte("14"))
+	s.Require().NoError(err)
+	s.Require().NotNil(fs)
+	s.Equal(14.0, *fs.Series)
+	s.Equal(14.0, *fs.Legend)
+	s.Equal(14.0, *fs.Label)
+}
+
+func (s *FontSizeSuite) TestParseStrictObject() {
+	fs, err := shared.ParseFontSizeJSONStrict([]byte(`{"series":16,"legend":10}`))
+	s.Require().NoError(err)
+	s.Require().NotNil(fs)
+	s.Equal(16.0, *fs.Series)
+	s.Equal(10.0, *fs.Legend)
+	s.Nil(fs.Label)
+}
+
+func (s *FontSizeSuite) TestParseStrictEmptyOrNull() {
+	for _, raw := range []string{"", "  ", "null"} {
+		fs, err := shared.ParseFontSizeJSONStrict([]byte(raw))
+		s.Require().NoError(err, raw)
+		s.Nil(fs, raw)
+	}
+}
+
+func (s *FontSizeSuite) TestParseStrictErrors() {
+	for _, test := range []struct {
+		raw string
+		err string
+	}{
+		{raw: "abc", err: "must be a number or object"},
+		{raw: `"14px"`, err: "must be a number or object"},
+		{raw: "{", err: "must be a number or object"},
+		{raw: "[]", err: "must be a number or object"},
+		{raw: "0", err: "must be a finite number greater than 0"},
+		{raw: "-1", err: "must be a finite number greater than 0"},
+		{raw: `{"series":"x"}`, err: "series must be a finite number greater than 0"},
+		{raw: `{"series":0}`, err: "series must be a finite number greater than 0"},
+		{raw: `{"bogus":1}`, err: `unknown key "bogus"`},
+	} {
+		fs, err := shared.ParseFontSizeJSONStrict([]byte(test.raw))
+		s.Require().Error(err, test.raw)
+		s.Nil(fs, test.raw)
+		s.EqualError(err, test.err, test.raw)
+	}
+}
+
+func (s *FontSizeSuite) TestUnmarshalNull() {
+	var fs shared.FontSize
+	s.Require().NoError(json.Unmarshal([]byte("null"), &fs))
+	s.True(fs.Empty())
+}
+
+func (s *FontSizeSuite) TestUnmarshalZeroDropped() {
+	var fs shared.FontSize
+	s.Require().NoError(json.Unmarshal([]byte("0"), &fs))
+	s.True(fs.Empty())
+}
+
+func (s *FontSizeSuite) TestUnmarshalUnknownOnlyObject() {
+	var fs shared.FontSize
+	s.Require().NoError(json.Unmarshal([]byte(`{"bogus":1}`), &fs))
+	s.True(fs.Empty())
+}
+
+func (s *FontSizeSuite) TestMarshalUnequalObject() {
+	raw, err := json.Marshal(shared.FontSize{
+		Series: shared.F64(16),
+		Legend: shared.F64(10),
+		Label:  shared.F64(12),
+	})
+	s.Require().NoError(err)
+	s.JSONEq(`{"series":16,"legend":10,"label":12}`, string(raw))
+}
+
+func (s *FontSizeSuite) TestEmptyNilReceiver() {
+	var fs *shared.FontSize
+	s.True(fs.Empty())
+}
+
+func (s *FontSizeSuite) TestParseBagEmptySegment() {
+	fs, warns := shared.ParseFontSizeFlag("series=14;;legend=10")
+	s.Empty(warns)
+	s.Require().NotNil(fs)
+	s.Equal(14.0, *fs.Series)
+	s.Equal(10.0, *fs.Legend)
+}
+
+func (s *FontSizeSuite) TestParseBagMissingEquals() {
+	fs, warns := shared.ParseFontSizeFlag("series=14;oops")
+	s.Len(warns, 1)
+	s.Require().NotNil(fs)
+	s.Equal(14.0, *fs.Series)
+}
+
+func (s *FontSizeSuite) TestParseBagAllInvalid() {
+	fs, warns := shared.ParseFontSizeFlag("series=abc")
+	s.Nil(fs)
+	s.Len(warns, 1)
+}
+
+func (s *FontSizeSuite) TestParseBareNegativeInf() {
+	fs, warns := shared.ParseFontSizeFlag("-Inf")
+	s.Nil(fs)
+	s.NotEmpty(warns)
+}

--- a/shared/merge.go
+++ b/shared/merge.go
@@ -169,9 +169,13 @@ func fontSizeOf(ds Dataset) *FontSize {
 }
 
 func mergeAppearances(newer, older Dataset) *Appearance {
+	font := fontSizeOf(newer)
+	if font.Empty() {
+		font = fontSizeOf(older)
+	}
 	return CompactAppearance(&Appearance{
 		Themes:   mergeThemes(datasetThemes(newer), datasetThemes(older)),
-		FontSize: firstFontSize(fontSizeOf(newer), fontSizeOf(older)),
+		FontSize: cloneFontSize(font),
 	})
 }
 
@@ -180,13 +184,6 @@ func foldAppearance(datasets []Dataset) *Appearance {
 		Themes:   foldThemes(datasets),
 		FontSize: foldFontSize(datasets),
 	})
-}
-
-func firstFontSize(newer, older *FontSize) *FontSize {
-	if !newer.Empty() {
-		return cloneFontSize(newer)
-	}
-	return cloneFontSize(older)
 }
 
 func foldFontSize(datasets []Dataset) *FontSize {

--- a/shared/merge.go
+++ b/shared/merge.go
@@ -37,7 +37,7 @@ func MergeDatasets(benchmarks []Dataset, dim Dimension) []Dataset {
 
 		if existing, exists := tags[tag]; exists {
 			if tag == noTagKey {
-				// Newer timestamp wins for data; always union Themes.
+				// Newer timestamp wins for data; always union appearance.themes.
 				var newer, older Dataset
 				if existing.Timestamp >= ds.Timestamp {
 					newer, older = *existing, ds
@@ -45,8 +45,7 @@ func MergeDatasets(benchmarks []Dataset, dim Dimension) []Dataset {
 					newer, older = ds, *existing
 				}
 				merged := newer
-				merged.Themes = mergeThemes(datasetThemes(newer), datasetThemes(older))
-				merged.Theme = ""
+				merged.Appearance = mergeAppearances(newer, older)
 				tags[tag] = &merged
 				continue
 			}
@@ -93,8 +92,7 @@ func MergeDatasets(benchmarks []Dataset, dim Dimension) []Dataset {
 				latest := tagged[len(tagged)-1]
 				base.Tag = latest.Tag
 				base.Timestamp = latest.Timestamp
-				base.Themes = foldThemes(allDatasets)
-				base.Theme = ""
+				base.Appearance = foldAppearance(allDatasets)
 				base.History = buildHistory(allDatasets, latest.Tag)
 				base.Data = mergeData(allDatasets, dim)
 				base.Axes = EnsureAxis(base.Axes, dim)
@@ -104,8 +102,7 @@ func MergeDatasets(benchmarks []Dataset, dim Dimension) []Dataset {
 
 			latest := tagged[len(tagged)-1]
 			base := deepCloneDataset(latest)
-			base.Themes = foldThemes(tagged)
-			base.Theme = ""
+			base.Appearance = foldAppearance(tagged)
 			base.History = buildHistory(tagged, latest.Tag)
 			base.Data = mergeData(tagged, dim)
 			base.Axes = EnsureAxis(base.Axes, dim)
@@ -147,22 +144,88 @@ func deepCloneDataset(src Dataset) Dataset {
 		copy(dst.Settings, src.Settings)
 	}
 
-	if src.Themes != nil {
-		dst.Themes = cloneThemes(src.Themes)
-	}
+	dst.Appearance = cloneAppearance(src.Appearance)
 
 	return dst
 }
 
-// datasetThemes returns the theme catalog for merge, expanding a legacy Theme
-// string when Themes is empty (in-memory datasets that skipped UnmarshalJSON).
 func datasetThemes(ds Dataset) []Theme {
-	if len(ds.Themes) > 0 {
-		return ds.Themes
+	if ds.Appearance == nil {
+		return nil
 	}
-	tmp := ds
-	tmp.migrateLegacyTheme()
+	if len(ds.Appearance.Themes) > 0 {
+		return ds.Appearance.Themes
+	}
+	tmp := *ds.Appearance
+	tmp.migrateTheme()
 	return tmp.Themes
+}
+
+func fontSizeOf(ds Dataset) *FontSize {
+	if ds.Appearance == nil {
+		return nil
+	}
+	return ds.Appearance.FontSize
+}
+
+func mergeAppearances(newer, older Dataset) *Appearance {
+	return CompactAppearance(&Appearance{
+		Themes:   mergeThemes(datasetThemes(newer), datasetThemes(older)),
+		FontSize: firstFontSize(fontSizeOf(newer), fontSizeOf(older)),
+	})
+}
+
+func foldAppearance(datasets []Dataset) *Appearance {
+	return CompactAppearance(&Appearance{
+		Themes:   foldThemes(datasets),
+		FontSize: foldFontSize(datasets),
+	})
+}
+
+func firstFontSize(newer, older *FontSize) *FontSize {
+	if !newer.Empty() {
+		return cloneFontSize(newer)
+	}
+	return cloneFontSize(older)
+}
+
+func foldFontSize(datasets []Dataset) *FontSize {
+	var font *FontSize
+	for _, ds := range datasets {
+		if fs := fontSizeOf(ds); !fs.Empty() {
+			font = cloneFontSize(fs)
+		}
+	}
+	return font
+}
+
+func cloneAppearance(a *Appearance) *Appearance {
+	if a == nil {
+		return nil
+	}
+	out := Appearance{
+		Theme:    a.Theme,
+		Themes:   cloneThemes(a.Themes),
+		FontSize: cloneFontSize(a.FontSize),
+	}
+	return CompactAppearance(&out)
+}
+
+func cloneFontSize(f *FontSize) *FontSize {
+	if f.Empty() {
+		return nil
+	}
+	out := FontSize{}
+	if f.Series != nil {
+		out.Series = F64(*f.Series)
+	}
+	if f.Legend != nil {
+		out.Legend = F64(*f.Legend)
+	}
+	if f.Label != nil {
+		out.Label = F64(*f.Label)
+	}
+	return &out
 }
 
 // mergeThemes unions two theme catalogs by case-insensitive name.
@@ -335,9 +398,8 @@ func replaceTagData(existing, incoming Dataset, dim Dimension) Dataset {
 	result.Data = append(kept, mergeDataForTag(incoming, dim)...)
 	result.Tag = incoming.Tag
 	result.Timestamp = incoming.Timestamp
-	// incoming is the newer-by-timestamp dataset; union themes with it preferred.
-	result.Themes = mergeThemes(datasetThemes(incoming), datasetThemes(existing))
-	result.Theme = ""
+	// incoming is the newer-by-timestamp dataset; union appearance.themes with it preferred.
+	result.Appearance = mergeAppearances(incoming, existing)
 	if incoming.Meta != nil {
 		m := *incoming.Meta
 		if incoming.Meta.CPU != nil {

--- a/shared/merge.go
+++ b/shared/merge.go
@@ -187,8 +187,15 @@ func foldAppearance(datasets []Dataset) *Appearance {
 }
 
 func foldFontSize(datasets []Dataset) *FontSize {
+	// Sort a copy by timestamp so fold order is stable regardless of input order.
+	ordered := make([]Dataset, len(datasets))
+	copy(ordered, datasets)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].Timestamp < ordered[j].Timestamp
+	})
+
 	var font *FontSize
-	for _, ds := range datasets {
+	for _, ds := range ordered {
 		if fs := fontSizeOf(ds); !fs.Empty() {
 			font = cloneFontSize(fs)
 		}

--- a/shared/merge_test.go
+++ b/shared/merge_test.go
@@ -517,6 +517,23 @@ func (s *MergeSuite) TestMergeFontSizeNewerWinsElseOlder() {
 	s.Equal(16.0, *result[0].Appearance.FontSize.Series)
 }
 
+func (s *MergeSuite) TestMergeFontSizeFoldsByTimestamp() {
+	untagged := Dataset{
+		Name:       "Bench",
+		Timestamp:  "2026-05-14T10:00:00Z",
+		Data:       []DataPoint{{Name: "legacy"}},
+		Appearance: &Appearance{FontSize: &FontSize{Series: F64(16)}},
+	}
+	tagged := makeBench("v1", "Bench", "2026-05-13T10:00:00Z", []DataPoint{{Name: "tagged"}})
+	tagged.Appearance = &Appearance{FontSize: &FontSize{Series: F64(10)}}
+
+	result := MergeDatasets([]Dataset{untagged, tagged}, DimensionName)
+	s.Require().Len(result, 1)
+	s.Require().NotNil(result[0].Appearance)
+	s.Require().NotNil(result[0].Appearance.FontSize)
+	s.Equal(16.0, *result[0].Appearance.FontSize.Series)
+}
+
 func (s *MergeSuite) TestMergeThemesPure() {
 	newer := []Theme{
 		{Name: "A", Colors: []string{"#a2"}},

--- a/shared/merge_test.go
+++ b/shared/merge_test.go
@@ -351,108 +351,103 @@ func (s *MergeSuite) TestMergeDatasetsSameNameSameTagDedup() {
 }
 
 func (s *MergeSuite) TestMergeUsesNewestActiveTheme() {
-	// Legacy Theme string migrates into Themes during merge.
+	// Appearance.Theme string expands into the catalog during merge.
 	legacy := Dataset{
-		Name: "Bench", Theme: "vintage", Timestamp: "2026-05-12T10:00:00Z",
+		Name: "Bench", Appearance: &Appearance{Theme: "vintage"}, Timestamp: "2026-05-12T10:00:00Z",
 		Data: []DataPoint{{Name: "legacy"}},
 	}
 	latest := makeBench("v2", "Bench", "2026-05-14T10:00:00Z",
 		[]DataPoint{{Name: "", XAxis: "speed", YAxis: "1e4"}})
-	latest.Themes = []Theme{{Name: "roma", Colors: []string{"#E01F54"}}}
+	latest.Appearance = &Appearance{Themes: []Theme{{Name: "roma", Colors: []string{"#E01F54"}}}}
 
 	result := MergeDatasets([]Dataset{legacy, latest}, DimensionName)
 	s.Require().Len(result, 1)
-	s.Empty(result[0].Theme)
-	s.Require().GreaterOrEqual(len(result[0].Themes), 1)
-	s.Equal("roma", result[0].Themes[0].Name)
-	// Older-only theme is preserved in the catalog.
-	s.True(themeNamesContain(result[0].Themes, "vintage"))
+	s.Require().GreaterOrEqual(len(result[0].ThemeCatalog()), 1)
+	s.Equal("roma", result[0].ThemeCatalog()[0].Name)
+	s.True(themeNamesContain(result[0].ThemeCatalog(), "vintage"))
 
 	updated := latest
 	updated.Timestamp = "2026-05-15T10:00:00Z"
-	updated.Themes = []Theme{{Name: "chalk", Colors: []string{"#111"}}}
+	updated.Appearance = &Appearance{Themes: []Theme{{Name: "chalk", Colors: []string{"#111"}}}}
 	result = MergeDatasets([]Dataset{result[0], updated}, DimensionName)
 	s.Require().Len(result, 1)
-	s.Empty(result[0].Theme)
-	s.Equal("chalk", result[0].Themes[0].Name)
+	s.Equal("chalk", result[0].ThemeCatalog()[0].Name)
 }
 
 func (s *MergeSuite) TestMergePreservesThemesWhenIncomingHasNone() {
 	existing := makeBench("v1", "Bench", "2026-05-13T10:00:00Z",
 		[]DataPoint{{Name: "", XAxis: "speed", YAxis: "1e4"}})
-	existing.Themes = []Theme{{Name: "walden", Colors: []string{"#3F51B5"}}}
+	existing.Appearance = &Appearance{Themes: []Theme{{Name: "walden", Colors: []string{"#3F51B5"}}}}
 	incoming := makeBench("v1", "Bench", "2026-05-14T10:00:00Z",
 		[]DataPoint{{Name: "", XAxis: "speed", YAxis: "2e4"}})
 
 	result := MergeDatasets([]Dataset{existing, incoming}, DimensionName)
 	s.Require().Len(result, 1)
-	s.Empty(result[0].Theme)
-	s.Require().Len(result[0].Themes, 1)
-	s.Equal("walden", result[0].Themes[0].Name)
+	s.Require().Len(result[0].ThemeCatalog(), 1)
+	s.Equal("walden", result[0].ThemeCatalog()[0].Name)
 }
 
 func (s *MergeSuite) TestMergeThemesUnionByName() {
 	older := makeBench("v1", "Bench", "2026-05-13T10:00:00Z",
 		[]DataPoint{{Name: "", XAxis: "speed", YAxis: "1e4"}})
-	older.Themes = []Theme{
+	older.Appearance = &Appearance{Themes: []Theme{
 		{Name: "vintage", Colors: []string{"#old-v"}},
 		{Name: "roma", Colors: []string{"#old-r"}},
-	}
+	}}
 	newer := makeBench("v2", "Bench", "2026-05-14T10:00:00Z",
 		[]DataPoint{{Name: "", XAxis: "speed", YAxis: "2e4"}})
-	newer.Themes = []Theme{
+	newer.Appearance = &Appearance{Themes: []Theme{
 		{Name: "roma", Colors: []string{"#new-r"}},
 		{Name: "chalk", Colors: []string{"#new-c"}},
-	}
+	}}
 
 	result := MergeDatasets([]Dataset{older, newer}, DimensionName)
 	s.Require().Len(result, 1)
-	s.Empty(result[0].Theme)
-	// Newest order first (roma, chalk), then older-only (vintage).
-	s.Require().Len(result[0].Themes, 3)
-	s.Equal("roma", result[0].Themes[0].Name)
-	s.Equal([]string{"#new-r"}, result[0].Themes[0].Colors) // newer content wins
-	s.Equal("chalk", result[0].Themes[1].Name)
-	s.Equal("vintage", result[0].Themes[2].Name)
-	s.Equal([]string{"#old-v"}, result[0].Themes[2].Colors)
+	catalog := result[0].ThemeCatalog()
+	s.Require().Len(catalog, 3)
+	s.Equal("roma", catalog[0].Name)
+	s.Equal([]string{"#new-r"}, catalog[0].Colors)
+	s.Equal("chalk", catalog[1].Name)
+	s.Equal("vintage", catalog[2].Name)
+	s.Equal([]string{"#old-v"}, catalog[2].Colors)
 }
 
 func (s *MergeSuite) TestMergeThemesCaseInsensitiveName() {
 	older := makeBench("v1", "Bench", "2026-05-13T10:00:00Z",
 		[]DataPoint{{Name: "a"}})
-	older.Themes = []Theme{{Name: "Roma", Colors: []string{"#old"}}}
+	older.Appearance = &Appearance{Themes: []Theme{{Name: "Roma", Colors: []string{"#old"}}}}
 	newer := makeBench("v2", "Bench", "2026-05-14T10:00:00Z",
 		[]DataPoint{{Name: "b"}})
-	newer.Themes = []Theme{{Name: "ROMA", Colors: []string{"#new"}}}
+	newer.Appearance = &Appearance{Themes: []Theme{{Name: "ROMA", Colors: []string{"#new"}}}}
 
 	result := MergeDatasets([]Dataset{older, newer}, DimensionName)
 	s.Require().Len(result, 1)
-	s.Require().Len(result[0].Themes, 1)
-	s.Equal("ROMA", result[0].Themes[0].Name) // newer name spelling kept
-	s.Equal([]string{"#new"}, result[0].Themes[0].Colors)
+	s.Require().Len(result[0].ThemeCatalog(), 1)
+	s.Equal("ROMA", result[0].ThemeCatalog()[0].Name)
+	s.Equal([]string{"#new"}, result[0].ThemeCatalog()[0].Colors)
 }
 
 func (s *MergeSuite) TestMergeThemesNewestActiveFirst() {
 	older := makeBench("v1", "Bench", "2026-05-13T10:00:00Z",
 		[]DataPoint{{Name: "a"}})
-	older.Themes = []Theme{
+	older.Appearance = &Appearance{Themes: []Theme{
 		{Name: "vintage", Colors: []string{"#v"}},
 		{Name: "westeros", Colors: []string{"#w"}},
-	}
+	}}
 	newer := makeBench("v2", "Bench", "2026-05-14T10:00:00Z",
 		[]DataPoint{{Name: "b"}})
-	newer.Themes = []Theme{
+	newer.Appearance = &Appearance{Themes: []Theme{
 		{Name: "chalk", Colors: []string{"#c"}},
 		{Name: "westeros", Colors: []string{"#w2"}},
-	}
+	}}
 
 	result := MergeDatasets([]Dataset{older, newer}, DimensionName)
 	s.Require().Len(result, 1)
-	// Newest Themes[0] stays first (active).
-	s.Equal("chalk", result[0].Themes[0].Name)
-	s.Equal("westeros", result[0].Themes[1].Name)
-	s.Equal([]string{"#w2"}, result[0].Themes[1].Colors)
-	s.Equal("vintage", result[0].Themes[2].Name)
+	catalog := result[0].ThemeCatalog()
+	s.Equal("chalk", catalog[0].Name)
+	s.Equal("westeros", catalog[1].Name)
+	s.Equal([]string{"#w2"}, catalog[1].Colors)
+	s.Equal("vintage", catalog[2].Name)
 }
 
 func (s *MergeSuite) TestMergeThemesEmptyOK() {
@@ -463,46 +458,63 @@ func (s *MergeSuite) TestMergeThemesEmptyOK() {
 
 	result := MergeDatasets([]Dataset{bench1, bench2}, DimensionName)
 	s.Require().Len(result, 1)
-	s.Empty(result[0].Themes)
-	s.Empty(result[0].Theme)
+	s.Empty(result[0].ThemeCatalog())
+	s.Nil(result[0].Appearance)
 }
 
 func (s *MergeSuite) TestMergeThemesNoTagUnion() {
 	older := Dataset{
-		Name:      "Bench",
-		Timestamp: "2026-01-01T00:00:00Z",
-		Themes:    []Theme{{Name: "vintage", Colors: []string{"#v"}}},
-		Data:      []DataPoint{{Name: "first"}},
+		Name:       "Bench",
+		Timestamp:  "2026-01-01T00:00:00Z",
+		Appearance: &Appearance{Themes: []Theme{{Name: "vintage", Colors: []string{"#v"}}}},
+		Data:       []DataPoint{{Name: "first"}},
 	}
 	newer := Dataset{
-		Name:      "Bench",
-		Timestamp: "2026-02-01T00:00:00Z",
-		Themes:    []Theme{{Name: "roma", Colors: []string{"#r"}}},
-		Data:      []DataPoint{{Name: "second"}},
+		Name:       "Bench",
+		Timestamp:  "2026-02-01T00:00:00Z",
+		Appearance: &Appearance{Themes: []Theme{{Name: "roma", Colors: []string{"#r"}}}},
+		Data:       []DataPoint{{Name: "second"}},
 	}
 
 	result := MergeDatasets([]Dataset{older, newer}, DimensionName)
 	s.Require().Len(result, 1)
 	s.Equal("second", result[0].Data[0].Name)
-	s.Require().Len(result[0].Themes, 2)
-	s.Equal("roma", result[0].Themes[0].Name)
-	s.Equal("vintage", result[0].Themes[1].Name)
+	s.Require().Len(result[0].ThemeCatalog(), 2)
+	s.Equal("roma", result[0].ThemeCatalog()[0].Name)
+	s.Equal("vintage", result[0].ThemeCatalog()[1].Name)
 }
 
 func (s *MergeSuite) TestMergeThemesDeepCloneIndependence() {
 	srcColors := []string{"#shared"}
 	bench1 := makeBench("v1", "Bench", "2026-05-13T10:00:00Z",
 		[]DataPoint{{Name: "a"}})
-	bench1.Themes = []Theme{{Name: "roma", Colors: srcColors}}
+	bench1.Appearance = &Appearance{Themes: []Theme{{Name: "roma", Colors: srcColors}}}
 	bench2 := makeBench("v2", "Bench", "2026-05-14T10:00:00Z",
 		[]DataPoint{{Name: "b"}})
-	bench2.Themes = []Theme{{Name: "chalk", Colors: []string{"#c"}}}
+	bench2.Appearance = &Appearance{Themes: []Theme{{Name: "chalk", Colors: []string{"#c"}}}}
 
 	result := MergeDatasets([]Dataset{bench1, bench2}, DimensionName)
 	s.Require().Len(result, 1)
-	// Mutating result must not alias source color slice.
-	result[0].Themes[1].Colors[0] = "#mutated"
+	result[0].ThemeCatalog()[1].Colors[0] = "#mutated"
 	s.Equal("#shared", srcColors[0])
+}
+
+func (s *MergeSuite) TestMergeFontSizeNewerWinsElseOlder() {
+	older := makeBench("v1", "Bench", "2026-05-13T10:00:00Z", []DataPoint{{Name: "a"}})
+	older.Appearance = &Appearance{FontSize: &FontSize{Series: F64(14), Legend: F64(14), Label: F64(14)}}
+	newer := makeBench("v2", "Bench", "2026-05-14T10:00:00Z", []DataPoint{{Name: "b"}})
+	newer.Appearance = &Appearance{FontSize: &FontSize{Series: F64(16)}}
+
+	result := MergeDatasets([]Dataset{older, newer}, DimensionName)
+	s.Require().Len(result, 1)
+	s.Require().NotNil(result[0].Appearance.FontSize)
+	s.Equal(16.0, *result[0].Appearance.FontSize.Series)
+	s.Nil(result[0].Appearance.FontSize.Legend)
+
+	newerNoSize := makeBench("v3", "Bench", "2026-05-15T10:00:00Z", []DataPoint{{Name: "c"}})
+	result = MergeDatasets([]Dataset{result[0], newerNoSize}, DimensionName)
+	s.Require().NotNil(result[0].Appearance.FontSize)
+	s.Equal(16.0, *result[0].Appearance.FontSize.Series)
 }
 
 func (s *MergeSuite) TestMergeThemesPure() {

--- a/ui/src/composables/charts/baseChartOptions.ts
+++ b/ui/src/composables/charts/baseChartOptions.ts
@@ -2,7 +2,7 @@ import type { Ref } from 'vue'
 import type { EChartsOption } from 'echarts'
 import type { Axis, BarBackground, ChartData, Sort, ScaleInput, ChartType } from '@/types'
 import { createTooltipConfig, createToolboxConfig, getChartStyling } from './shared/chartConfig'
-import { fontSize } from './shared/common'
+import { chartFontSize } from './shared/chartFontSize'
 import { is3D } from '@/lib/utils'
 
 export interface BaseChartConfig {
@@ -73,7 +73,7 @@ export const getBaseOptions = (config: BaseChartConfig): Partial<EChartsOption> 
       top: 0,
       itemWidth: 10,
       itemHeight: 10,
-      textStyle: { fontSize, color: textColor },
+      textStyle: { fontSize: chartFontSize().legend, color: textColor },
     },
     emphasis: {
       focus: 'series',

--- a/ui/src/composables/charts/shared/3d.ts
+++ b/ui/src/composables/charts/shared/3d.ts
@@ -13,6 +13,7 @@ import {
   type ChartStyling,
 } from './chartConfig'
 import { resolveLogScale } from './common'
+import { chartFontSize } from './chartFontSize'
 
 /** Blue-to-red gradient for value-mode 3D visualMap (metric height). */
 export const VALUE_3D_COLOR_RANGE = [
@@ -355,7 +356,7 @@ export function continuous3DGridCounts(pointCount: number): { xCount: number; yC
 
 export function makeAxis3DCommon(styling: ChartStyling) {
   return {
-    axisLabel: { color: styling.textColor },
+    axisLabel: { color: styling.textColor, fontSize: chartFontSize().label },
     axisLine: { lineStyle: { color: styling.axisColor } },
   }
 }
@@ -609,7 +610,7 @@ export function buildContinuous3DOptions(
           const labelVal = metricDimension ? p.value[3] : p.value[2]
           return labelVal === undefined ? '' : formatChartNumber(labelVal)
         },
-        textStyle: { fontSize: 12, color: styling.textColor },
+        textStyle: { fontSize: chartFontSize().series, color: styling.textColor },
       },
       emphasis: { label: { show: false } },
     })),
@@ -739,6 +740,6 @@ export function create3DCellLabel(
       const total = cellTotals[`${xi},${yi}`]
       return total === undefined ? '' : formatChartNumber(total)
     },
-    textStyle: { fontSize: 12, color: textColor },
+    textStyle: { fontSize: chartFontSize().series, color: textColor },
   }
 }

--- a/ui/src/composables/charts/shared/chartConfig.ts
+++ b/ui/src/composables/charts/shared/chartConfig.ts
@@ -1,6 +1,6 @@
 import type { EChartsOption } from 'echarts'
 import type { ScaleType } from '@/types'
-import { fontSize } from './common'
+import { chartFontSize } from './chartFontSize'
 import { describe } from '@/lib/stats'
 import { formatChartNumber } from '@/lib/utils'
 
@@ -309,7 +309,7 @@ export function createValueAxisConfig(
       ? { name: yAxisName, nameLocation: 'middle', nameGap: 45, nameTextStyle: nameStyle }
       : {}),
     splitLine: { lineStyle: { opacity: styling.opacity } },
-    axisLabel: { color: styling.textColor, fontSize },
+    axisLabel: { color: styling.textColor, fontSize: chartFontSize().label },
     axisLine: { lineStyle: { color: styling.axisColor } },
   }
 
@@ -324,7 +324,7 @@ export function createValueAxisConfig(
       ...(xAxisName
         ? { name: xAxisName, nameLocation: 'middle', nameGap: 30, nameTextStyle: nameStyle }
         : {}),
-      axisLabel: { color: styling.textColor, fontSize },
+      axisLabel: { color: styling.textColor, fontSize: chartFontSize().label },
       axisLine: { lineStyle: { color: styling.axisColor } },
       splitLine: { lineStyle: { opacity: styling.opacity } },
     },
@@ -447,7 +447,7 @@ export function createAxisConfig(
         // Series names on the x axis — keep at the default tick size.
         interval: isLargeXAxis(xAxisData) ? 'auto' : 0,
         rotate: hasRotatedXLabels(xAxisData, hasDataZoom) ? 30 : 0,
-        fontSize,
+        fontSize: chartFontSize().label,
         color: styling.textColor,
         // No axis title / slider: sit series ticks in the expanded bottom band.
         ...(!hasDataZoom && !xAxisName ? { margin: 14 } : {}),
@@ -518,7 +518,7 @@ export function createHorizontalAxisConfig(
         : {}),
       axisLabel: {
         interval: isLargeXAxis(yAxisData) ? 'auto' : 0,
-        fontSize,
+        fontSize: chartFontSize().label,
         color: styling.textColor,
         ...(!hasDataZoom && !categoryAxisName ? { margin: 14 } : {}),
       },
@@ -867,7 +867,7 @@ export function createLegendConfig(
     ...(!hasCustomVerticalPosition ? { top: 0 } : {}),
     itemWidth: 10,
     itemHeight: 10,
-    textStyle: { fontSize, color: styling.textColor },
+    textStyle: { fontSize: chartFontSize().legend, color: styling.textColor },
     data: series.map((s) => s.xAxis),
     ...customConfig,
   }
@@ -954,7 +954,7 @@ export const createLabelConfig = (
     if (raw == null) return ''
     return typeof raw === 'number' ? formatChartNumber(raw) : String(raw)
   },
-  fontSize,
+  fontSize: chartFontSize().series,
   color: stacked ? '#fff' : styling.textColor,
   textBorderColor: stacked ? 'rgba(0,0,0,0.5)' : null,
   textBorderWidth: stacked ? 2 : null,

--- a/ui/src/composables/charts/shared/chartFontSize.test.ts
+++ b/ui/src/composables/charts/shared/chartFontSize.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { appearanceFontSize, chartFontSize } from './chartFontSize'
+import { DEFAULT_FONT_SIZE } from '@/lib/fontSize'
+
+describe('chartFontSize', () => {
+  it('defaults to 12 when unset', () => {
+    appearanceFontSize.value = undefined
+    expect(chartFontSize()).toEqual({
+      series: DEFAULT_FONT_SIZE,
+      legend: DEFAULT_FONT_SIZE,
+      label: DEFAULT_FONT_SIZE,
+    })
+  })
+
+  it('resolves a baked number and a partial object', () => {
+    appearanceFontSize.value = 14
+    expect(chartFontSize().legend).toBe(14)
+    appearanceFontSize.value = { series: 16 }
+    expect(chartFontSize()).toEqual({
+      series: 16,
+      legend: DEFAULT_FONT_SIZE,
+      label: DEFAULT_FONT_SIZE,
+    })
+  })
+})

--- a/ui/src/composables/charts/shared/chartFontSize.ts
+++ b/ui/src/composables/charts/shared/chartFontSize.ts
@@ -1,0 +1,10 @@
+import { shallowRef } from 'vue'
+import { resolveFontSize, type FontSizeSpec, type ResolvedFontSize } from '@/lib/fontSize'
+
+/** Baked appearance.fontSize for the active dataset (set by useDataPoint). */
+export const appearanceFontSize = shallowRef<number | FontSizeSpec | undefined>()
+
+/** Resolved series/legend/label sizes from the active dataset appearance. */
+export function chartFontSize(): ResolvedFontSize {
+  return resolveFontSize(appearanceFontSize.value)
+}

--- a/ui/src/composables/charts/shared/common.test.ts
+++ b/ui/src/composables/charts/shared/common.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest'
 import { ref } from 'vue'
 import type { ChartData, Point3D } from '@/types'
 import {
-  fontSize,
   sortBy,
   sortByTotal,
   sortByValue,
@@ -12,12 +11,6 @@ import {
   computeSeriesTotals,
   sortByAxisTotal,
 } from './common'
-
-describe('fontSize', () => {
-  it('is 12', () => {
-    expect(fontSize).toBe(12)
-  })
-})
 
 describe('sortBy / sortByTotal / sortByValue', () => {
   it('sorts ascending and descending by key', () => {

--- a/ui/src/composables/charts/shared/common.ts
+++ b/ui/src/composables/charts/shared/common.ts
@@ -4,8 +4,6 @@ import type { SortOrder, ScaleType, ChartData, Sort } from '@/types'
 import type { Point3D } from '@/types'
 import { hasYAxis } from '@/lib/utils'
 
-export const fontSize = 12
-
 export const sortBy =
   <K extends string>(key: K) =>
   <T extends Record<K, number>>(sortOrder: SortOrder) => {

--- a/ui/src/composables/charts/shared/seriesConfig.test.ts
+++ b/ui/src/composables/charts/shared/seriesConfig.test.ts
@@ -6,7 +6,7 @@ import {
   createPieLabelConfig,
   createPieSeriesConfig,
 } from './seriesConfig'
-import { fontSize } from './common'
+import { DEFAULT_FONT_SIZE } from '@/lib/fontSize'
 
 describe('resolveSeriesSymbol', () => {
   it('returns defaults when overrides absent', () => {
@@ -79,7 +79,7 @@ describe('createPieLabelConfig / createPieSeriesConfig', () => {
     expect(createPieLabelConfig(true, styling, fmt)).toEqual({
       show: true,
       formatter: fmt,
-      fontSize,
+      fontSize: DEFAULT_FONT_SIZE,
       color: '#abc',
     })
     expect(createPieLabelConfig(false, styling).show).toBe(false)
@@ -93,7 +93,7 @@ describe('createPieLabelConfig / createPieSeriesConfig', () => {
       radius: ['0%', '70%'],
       center: ['50%', '50%'],
       data,
-      label: { show: true, color: '#abc', fontSize },
+      label: { show: true, color: '#abc', fontSize: DEFAULT_FONT_SIZE },
     })
   })
 

--- a/ui/src/composables/charts/shared/seriesConfig.ts
+++ b/ui/src/composables/charts/shared/seriesConfig.ts
@@ -1,4 +1,4 @@
-import { fontSize } from './common'
+import { chartFontSize } from './chartFontSize'
 
 export type SeriesSymbolProps = {
   symbol?: string
@@ -46,7 +46,7 @@ export function createPieLabelConfig(
   return {
     show: showLabels,
     formatter: customFormatter,
-    fontSize,
+    fontSize: chartFontSize().series,
     color: styling.textColor,
   }
 }

--- a/ui/src/composables/charts/useChordChartOptions.ts
+++ b/ui/src/composables/charts/useChordChartOptions.ts
@@ -3,7 +3,7 @@ import type { EChartsOption } from 'echarts'
 import { type BaseChartConfig, getBaseOptions } from './baseChartOptions'
 import { hasXAxis, hasYAxis } from '@/lib/utils'
 import { getChartStyling } from './shared/chartConfig'
-import { fontSize } from './shared/common'
+import { chartFontSize } from './shared/chartFontSize'
 import { emptyEdgeChartOption, prepareEdgeChart } from './shared/edgeChart'
 
 // Thin outer ring (demo geometry). top = legend band + gap; bottom = same gap.
@@ -55,7 +55,7 @@ export function useChordChartOptions(config: BaseChartConfig) {
         itemHeight: 10,
         data: nodes.map((n) => n.name),
         selected,
-        textStyle: { fontSize, color: styling.textColor },
+        textStyle: { fontSize: chartFontSize().legend, color: styling.textColor },
       },
       tooltip,
       series: [
@@ -69,7 +69,7 @@ export function useChordChartOptions(config: BaseChartConfig) {
             position: 'inside',
             color: '#fff',
             fontWeight: 'bold',
-            fontSize,
+            fontSize: chartFontSize().series,
           },
         },
       ],

--- a/ui/src/composables/charts/useCorrelationOption.ts
+++ b/ui/src/composables/charts/useCorrelationOption.ts
@@ -10,6 +10,7 @@ import {
   hasRotatedXLabels,
 } from './shared/chartConfig'
 import { fontSize } from './shared/common'
+import { chartFontSize } from './shared/chartFontSize'
 
 const PREFIX: Record<CorrelationMethod, string> = {
   pearson: 'r',
@@ -74,7 +75,7 @@ export function buildCorrelationOption(
       splitArea: { show: true },
       axisLabel: {
         color: styling.textColor,
-        fontSize,
+        fontSize: chartFontSize().label,
         interval: large ? 'auto' : 0,
         rotate: hasRotatedXLabels(labels, large) ? 30 : 0,
       },
@@ -86,7 +87,11 @@ export function buildCorrelationOption(
       data: labels,
       inverse: true,
       splitArea: { show: true },
-      axisLabel: { color: styling.textColor, fontSize, interval: large ? 'auto' : 0 },
+      axisLabel: {
+        color: styling.textColor,
+        fontSize: chartFontSize().label,
+        interval: large ? 'auto' : 0,
+      },
       axisLine: { lineStyle: { color: styling.axisColor } },
     },
     visualMap: {

--- a/ui/src/composables/charts/useCorrelationOption.ts
+++ b/ui/src/composables/charts/useCorrelationOption.ts
@@ -9,7 +9,6 @@ import {
   createHeatmapLayoutConfig,
   hasRotatedXLabels,
 } from './shared/chartConfig'
-import { fontSize } from './shared/common'
 import { chartFontSize } from './shared/chartFontSize'
 
 const PREFIX: Record<CorrelationMethod, string> = {
@@ -102,7 +101,7 @@ export function buildCorrelationOption(
       left: 'center',
       bottom: layout.visualMapBottom,
       precision: 2,
-      textStyle: { color: styling.textColor, fontSize },
+      textStyle: { color: styling.textColor, fontSize: chartFontSize().legend },
       inRange: { color: vmColors },
     },
     series: [
@@ -112,7 +111,7 @@ export function buildCorrelationOption(
         label: {
           show: true,
           color: styling.textColor,
-          fontSize,
+          fontSize: chartFontSize().series,
           formatter: (p: unknown) => {
             const v = (p as { data: [number, number, number] }).data[2]
             return Number(v.toFixed(2)).toString()

--- a/ui/src/composables/charts/useHeatmapChartOptions.ts
+++ b/ui/src/composables/charts/useHeatmapChartOptions.ts
@@ -16,6 +16,7 @@ import {
   hasRotatedXLabels,
   type ChartStyling,
 } from './shared/chartConfig'
+import { chartFontSize } from './shared/chartFontSize'
 
 function formatCellNumber(v: number): string {
   if (Math.abs(v) >= 1e6) return formatChartNumber(v / 1e6) + 'M'
@@ -66,7 +67,7 @@ function buildHeatmapCartesian(input: HeatmapCartesianInput) {
       data: xCategories,
       axisLabel: {
         color: styling.textColor,
-        fontSize: 12,
+        fontSize: chartFontSize().label,
         interval: largeX ? 'auto' : 0,
         rotate: hasRotatedXLabels(xCategories, largeX) ? 30 : 0,
       },
@@ -83,7 +84,11 @@ function buildHeatmapCartesian(input: HeatmapCartesianInput) {
     yAxis: {
       type: 'category' as const,
       data: yCategories,
-      axisLabel: { color: styling.textColor, fontSize: 12, interval: largeY ? 'auto' : 0 },
+      axisLabel: {
+        color: styling.textColor,
+        fontSize: chartFontSize().label,
+        interval: largeY ? 'auto' : 0,
+      },
       axisLine: { lineStyle: { color: styling.axisColor } },
       ...(axisLabels?.y
         ? {

--- a/ui/src/composables/charts/usePieChartOptions.ts
+++ b/ui/src/composables/charts/usePieChartOptions.ts
@@ -5,7 +5,8 @@ import { type BaseChartConfig, getBaseOptions } from './baseChartOptions'
 import { getNextColorFor, hasXAxis, hasYAxis, hasZAxis } from '@/lib/utils'
 import { getChartStyling, getTooltipTheme, formatTooltipValue } from './shared/chartConfig'
 import { createPieSeriesConfig } from './shared/seriesConfig'
-import { fontSize, sortByTotal, sortByValue } from './shared/common'
+import { sortByTotal, sortByValue } from './shared/common'
+import { chartFontSize } from './shared/chartFontSize'
 import type { Point3D } from '@/types'
 
 type SeriesWithTotal = { xAxis: string; values: (number | null)[]; total: number }
@@ -47,7 +48,7 @@ const makePieTitle = (
   left,
   top: '5%',
   textAlign: 'center',
-  textStyle: { color: styling.textColor, fontSize, fontWeight: 'bold' },
+  textStyle: { color: styling.textColor, fontSize: chartFontSize().series, fontWeight: 'bold' },
 })
 
 export function usePieChartOptions(config: BaseChartConfig) {

--- a/ui/src/composables/charts/useRadarChartOptions.ts
+++ b/ui/src/composables/charts/useRadarChartOptions.ts
@@ -3,7 +3,8 @@ import type { EChartsOption } from 'echarts'
 import { type BaseChartConfig, getBaseOptions } from './baseChartOptions'
 import { getNextColorFor, hasXAxis, hasYAxis, hasZAxis } from '@/lib/utils'
 import { getChartStyling, getTooltipTheme, formatRadarItemTooltip } from './shared/chartConfig'
-import { fontSize, sortByTotal } from './shared/common'
+import { sortByTotal } from './shared/common'
+import { chartFontSize } from './shared/chartFontSize'
 
 const makeIndicators = (names: string[], perSpokeMax: number[]) =>
   names.map((name, i) => ({ name, max: Math.max(perSpokeMax[i]! * 1.1, 1) }))
@@ -21,7 +22,7 @@ const radarConfig = (
   styling: ReturnType<typeof getChartStyling>
 ) => ({
   indicator: indicators,
-  axisName: { color: styling.textColor },
+  axisName: { color: styling.textColor, fontSize: chartFontSize().label },
   splitLine: { lineStyle: { color: styling.axisColor } },
   splitArea: { areaStyle: { opacity: 0.05 } },
 })
@@ -33,7 +34,11 @@ export function useRadarChartOptions(config: BaseChartConfig) {
     const cd = chartData.value
     const styling = getChartStyling(isDark.value)
     const baseOptions = getBaseOptions(config)
-    const label = { show: showLabels.value, fontSize, color: styling.textColor }
+    const label = {
+      show: showLabels.value,
+      fontSize: chartFontSize().series,
+      color: styling.textColor,
+    }
 
     // X only: xAxis values as spokes, single polygon with totals
     if (!hasYAxis(chartData)) {

--- a/ui/src/composables/charts/useSankeyChartOptions.ts
+++ b/ui/src/composables/charts/useSankeyChartOptions.ts
@@ -3,7 +3,7 @@ import type { EChartsOption } from 'echarts'
 import { type BaseChartConfig, getBaseOptions } from './baseChartOptions'
 import { hasXAxis, hasYAxis } from '@/lib/utils'
 import { getChartStyling } from './shared/chartConfig'
-import { fontSize } from './shared/common'
+import { chartFontSize } from './shared/chartFontSize'
 import { formatTooltipValue } from './shared/chartConfig'
 import { emptyEdgeChartOption, prepareEdgeChart } from './shared/edgeChart'
 
@@ -49,14 +49,14 @@ export function useSankeyChartOptions(config: BaseChartConfig) {
           label: {
             show: true,
             color: styling.textColor,
-            fontSize,
+            fontSize: chartFontSize().series,
           },
           edgeLabel: {
             show: showLabels.value,
             formatter: (params: { data?: { value?: number }; value?: number }) =>
               formatTooltipValue(params.data?.value ?? params.value),
             color: styling.textColor,
-            fontSize,
+            fontSize: chartFontSize().series,
           },
         },
       ],

--- a/ui/src/composables/useDataPoint.test.ts
+++ b/ui/src/composables/useDataPoint.test.ts
@@ -246,10 +246,10 @@ describe('useDataPoint embedded VIZB_DATA', () => {
     expect(fetcher).not.toHaveBeenCalled()
   })
 
-  it('applies a legacy hex theme string when the dataset has no themes[]', async () => {
+  it('applies a hex appearance.theme string when the dataset has no themes[]', async () => {
     const one = {
       name: 'Legacy theme',
-      theme: '#f00,#0f0,#00f',
+      appearance: { theme: '#f00,#0f0,#00f' },
       data: [{ name: 'a', value: 1 }],
       settings: [{ type: 'bar' as const }],
     }
@@ -264,7 +264,7 @@ describe('useDataPoint embedded VIZB_DATA', () => {
     const state = useDataPoint()
 
     await vi.waitFor(() => expect(state.loading.value).toBe(false))
-    expect(state.activeDataset.value?.theme).toBe('#f00,#0f0,#00f')
+    expect(state.activeDataset.value?.appearance?.theme).toBe('#f00,#0f0,#00f')
     expect(activeThemeName.value).toBe('#f00,#0f0,#00f')
   })
 

--- a/ui/src/composables/useDataPoint.ts
+++ b/ui/src/composables/useDataPoint.ts
@@ -11,6 +11,7 @@ import {
 import { presentAxisString } from '../lib/swap'
 import { useSettingsStore } from './useSettingsStore'
 import { registerDatasetThemes, resolveActiveTheme } from '../lib/themes'
+import { appearanceFontSize } from './charts/shared/chartFontSize'
 import {
   classifyPayload,
   fetchDatasetDetail,
@@ -221,15 +222,16 @@ const resultGroups = computed(() => groupNames.value.map((name) => ({ name })))
 watch(
   () => activeDataset.value,
   (dataset) => {
-    registerDatasetThemes(dataset?.themes)
+    appearanceFontSize.value = dataset?.appearance?.fontSize
+    registerDatasetThemes(dataset?.appearance?.themes)
     const active = resolveActiveTheme(dataset)
-    // Legacy hex-only theme string: apply the comma-separated palette key.
+    // Hex-only appearance.theme: apply the comma-separated palette key.
     if (
       active.name === 'custom' &&
-      dataset?.theme?.trim().startsWith('#') &&
-      !dataset.themes?.length
+      dataset?.appearance?.theme?.trim().startsWith('#') &&
+      !dataset.appearance?.themes?.length
     ) {
-      initializeTheme(dataset.theme)
+      initializeTheme(dataset.appearance.theme)
       return
     }
     initializeTheme(active.name)

--- a/ui/src/lib/fontSize.test.ts
+++ b/ui/src/lib/fontSize.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_FONT_SIZE, resolveFontSize } from './fontSize'
+
+describe('resolveFontSize', () => {
+  it('defaults all keys to 12', () => {
+    expect(resolveFontSize(undefined)).toEqual({
+      series: DEFAULT_FONT_SIZE,
+      legend: DEFAULT_FONT_SIZE,
+      label: DEFAULT_FONT_SIZE,
+    })
+  })
+
+  it('applies a number to all three keys', () => {
+    expect(resolveFontSize(14)).toEqual({ series: 14, legend: 14, label: 14 })
+    expect(resolveFontSize(12.5)).toEqual({ series: 12.5, legend: 12.5, label: 12.5 })
+  })
+
+  it('fills missing object keys with 12', () => {
+    expect(resolveFontSize({ series: 16, legend: 10 })).toEqual({
+      series: 16,
+      legend: 10,
+      label: DEFAULT_FONT_SIZE,
+    })
+  })
+
+  it('ignores invalid numbers', () => {
+    expect(resolveFontSize(0)).toEqual({
+      series: DEFAULT_FONT_SIZE,
+      legend: DEFAULT_FONT_SIZE,
+      label: DEFAULT_FONT_SIZE,
+    })
+    expect(resolveFontSize({ series: -1, legend: Number.NaN, label: 14 })).toEqual({
+      series: DEFAULT_FONT_SIZE,
+      legend: DEFAULT_FONT_SIZE,
+      label: 14,
+    })
+  })
+})

--- a/ui/src/lib/fontSize.test.ts
+++ b/ui/src/lib/fontSize.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { DEFAULT_FONT_SIZE, resolveFontSize } from './fontSize'
 
 describe('resolveFontSize', () => {
-  it('defaults all keys to 12', () => {
+  it('defaults all keys to 14', () => {
     expect(resolveFontSize(undefined)).toEqual({
       series: DEFAULT_FONT_SIZE,
       legend: DEFAULT_FONT_SIZE,
@@ -15,7 +15,7 @@ describe('resolveFontSize', () => {
     expect(resolveFontSize(12.5)).toEqual({ series: 12.5, legend: 12.5, label: 12.5 })
   })
 
-  it('fills missing object keys with 12', () => {
+  it('fills missing object keys with 14', () => {
     expect(resolveFontSize({ series: 16, legend: 10 })).toEqual({
       series: 16,
       legend: 10,

--- a/ui/src/lib/fontSize.test.ts
+++ b/ui/src/lib/fontSize.test.ts
@@ -34,5 +34,10 @@ describe('resolveFontSize', () => {
       legend: DEFAULT_FONT_SIZE,
       label: 14,
     })
+    expect(resolveFontSize(Number.POSITIVE_INFINITY)).toEqual({
+      series: DEFAULT_FONT_SIZE,
+      legend: DEFAULT_FONT_SIZE,
+      label: DEFAULT_FONT_SIZE,
+    })
   })
 })

--- a/ui/src/lib/fontSize.ts
+++ b/ui/src/lib/fontSize.ts
@@ -1,0 +1,29 @@
+export const DEFAULT_FONT_SIZE = 12
+
+export type FontSizeSpec = {
+  series?: number
+  legend?: number
+  label?: number
+}
+
+export type ResolvedFontSize = {
+  series: number
+  legend: number
+  label: number
+}
+
+function validSize(n: unknown): n is number {
+  return typeof n === 'number' && Number.isFinite(n) && n > 0
+}
+
+export function resolveFontSize(input?: number | FontSizeSpec | null): ResolvedFontSize {
+  if (typeof input === 'number' && validSize(input)) {
+    return { series: input, legend: input, label: input }
+  }
+  const spec = input && typeof input === 'object' ? input : {}
+  return {
+    series: validSize(spec.series) ? spec.series : DEFAULT_FONT_SIZE,
+    legend: validSize(spec.legend) ? spec.legend : DEFAULT_FONT_SIZE,
+    label: validSize(spec.label) ? spec.label : DEFAULT_FONT_SIZE,
+  }
+}

--- a/ui/src/lib/fontSize.ts
+++ b/ui/src/lib/fontSize.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_FONT_SIZE = 12
+export const DEFAULT_FONT_SIZE = 14
 
 export type FontSizeSpec = {
   series?: number

--- a/ui/src/lib/themes.test.ts
+++ b/ui/src/lib/themes.test.ts
@@ -65,26 +65,26 @@ describe('themes', () => {
   })
 
   it('resolveActiveTheme uses themes[0] when present, else default', () => {
-    expect(resolveActiveTheme({ themes: [westeros, vintage] })).toMatchObject({
+    expect(resolveActiveTheme({ appearance: { themes: [westeros, vintage] } })).toMatchObject({
       name: 'westeros',
       colors: westeros.colors,
       visualMapColors: westeros.visualMapColors,
     })
-    expect(resolveActiveTheme({ themes: [] })).toEqual(DEFAULT_THEME)
+    expect(resolveActiveTheme({ appearance: { themes: [] } })).toEqual(DEFAULT_THEME)
     expect(resolveActiveTheme({})).toEqual(DEFAULT_THEME)
     expect(resolveActiveTheme(null)).toEqual(DEFAULT_THEME)
   })
 
   it('soft-handles legacy hex theme string when themes is empty', () => {
-    expect(resolveActiveTheme({ theme: '#f00,#0f0,#00f' })).toMatchObject({
+    expect(resolveActiveTheme({ appearance: { theme: '#f00,#0f0,#00f' } })).toMatchObject({
       name: 'custom',
       colors: ['#f00', '#0f0', '#00f'],
     })
   })
 
   it('falls back to default for legacy named themes without themes[]', () => {
-    expect(resolveActiveTheme({ theme: 'westeros' })).toEqual(DEFAULT_THEME)
-    expect(resolveActiveTheme({ theme: 'macarons' })).toEqual(DEFAULT_THEME)
+    expect(resolveActiveTheme({ appearance: { theme: 'westeros' } })).toEqual(DEFAULT_THEME)
+    expect(resolveActiveTheme({ appearance: { theme: 'macarons' } })).toEqual(DEFAULT_THEME)
   })
 
   it('registers dataset themes for name-based palette resolution', () => {
@@ -202,7 +202,9 @@ describe('themes', () => {
   it('resolveActiveTheme fills missing visualMapColors and skips empty first theme', () => {
     expect(
       resolveActiveTheme({
-        themes: [{ name: 'brand', colors: ['#111', '#222', '#333'], visualMapColors: [] }],
+        appearance: {
+          themes: [{ name: 'brand', colors: ['#111', '#222', '#333'], visualMapColors: [] }],
+        },
       })
     ).toMatchObject({
       name: 'brand',
@@ -211,18 +213,19 @@ describe('themes', () => {
     })
     expect(
       resolveActiveTheme({
-        themes: [{ name: '', colors: ['#aaa', '#bbb'], visualMapColors: ['#aaa', '#bbb'] }],
+        appearance: {
+          themes: [{ name: '', colors: ['#aaa', '#bbb'], visualMapColors: ['#aaa', '#bbb'] }],
+        },
       }).name
     ).toBe('custom')
     // First entry without colors falls through to default / legacy.
     expect(
       resolveActiveTheme({
-        themes: [{ name: 'empty', colors: [], visualMapColors: [] }],
+        appearance: { themes: [{ name: 'empty', colors: [], visualMapColors: [] }] },
       })
     ).toEqual(DEFAULT_THEME)
-    // Legacy # string that is not a valid multi-hex palette → default.
-    expect(resolveActiveTheme({ theme: '#f00' })).toEqual(DEFAULT_THEME)
-    expect(resolveActiveTheme({ theme: '#ggg,#000' })).toEqual(DEFAULT_THEME)
+    expect(resolveActiveTheme({ appearance: { theme: '#f00' } })).toEqual(DEFAULT_THEME)
+    expect(resolveActiveTheme({ appearance: { theme: '#ggg,#000' } })).toEqual(DEFAULT_THEME)
   })
 
   it('registerDatasetThemes names a blank colors-only themes[0] as custom', () => {

--- a/ui/src/lib/themes.ts
+++ b/ui/src/lib/themes.ts
@@ -128,8 +128,8 @@ function themeFromCustomPalette(colors: string[]): Theme {
  * Named legacy themes without a themes[] catalog fall back to default
  * (UI no longer ships the 13-theme catalog).
  */
-export function resolveActiveTheme(dataset?: Pick<Dataset, 'themes' | 'theme'> | null): Theme {
-  const first = dataset?.themes?.[0]
+export function resolveActiveTheme(dataset?: Pick<Dataset, 'appearance'> | null): Theme {
+  const first = dataset?.appearance?.themes?.[0]
   if (first?.colors?.length) {
     return cloneTheme({
       name: first.name?.trim() || 'custom',
@@ -140,7 +140,7 @@ export function resolveActiveTheme(dataset?: Pick<Dataset, 'themes' | 'theme'> |
     })
   }
 
-  const legacy = dataset?.theme?.trim()
+  const legacy = dataset?.appearance?.theme?.trim()
   if (legacy?.startsWith('#')) {
     const colors = parseCustomPalette(legacy)
     if (colors) return themeFromCustomPalette(colors)

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -249,20 +249,24 @@ export type Theme = {
   visualMapColors?: string[]
 }
 
+export type FontSizeSpec = {
+  series?: number
+  legend?: number
+  label?: number
+}
+
+export type Appearance = {
+  themes?: Theme[]
+  /** Inbound theme name or palette; expanded into themes and omitted on rewrite. */
+  theme?: string
+  fontSize?: number | FontSizeSpec
+}
+
 export type Dataset = {
   id?: string
   name: string
   description?: string
-  /**
-   * Data-owned theme catalog. themes[0] is active when present; the UI only
-   * ships built-in `default` when themes is empty/absent.
-   */
-  themes?: Theme[]
-  /**
-   * Legacy single theme name/spec (pre-themes-array wire). Go migrates on load;
-   * pure UI JSON may still carry this — soft-handled when themes is empty.
-   */
-  theme?: string
+  appearance?: Appearance
   tag?: string
   timestamp?: string
   history?: HistoryEntry[]

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -42,7 +42,7 @@ const { isDark, toggleDark, chartType, themeName, setTheme } = useSettingsStore(
 const { sort, showLabels, scale, threeD } = useActiveChartShape()
 const { initFromUrl } = useUrlRouter()
 
-// Author provided 2+ themes → show selector (default + dataset.themes).
+// Author provided 2+ themes → show selector (default + appearance.themes).
 // 0–1 author themes → hide (available set is the single resolved theme only).
 const showThemeSelector = computed(() => shouldShowThemeSelector())
 


### PR DESCRIPTION
## What

Adds a dataset-level `--font-size` flag and moves the theme catalog + inbound `theme` string under a new `dataset.appearance` object.

### `--font-size`
- `vizb data.csv --font-size 14` → sets series (data labels), legend, and axis ticks to 14px
- `vizb data.csv --font-size series=16;legend=10;label=12` → bag form; missing keys stay at 12px
- Wireless hybrid: bare number when all three are equal, object otherwise
- Values are finite `float64 > 0`; invalid keys/values **warn-and-skip**; unknown keys dropped
- Parsed once and cached on the `FlagBag` (no double parse)

### `dataset.appearance`
- `{ "themes": [...], "theme": "...", "fontSize": 14 }`
- Legacy `theme` string expands into `themes[]` and is not re-emitted
- **No root-field compatibility** (as decided): old JSON with root `themes`/`theme` loads without the catalog; Convert rejects root aliases with 400

## Out of scope (per spec)
- Settings panel, URL param, per-chart override, leftover chart text (tooltips, visualMap, heatmap cells, 3D axis names, axis titles stay at their fixed sizes)

## Testing
- Go: warn-and-skip cases, assemble to `appearance`, migration, merge union/fontSize
- UI: `resolveFontSize` unit tests; chart option builders pick up sizes while tooltips/titles don't
- Verify: lefthook ran `format`, `go-test`, `ui-test` — all green; 1322 UI tests

## Breaking
New JSON/HTML writes `appearance` only; Convert **responses** are the new shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable chart text sizing through the `--font-size` CLI option and GitHub Action input.
  - Supports one size for all chart text or separate sizes for series labels, legends, and axis labels.
  - Chart text reflects configured font sizes, with defaults for missing or invalid values.

- **Breaking Changes**
  - Theme data and font-size settings now use the nested `dataset.appearance` structure.
  - Root-level `theme` and `themes` fields are no longer supported in JSON/API formats.

- **Documentation**
  - Updated CLI, API, UI, theme, and GitHub Action documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->