### PR TITLE
docs: split llms.txt into described doc sections

### DIFF
--- a/docs/src/lib/agent-md.test.ts
+++ b/docs/src/lib/agent-md.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import {
 	CORE_MD_PATHS,
+	DOC_SECTIONS,
 	buildLlmsTxt,
 	flattenMdx,
 	mdPathForId,
@@ -237,6 +238,36 @@ describe('CORE_MD_PATHS', () => {
 	});
 });
 
+describe('DOC_SECTIONS', () => {
+	it('lists every section in sidebar order with a description', () => {
+		assert.deepEqual(
+			DOC_SECTIONS.map((s) => s.label),
+			[
+				'Getting Started',
+				'Guides',
+				'Charts',
+				'Commands',
+				'UI',
+				'CI/CD',
+				'Examples',
+				'Reference',
+			],
+		);
+		for (const section of DOC_SECTIONS) {
+			assert.ok(section.description.trim(), section.label);
+			assert.ok(section.paths.length > 0, section.label);
+		}
+	});
+
+	it('lists each page exactly once, all as .md paths', () => {
+		const paths = DOC_SECTIONS.flatMap((s) => s.paths);
+		assert.equal(new Set(paths).size, paths.length, 'duplicate path');
+		for (const path of paths) {
+			assert.match(path, /^\/.*\.md$/);
+		}
+	});
+});
+
 describe('buildLlmsTxt', () => {
 	it('links only .md URLs and llms-full.txt, never HTML or GitHub raw', () => {
 		const txt = buildLlmsTxt('https://vizb.goptics.org/', [
@@ -256,6 +287,37 @@ describe('buildLlmsTxt', () => {
 			assert.equal(href.startsWith('/'), true, href);
 			assert.equal(href.includes('://'), false, href);
 		}
+	});
+
+	it('groups pages under sections with a description', () => {
+		const txt = buildLlmsTxt('https://vizb.goptics.org/', [
+			{
+				id: 'getting-started/install',
+				title: 'Install',
+				description: 'Install vizb',
+				body: '# Install\n',
+			},
+		]);
+		assert.match(
+			txt,
+			/## Getting Started\n\nFirst steps: what vizb is/,
+		);
+		assert.match(txt, /## Guides\n\nConceptual how-tos/);
+		assert.match(txt, /## Reference\n\nCapabilities, internals/);
+		const install = txt.indexOf('/getting-started/install.md');
+		assert.ok(install > -1 && install < txt.indexOf('## Guides'));
+	});
+
+	it('puts unmatched pages in a More fallback', () => {
+		const txt = buildLlmsTxt('https://vizb.goptics.org/', [
+			{
+				id: 'new-section/page',
+				title: 'New',
+				description: 'New page',
+				body: '# New\n',
+			},
+		]);
+		assert.match(txt, /## More\n\n- \[New\]\(\/new-section\/page\.md\)/);
 	});
 });
 

--- a/docs/src/lib/agent-md.ts
+++ b/docs/src/lib/agent-md.ts
@@ -34,6 +34,116 @@ export const CORE_MD_PATHS = [
 	'/troubleshooting.md',
 ] as const;
 
+export type DocSection = {
+	label: string;
+	description: string;
+	paths: string[];
+};
+
+export const DOC_SECTIONS: DocSection[] = [
+	{
+		label: 'Getting Started',
+		description:
+			'First steps: what vizb is, install, connect a coding agent, and the dimension model.',
+		paths: [
+			'/getting-started.md',
+			'/getting-started/install.md',
+			'/getting-started/ai-agents.md',
+			'/getting-started/dimensions.md',
+		],
+	},
+	{
+		label: 'Guides',
+		description:
+			'Conceptual how-tos: grouping vs select, tabular data, parsers, and merging datasets.',
+		paths: [
+			'/guides/group-vs-select.md',
+			'/guides/data.md',
+			'/guides/group.md',
+			'/guides/select.md',
+			'/guides/merging.md',
+			'/guides/parsers.md',
+		],
+	},
+	{
+		label: 'Charts',
+		description:
+			'Pick a chart type and its flags: bar, line, scatter, pie, radar, heatmap, sankey, chord, and 3D.',
+		paths: [
+			'/charts.md',
+			'/charts/bar.md',
+			'/charts/line.md',
+			'/charts/scatter.md',
+			'/charts/pie.md',
+			'/charts/radar.md',
+			'/charts/heatmap.md',
+			'/charts/sankey.md',
+			'/charts/chord.md',
+			'/charts/3d.md',
+		],
+	},
+	{
+		label: 'Commands',
+		description:
+			'CLI reference for the root command, chart generation, merge, ui, serve, and update.',
+		paths: [
+			'/commands/root.md',
+			'/commands/charts.md',
+			'/commands/merge.md',
+			'/commands/ui.md',
+			'/commands/serve.md',
+			'/commands/update.md',
+		],
+	},
+	{
+		label: 'UI',
+		description:
+			'Interacting with the generated HTML report: themes, settings, axis swapping, and stats.',
+		paths: [
+			'/ui.md',
+			'/ui/themes.md',
+			'/ui/settings.md',
+			'/ui/swapping.md',
+			'/ui/stats.md',
+		],
+	},
+	{
+		label: 'CI/CD',
+		description:
+			'Automate charts in pipelines with the GitHub Action and stateless or stateful CI.',
+		paths: [
+			'/ci-cd/github-action.md',
+			'/ci-cd/stateless.md',
+			'/ci-cd/stateful.md',
+			'/ci-cd/deploying.md',
+		],
+	},
+	{
+		label: 'Examples',
+		description: 'Sample datasets and live dashboards to copy from.',
+		paths: [
+			'/examples.md',
+			'/examples/tabular-data.md',
+			'/examples/math-and-3d.md',
+			'/examples/comparisons.md',
+			'/examples/github-legends.md',
+			'/examples/benchmarks.md',
+			'/examples/showcase.md',
+		],
+	},
+	{
+		label: 'Reference',
+		description:
+			'Capabilities, internals, troubleshooting, and roadmap.',
+		paths: [
+			'/features.md',
+			'/internals/how-it-works.md',
+			'/troubleshooting.md',
+			'/roadmap.md',
+		],
+	},
+];
+
 export function mdPathForId(id: string): string {
 	return `/${id.replace(/\/index$/, '') || 'index'}.md`;
 }
@@ -275,34 +385,40 @@ export function buildLlmsTxt(
 		return `- [${title}](${path})${desc}`;
 	};
 
-	const coreSet = new Set<string>(CORE_MD_PATHS);
+	const seen = new Set<string>(DOC_SECTIONS.flatMap((s) => s.paths));
 	const more = pages
 		.map((p) => mdPathForId(p.id))
-		.filter((p) => !coreSet.has(p) && p !== '/index.md')
+		.filter((p) => !seen.has(p) && p !== '/index.md')
 		.sort();
 
-	return [
+	const out = [
 		'# Vizb',
 		'',
 		'> Turn CSV, JSON, and Go/Rust/JavaScript benchmark output into a self-contained interactive HTML chart without writing chart code.',
 		'',
 		`Docs are at ${origin}. Links below are root-relative on that host.`,
 		'',
-		'Vizb is a CLI pipeline (auto-group, n/x/y/z dimensions, HTML or JSON), not a charting library to embed. Prefer minimal flags. Fetch one Core page rather than llms-full.txt.',
+		'Vizb is a CLI pipeline (auto-group, n/x/y/z dimensions, HTML or JSON), not a charting library to embed. Prefer minimal flags. Fetch only the section or page you need rather than llms-full.txt.',
 		'',
-		'## Core',
-		'',
-		...CORE_MD_PATHS.map(line),
-		'',
-		'## More',
-		'',
-		...more.map(line),
-		'',
+	];
+
+	for (const section of DOC_SECTIONS) {
+		out.push(`## ${section.label}`, '', section.description, '');
+		out.push(...section.paths.map(line), '');
+	}
+
+	if (more.length > 0) {
+		out.push('## More', '', ...more.map(line), '');
+	}
+
+	out.push(
 		'## Optional',
 		'',
 		'- [Complete documentation](/llms-full.txt): concatenated markdown dump of every docs page',
 		'',
-	].join('\n');
+	);
+
+	return out.join('\n');
 }
 
 export function buildLlmsFull(pages: DocPage[]): string {


### PR DESCRIPTION
## What

`llms.txt` grouped pages into only `## Core` and `## More`. This mirrors the actual docs structure so agents can decide which section to scrape.

`buildLlmsTxt` now emits one `##` section per Starlight sidebar group, each with a one-line description, followed by the page entries (title + frontmatter description):

- **Getting Started** (4), **Guides** (6), **Charts** (10), **Commands** (6), **UI** (5), **CI/CD** (4), **Examples** (7), **Reference** (Features, How It Works, Troubleshooting, Roadmap)
- Unmatched pages fall back to `## More`; `## Optional` keeps the `llms-full.txt` link.

`CORE_MD_PATHS`, `llms-full.txt`, `[...slug].md.ts`, and `scripts/check-agent-dist.mjs` are unchanged.

## Verification

- `pnpm test` (docs) — 34 pass
- `pnpm build` — 57 pages built
- `node --experimental-strip-types scripts/check-agent-dist.mjs` — OK

New tests assert section order + descriptions, one `.md` path per page, section grouping, and the `More` fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documentation indexes now organize pages into labeled sections with descriptions, making relevant content easier to find.
  - Generated `llms.txt` guidance now recommends fetching only the section or page needed.
  - Additional pages are grouped under a “More” section only when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->